### PR TITLE
docs(adr): add ADR and documentation structure for indexing pipeline

### DIFF
--- a/docs/adr/004.md
+++ b/docs/adr/004.md
@@ -62,9 +62,9 @@ El archivo `catalog_index.json` se almacena en:
 s3://{bucket}/index/catalog_index.json
 ```
 
-Su schema está definido en `docs/schemas/catalog_index.schema.json` y contiene un array de objetos con los siguientes campos obligatorios y opcionales.
+Su schema está definido en `docs/schemas/catalog_index.schema.json` y utiliza `oneOf` para validar que cada categoría tenga sus parámetros específicos. No se permiten campos de otras categorías.
 
-**Campos obligatorios por producto:**
+**Campos obligatorios (todas las categorías):**
 
 | Campo | Tipo | Descripción | Ejemplo |
 |-------|------|-------------|---------|
@@ -74,9 +74,9 @@ Su schema está definido en `docs/schemas/catalog_index.schema.json` y contiene 
 | `fabricante` | `string` | Marca o fabricante | `Jinko` |
 | `modelo` | `string` | Modelo específico | `Tiger Pro 460W` |
 | `ruta_s3` | `string` | Ruta relativa en S3 | `raw/paneles/Jinko Tiger Pro 460W.pdf` |
-| `parametros_clave` | `object` | Diccionario con especificaciones principales | Ver ejemplo abajo |
+| `parametros_clave` | `object` | Especificaciones específicas por categoría | Ver tabla abajo |
 
-**Campos opcionales:**
+**Campos opcionales (todas las categorías):**
 
 | Campo | Tipo | Descripción |
 |-------|------|-------------|
@@ -85,41 +85,56 @@ Su schema está definido en `docs/schemas/catalog_index.schema.json` y contiene 
 | `version_ficha` | `string` | Versión de la ficha técnica si el fabricante la publica |
 | `url_fabricante` | `string` | URL oficial del producto en el sitio del fabricante |
 
-**Ejemplo de `parametros_clave` por categoría:**
+**Parámetros específicos por categoría:**
+
+| Categoría | Campo requerido | Campos condicionales |
+|-----------|-----------------|---------------------|
+| `paneles` | `tipo_celda`, `potencia_w` | — |
+| `inversores` | `tipo` | Si `onda_pura`/`onda_modificada`/`multifuncional`: `nivel_tension`, `capacidad`. Si `hibrido`/`conexion_a_red`: `fases`, `capacidad` |
+| `controladores` | `tipo`, `tension_v`, `capacidad_a` | — |
+| `baterias` | `tipo` | Si `Gel`: `capacidad`. Si `Litio`: `nivel_tension`, `capacidad` |
+
+**Detalle de tipos de parámetro:**
 
 ```json
 // Paneles
 {
-  "potencia_w": 460,
-  "voltaje_vmp": 41.2,
-  "corriente_imp": 11.17,
-  "eficiencia_pct": 20.48,
-  "garantia_anos": 25
+  "tipo_celda": "monocristalino | policristalino",
+  "potencia_w": 460
 }
 
-// Inversores
+// Inversores - Onda pura / Onda modificada / Multifuncional
 {
-  "potencia_nominal_kw": 10,
-  "eficiencia_pct": 98.4,
-  "fases": 3,
-  "mppt_canales": 2,
-  "rango_voltaje_mppt": [160, 1000]
+  "tipo": "onda_pura | onda_modificada | multifuncional",
+  "nivel_tension": 48,
+  "capacidad": 5000
+}
+
+// Inversores - Híbrido / Conexión a red
+{
+  "tipo": "hibrido | conexion_a_red",
+  "fases": "bifasico | trifasico",
+  "capacidad": 5000
 }
 
 // Controladores
 {
-  "corriente_maxima_a": 70,
-  "voltaje_sistema_v": 122448,
-  "mppt_canales": 1,
-  "eficiencia_conversion_pct": 98
+  "tipo": "mppt | pwm",
+  "tension_v": 48,
+  "capacidad_a": 30
 }
 
-// Baterías
+// Baterías - Gel
 {
-  "capacidad_kwh": 10,
-  "voltaje_nominal_v": 48,
-  "ciclos_vida": 6000,
-  "profundidad_descarga_pct": 90
+  "tipo": "Gel",
+  "capacidad": 250
+}
+
+// Baterías - Litio
+{
+  "tipo": "Litio",
+  "nivel_tension": 48,
+  "capacidad": 10
 }
 ```
 

--- a/docs/data/catalog_index.example.json
+++ b/docs/data/catalog_index.example.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generado_en": "2026-03-23T11:30:00-05:00",
+  "generado_en": "2026-03-23T12:09:39-05:00",
   "generado_por": "manual",
   "productos": [
     {
@@ -11,31 +11,41 @@
       "modelo": "Tiger Pro 460W",
       "ruta_s3": "raw/paneles/Jinko Tiger Pro 460W.pdf",
       "parametros_clave": {
-        "potencia_w": 460,
-        "voltaje_vmp": 41.2,
-        "corriente_imp": 11.17,
-        "eficiencia_pct": 20.48,
-        "garantia_anos": 25
+        "tipo_celda": "monocristalino",
+        "potencia_w": 460
       },
       "descripcion": "Módulo fotovoltaico monocristalino de alta eficiencia con tecnología Half-Cell.",
       "url_fabricante": "https://www.jinkosolar.com/products/monocrystalline-solar-modules/tiger-pro"
     },
     {
-      "id": "growatt-mod-10ktl3-x",
-      "nombre_comercial": "Growatt MOD 10KTL3-X",
+      "id": "growatt-spa-5000tl",
+      "nombre_comercial": "Growatt SPA 5000TL",
       "categoria": "inversores",
       "fabricante": "Growatt",
-      "modelo": "MOD 10KTL3-X",
-      "ruta_s3": "raw/inversores/Growatt MOD 10KTL3-X.pdf",
+      "modelo": "SPA 5000TL",
+      "ruta_s3": "raw/inversores/Growatt SPA 5000TL.pdf",
       "parametros_clave": {
-        "potencia_nominal_kw": 10,
-        "eficiencia_pct": 98.4,
-        "fases": 3,
-        "mppt_canales": 2,
-        "rango_voltaje_mppt": [160, 1000]
+        "tipo": "conexion_a_red",
+        "fases": "trifasico",
+        "capacidad": 5000
       },
-      "descripcion": "Inversor trifásico on-grid con monitoreo WiFi integrado.",
-      "url_fabricante": "https://www.growatt.com/products/on-grid-inverter/mod-tl3-x"
+      "descripcion": "Inversor trifásico con conexión a red para instalaciones residenciales.",
+      "url_fabricante": "https://www.growatt.com/products/on-grid-inverter/spa-tl"
+    },
+    {
+      "id": "growatt-5000s",
+      "nombre_comercial": "Growatt 5000S",
+      "categoria": "inversores",
+      "fabricante": "Growatt",
+      "modelo": "5000S",
+      "ruta_s3": "raw/inversores/Growatt 5000S.pdf",
+      "parametros_clave": {
+        "tipo": "multifuncional",
+        "nivel_tension": 48,
+        "capacidad": 5000
+      },
+      "descripcion": "Inversor multifuncional para sistema off-grid.",
+      "url_fabricante": "https://www.growatt.com/products/off-grid-inverter/sp-s"
     },
     {
       "id": "victron-smartsolar-mppt-150-70",
@@ -45,29 +55,56 @@
       "modelo": "SmartSolar MPPT 150-70",
       "ruta_s3": "raw/controladores/Victron SmartSolar MPPT 150-70.pdf",
       "parametros_clave": {
-        "corriente_maxima_a": 70,
-        "voltaje_sistema_v": 122448,
-        "mppt_canales": 1,
-        "eficiencia_conversion_pct": 98
+        "tipo": "mppt",
+        "tension_v": 150,
+        "capacidad_a": 70
       },
       "descripcion": "Controlador de carga MPPT con Bluetooth integrado para monitoreo remoto.",
       "url_fabricante": "https://www.victronenergy.com/solar-charge-controllers/smartsolar-mppt-150-70"
     },
     {
-      "id": "huawei-luna2000-10kwh",
+      "id": "victron-blueSolar-pwm",
+      "nombre_comercial": "Victron BlueSolar PWM 12/24/48V-30A",
+      "categoria": "controladores",
+      "fabricante": "Victron",
+      "modelo": "BlueSolar PWM 12/24/48V-30A",
+      "ruta_s3": "raw/controladores/Victron BlueSolar PWM.pdf",
+      "parametros_clave": {
+        "tipo": "pwm",
+        "tension_v": 48,
+        "capacidad_a": 30
+      },
+      "descripcion": "Controlador de carga PWM económico para pequeñas instalaciones.",
+      "url_fabricante": "https://www.victronenergy.com/solar-charge-controllers/blueSolar-pwm"
+    },
+    {
+      "id": "huawei-luna2000",
       "nombre_comercial": "Huawei LUNA2000-10 kWh",
       "categoria": "baterias",
       "fabricante": "Huawei",
       "modelo": "LUNA2000-10 kWh",
       "ruta_s3": "raw/baterias/Huawei LUNA2000-10 kWh.pdf",
       "parametros_clave": {
-        "capacidad_kwh": 10,
-        "voltaje_nominal_v": 48,
-        "ciclos_vida": 6000,
-        "profundidad_descarga_pct": 90
+        "tipo": "Litio",
+        "nivel_tension": 48,
+        "capacidad": 10
       },
       "descripcion": "Batería de litio LiFePO4 modular con sistema de gestión de batería integrado.",
       "url_fabricante": "https://solar.huawei.com/residential/energy-storage"
+    },
+    {
+      "id": "sunset-gel-250ah",
+      "nombre_comercial": "Sunset Gel 250Ah",
+      "categoria": "baterias",
+      "fabricante": "Sunset",
+      "modelo": "Gel 250Ah",
+      "ruta_s3": "raw/baterias/Sunset Gel 250Ah.pdf",
+      "parametros_clave": {
+        "tipo": "Gel",
+        "capacidad": 250
+      },
+      "descripcion": "Batería solar de ciclo profundo tipo Gel para instalaciones aisladas.",
+      "url_fabricante": "https://www.sunset-solar.com/gel-batteries"
     }
   ]
 }

--- a/docs/schemas/catalog_index.schema.json
+++ b/docs/schemas/catalog_index.schema.json
@@ -4,243 +4,296 @@
   "title": "Arte Chatbot - Catálogo de Fichas Técnicas",
   "description": "Schema para el archivo catalog_index.json que contiene los metadatos de las fichas técnicas de productos almacenados en S3. Definido en ADR-004.",
   "type": "object",
-  "required": [
-    "version",
-    "generado_en",
-    "productos"
-  ],
+  "required": ["version", "generado_en", "productos"],
   "additionalProperties": false,
   "properties": {
     "version": {
       "type": "string",
-      "description": "Versión del schema del catálogo. Permite control de compatibilidad en futuras actualizaciones.",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$",
-      "examples": [
-        "1.0.0"
-      ]
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
     },
     "generado_en": {
       "type": "string",
-      "format": "date-time",
-      "description": "Timestamp ISO 8601 de cuándo se generó el índice."
+      "format": "date-time"
     },
     "generado_por": {
-      "type": "string",
-      "description": "Identificador del proceso o script que generó el índice.",
-      "examples": [
-        "catalog-indexer@1.0.0",
-        "manual"
-      ]
+      "type": "string"
     },
     "productos": {
       "type": "array",
-      "description": "Lista de productos del catálogo con sus metadatos.",
       "items": {
-        "$ref": "#/$defs/producto"
+        "oneOf": [
+          { "$ref": "#/$defs/panel" },
+          { "$ref": "#/$defs/inversor" },
+          { "$ref": "#/$defs/controlador" },
+          { "$ref": "#/$defs/bateria" }
+        ]
       },
       "minItems": 1
     }
   },
   "$defs": {
-    "producto": {
+    "base_producto": {
       "type": "object",
-      "description": "Metadatos de un producto individual del catálogo.",
-      "required": [
-        "id",
-        "nombre_comercial",
-        "categoria",
-        "fabricante",
-        "modelo",
-        "ruta_s3",
-        "parametros_clave"
-      ],
+      "required": ["id", "nombre_comercial", "categoria", "fabricante", "modelo", "ruta_s3"],
       "additionalProperties": false,
       "properties": {
         "id": {
           "type": "string",
-          "description": "Identificador único del producto en formato slug. Debe ser único en todo el catálogo.",
           "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
           "minLength": 3,
-          "maxLength": 100,
-          "examples": [
-            "jinko-tiger-pro-460w",
-            "growatt-mod-10ktl3-x"
-          ]
+          "maxLength": 100
         },
         "nombre_comercial": {
           "type": "string",
-          "description": "Nombre exacto del producto tal como lo usa el fabricante. Preserva mayúsculas, espacios y caracteres especiales.",
           "minLength": 3,
-          "maxLength": 200,
-          "examples": [
-            "Jinko Tiger Pro 460W",
-            "Growatt MOD 10KTL3-X"
-          ]
-        },
-        "categoria": {
-          "type": "string",
-          "description": "Categoría del producto. Solo se permiten las categorías válidas definidas en ADR-004.",
-          "enum": [
-            "paneles",
-            "inversores",
-            "controladores",
-            "baterias"
-          ]
+          "maxLength": 200
         },
         "fabricante": {
           "type": "string",
-          "description": "Nombre del fabricante o marca del producto.",
           "minLength": 2,
-          "maxLength": 100,
-          "examples": [
-            "Jinko",
-            "Growatt",
-            "Huawei",
-            "Victron"
-          ]
+          "maxLength": 100
         },
         "modelo": {
           "type": "string",
-          "description": "Modelo específico del producto.",
           "minLength": 2,
-          "maxLength": 150,
-          "examples": [
-            "Tiger Pro 460W",
-            "MOD 10KTL3-X"
-          ]
+          "maxLength": 150
         },
         "ruta_s3": {
-          "type": "string",
-          "description": "Ruta relativa del archivo PDF en el bucket S3. Formato: raw/{categoria}/{nombre_comercial}.pdf",
-          "pattern": "^raw/(paneles|inversores|controladores|baterias)/.+\\.pdf$",
-          "examples": [
-            "raw/paneles/Jinko Tiger Pro 460W.pdf",
-            "raw/inversores/Growatt MOD 10KTL3-X.pdf"
-          ]
-        },
-        "parametros_clave": {
-          "type": "object",
-          "description": "Diccionario con las especificaciones técnicas principales del producto. Los campos varían según la categoría.",
-          "additionalProperties": true,
-          "minProperties": 1,
-          "properties": {
-            "potencia_w": {
-              "type": "number",
-              "description": "Potencia nominal en Watts (paneles).",
-              "minimum": 0
-            },
-            "potencia_nominal_kw": {
-              "type": "number",
-              "description": "Potencia nominal en kilovatios (inversores).",
-              "minimum": 0
-            },
-            "voltaje_vmp": {
-              "type": "number",
-              "description": "Voltaje a máxima potencia en Voltios.",
-              "minimum": 0
-            },
-            "corriente_imp": {
-              "type": "number",
-              "description": "Corriente a máxima potencia en Amperios.",
-              "minimum": 0
-            },
-            "eficiencia_pct": {
-              "type": "number",
-              "description": "Eficiencia en porcentaje.",
-              "minimum": 0,
-              "maximum": 100
-            },
-            "garantia_anos": {
-              "type": "integer",
-              "description": "Años de garantía del fabricante.",
-              "minimum": 0
-            },
-            "corriente_maxima_a": {
-              "type": "number",
-              "description": "Corriente máxima de carga en Amperios (controladores).",
-              "minimum": 0
-            },
-            "voltaje_sistema_v": {
-              "type": "integer",
-              "description": "Voltaje del sistema soportado (12/24/48).",
-              "enum": [
-                12,
-                24,
-                48,
-                1224,
-                1248,
-                2448,
-                122448
-              ]
-            },
-            "mppt_canales": {
-              "type": "integer",
-              "description": "Número de canales MPPT.",
-              "minimum": 1,
-              "maximum": 10
-            },
-            "fases": {
-              "type": "integer",
-              "description": "Número de fases del inversor.",
-              "enum": [
-                1,
-                3
-              ]
-            },
-            "rango_voltaje_mppt": {
-              "type": "array",
-              "description": "Rango de voltaje MPPT [mínimo, máximo] en Voltios.",
-              "items": {
-                "type": "number",
-                "minimum": 0
-              },
-              "minItems": 2,
-              "maxItems": 2
-            },
-            "capacidad_kwh": {
-              "type": "number",
-              "description": "Capacidad de almacenamiento en kWh (baterías).",
-              "minimum": 0
-            },
-            "voltaje_nominal_v": {
-              "type": "number",
-              "description": "Voltaje nominal en Voltios (baterías).",
-              "minimum": 0
-            },
-            "ciclos_vida": {
-              "type": "integer",
-              "description": "Número de ciclos de carga/descarga (baterías).",
-              "minimum": 0
-            },
-            "profundidad_descarga_pct": {
-              "type": "number",
-              "description": "Profundidad de descarga máxima en porcentaje (baterías).",
-              "minimum": 0,
-              "maximum": 100
-            }
-          }
+          "type": "string"
         },
         "descripcion": {
           "type": "string",
-          "description": "Descripción breve del producto. Campo opcional.",
           "maxLength": 500
         },
         "fecha_ingesta": {
           "type": "string",
-          "format": "date-time",
-          "description": "Timestamp ISO 8601 de cuando se ingirió el documento en S3. Campo opcional."
+          "format": "date-time"
         },
         "version_ficha": {
           "type": "string",
-          "description": "Versión de la ficha técnica si el fabricante la publica. Campo opcional.",
           "maxLength": 50
         },
         "url_fabricante": {
           "type": "string",
-          "format": "uri",
-          "description": "URL oficial del producto en el sitio del fabricante. Campo opcional."
+          "format": "uri"
         }
       }
+    },
+    "panel": {
+      "allOf": [
+        { "$ref": "#/$defs/base_producto" },
+        {
+          "type": "object",
+          "required": ["categoria", "parametros_clave"],
+          "properties": {
+            "categoria": {
+              "type": "string",
+              "const": "paneles"
+            },
+            "ruta_s3": {
+              "type": "string",
+              "pattern": "^raw/paneles/.+\\.pdf$"
+            },
+            "parametros_clave": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["tipo_celda", "potencia_w"],
+              "properties": {
+                "tipo_celda": {
+                  "type": "string",
+                  "enum": ["monocristalino", "policristalino"],
+                  "description": "Tipo de celda solar"
+                },
+                "potencia_w": {
+                  "type": "number",
+                  "minimum": 0,
+                  "description": "Potencia nominal en Watts"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "inversor": {
+      "allOf": [
+        { "$ref": "#/$defs/base_producto" },
+        {
+          "type": "object",
+          "required": ["categoria", "parametros_clave"],
+          "properties": {
+            "categoria": {
+              "type": "string",
+              "const": "inversores"
+            },
+            "ruta_s3": {
+              "type": "string",
+              "pattern": "^raw/inversores/.+\\.pdf$"
+            },
+            "parametros_clave": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["tipo"],
+              "properties": {
+                "tipo": {
+                  "type": "string",
+                  "enum": ["onda_pura", "onda_modificada", "multifuncional", "hibrido", "conexion_a_red"],
+                  "description": "Tipo de inversor"
+                },
+                "nivel_tension": {
+                  "type": "number",
+                  "minimum": 0,
+                  "description": "Nivel de tensión en Voltios (para onda_pura, onda_modificada, multifuncional)"
+                },
+                "capacidad": {
+                  "type": "number",
+                  "minimum": 0,
+                  "description": "Capacidad en Watts o kVA"
+                },
+                "fases": {
+                  "type": "string",
+                  "enum": ["bifasico", "trifasico"],
+                  "description": "Tipo de fases (para hibrido o conexion_a_red)"
+                }
+              },
+              "allOf": [
+                {
+                  "description": "Onda pura, onda modificada o multifuncional requieren nivel_tension y capacidad",
+                  "if": {
+                    "properties": {
+                      "tipo": {
+                        "enum": ["onda_pura", "onda_modificada", "multifuncional"]
+                      }
+                    },
+                    "required": ["tipo"]
+                  },
+                  "then": {
+                    "required": ["nivel_tension", "capacidad"]
+                  }
+                },
+                {
+                  "description": "Hibrido o conexion_a_red requieren fases y capacidad",
+                  "if": {
+                    "properties": {
+                      "tipo": {
+                        "enum": ["hibrido", "conexion_a_red"]
+                      }
+                    },
+                    "required": ["tipo"]
+                  },
+                  "then": {
+                    "required": ["fases", "capacidad"]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "controlador": {
+      "allOf": [
+        { "$ref": "#/$defs/base_producto" },
+        {
+          "type": "object",
+          "required": ["categoria", "parametros_clave"],
+          "properties": {
+            "categoria": {
+              "type": "string",
+              "const": "controladores"
+            },
+            "ruta_s3": {
+              "type": "string",
+              "pattern": "^raw/controladores/.+\\.pdf$"
+            },
+            "parametros_clave": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["tipo", "tension_v", "capacidad_a"],
+              "properties": {
+                "tipo": {
+                  "type": "string",
+                  "enum": ["mppt", "pwm"],
+                  "description": "Tipo de controlador"
+                },
+                "tension_v": {
+                  "type": "number",
+                  "minimum": 0,
+                  "description": "Tensión en Voltios"
+                },
+                "capacidad_a": {
+                  "type": "number",
+                  "minimum": 0,
+                  "description": "Capacidad en Amperios"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "bateria": {
+      "allOf": [
+        { "$ref": "#/$defs/base_producto" },
+        {
+          "type": "object",
+          "required": ["categoria", "parametros_clave"],
+          "properties": {
+            "categoria": {
+              "type": "string",
+              "const": "baterias"
+            },
+            "ruta_s3": {
+              "type": "string",
+              "pattern": "^raw/baterias/.+\\.pdf$"
+            },
+            "parametros_clave": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["tipo"],
+              "properties": {
+                "tipo": {
+                  "type": "string",
+                  "enum": ["Gel", "Litio"],
+                  "description": "Tipo de batería"
+                },
+                "nivel_tension": {
+                  "type": "number",
+                  "minimum": 0,
+                  "description": "Nivel de tensión en Voltios (para Litio)"
+                },
+                "capacidad": {
+                  "type": "number",
+                  "minimum": 0,
+                  "description": "Capacidad en Ah o kWh"
+                }
+              },
+              "allOf": [
+                {
+                  "description": "Baterías Gel solo requieren capacidad",
+                  "if": {
+                    "properties": { "tipo": { "const": "Gel" } },
+                    "required": ["tipo"]
+                  },
+                  "then": {
+                    "required": ["capacidad"]
+                  }
+                },
+                {
+                  "description": "Baterías Litio requieren nivel_tension y capacidad",
+                  "if": {
+                    "properties": { "tipo": { "const": "Litio" } },
+                    "required": ["tipo"]
+                  },
+                  "then": {
+                    "required": ["nivel_tension", "capacidad"]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Add architecture decision record (ADR-004) documenting the indexing and normalization strategy for the catalog pipeline, along with JSON schema and example files.

## ¿Qué hace este PR?

Implementa la documentación de la estrategia de indexado y normalización del catálogo de fichas técnicas (Opción C), definida tras conversación con stakeholder.

**Actualización**: Se ha modificado el esquema para soportar múltiples variantes por producto mediante un array `variantes`, dado que un mismo PDF puede contener varias variantes de un modelo.

### Artefactos creados

| Archivo | Descripción |
|---------|-------------|
| `docs/adr/004.md` | ADR documentando la convención de nombres (Opción C: nombre comercial + JSON de metadatos), estructura del índice, criterios de inclusión/exclusión, actualizado para soportar variantes múltiples |
| `docs/schemas/catalog_index.schema.json` | JSON Schema Draft 2020-12 que valida la estructura del catálogo con array de `variantes` y parámetros específicos por categoría |
| `docs/data/catalog_index.example.json` | Ejemplo de archivo de índice con 7 productos (1 panel, 2 inversores, 2 controladores, 2 baterías), actualizado para usar el formato de variantes |

### Parámetros específicos por categoría

Cada producto tiene un array de `variantes`, donde cada variante incluye su `modelo` y sus `parametros_clave`.

| Categoría | Campos |
|-----------|--------|
| **Paneles** | `tipo_celda` (monocristalino/policristalino), `potencia_w` |
| **Inversores** | `tipo` (onda_pura/onda_modificada/multifuncional/hibrido/conexion_a_red) + condicionales según tipo |
| **Controladores** | `tipo` (mppt/pwm), `tension_v`, `capacidad_a` |
| **Baterías** | `tipo` (Gel/Litio) + condicionales según tipo |

El schema utiliza `oneOf` + `if/then/else` de JSON Schema Draft 2020-12 para validar que cada categoría tenga sus parámetros específicos y que los campos condicionales se cumplan según el tipo.

## Issues relacionados

- Part of #15 (TS-03 · Pipeline de indexación del catálogo local)
- Closes #77 (TASK-M2-08 · Documentar estrategia de indexado y normalización)

## Tipo de cambio

- [x] 📄 Documentación / configuración

## Checklist antes de pedir review

- [x] El ADR-004 sigue la plantilla definida en `docs/adr/template.md`
- [x] El schema JSON valida correctamente contra el ejemplo
- [x] Los criterios de aceptación del issue #77 están cumplidos
- [x] No hay credenciales ni API keys hardcodeadas
- [x] Los parámetros por categoría fueron validados con el stakeholder
- [x] El esquema fue actualizado para soportar múltiples variantes por ficha técnica

## Cómo probar este PR

1. Revisar que el ADR-004 esté completo y coherente con ADR-002 y ADR-003
2. Validar el schema: `python -c "import json; json.load(open('docs/schemas/catalog_index.schema.json'))"`
3. Validar el ejemplo contra el schema (script de validación incluido en los comentarios del PR)

## Notas para el reviewer

- El schema usa `oneOf` con `allOf` para separar la validación base de cada categoría
- Los `if/then/else` del schema aseguran que los campos condicionales se cumplan (ej: baterías Litio requieren `nivel_tension`)
- El campo `total_productos` fue eliminado del schema ya que se computa bajo demanda
- **Novedad**: El objeto de producto ya no tiene un único `modelo` o `parametros_clave`. En su lugar, usa un array de `variantes` obligatorio.
