### PR TITLE
feat(schema)!: implement variant inheritance with parametros_comunes

### DIFF
--- a/docs/adr/004.md
+++ b/docs/adr/004.md
@@ -43,15 +43,15 @@ s3://{bucket}/raw/{categoria}/{nombre_comercial}.pdf
 
 Donde:
 - `{categoria}`: `paneles` | `inversores` | `controladores` | `baterias`
-- `{nombre_comercial}`: Nombre exacto del producto, sin normalización agresiva, preservando mayúsculas, espacios y caracteres especiales del fabricante.
+- `{nombre_comercial}`: Nombre de la serie o línea de productos, sin normalización agresiva, preservando mayúsculas, espacios y caracteres especiales del fabricante. Un mismo PDF puede contener fichas técnicas de múltiples variantes de la misma serie.
 
 **Ejemplos concretos:**
 
 ```
-s3://arte-chatbot-data/raw/paneles/Jinko Tiger Pro 460W.pdf
-s3://arte-chatbot-data/raw/inversores/Growatt MOD 10KTL3-X.pdf
-s3://arte-chatbot-data/raw/controladores/Victron SmartSolar MPPT 150-70.pdf
-s3://arte-chatbot-data/raw/baterias/Huawei LUNA2000-10 kWh.pdf
+s3://arte-chatbot-data/raw/paneles/Jinko Tiger Pro.pdf
+s3://arte-chatbot-data/raw/inversores/Growatt SPA TL.pdf
+s3://arte-chatbot-data/raw/controladores/Victron SmartSolar MPPT.pdf
+s3://arte-chatbot-data/raw/baterias/Huawei LUNA2000.pdf
 ```
 
 ### Estructura del archivo de metadatos
@@ -62,110 +62,157 @@ El archivo `catalog_index.json` se almacena en:
 s3://{bucket}/index/catalog_index.json
 ```
 
-Su schema está definido en `docs/schemas/catalog_index.schema.json` y utiliza `oneOf` para validar que cada categoría tenga sus parámetros específicos. No se permiten campos de otras categorías.
+Su schema está definido en `docs/schemas/catalog_index.schema.json` y utiliza `oneOf` para validar que cada categoría tenga sus parámetros específicos. El schema implementa un patrón de **herencia con overrides**: los parámetros técnicos compartidos por todas las variantes de una serie se definen en `parametros_comunes` a nivel de producto, mientras que cada variante solo especifica en `parametros_clave` los campos que difieren (e.g., potencia, capacidad).
 
 **Campos obligatorios (todas las categorías):**
 
 | Campo | Tipo | Descripción | Ejemplo |
 |-------|------|-------------|---------|
-| `id` | `string` | Identificador único del producto (slug) | `jinko-tiger-pro-460w` |
-| `nombre_comercial` | `string` | Nombre exacto del producto | `Jinko Tiger Pro 460W` |
+| `id` | `string` | Identificador único de la serie (slug) | `jinko-tiger-pro` |
+| `nombre_comercial` | `string` | Nombre de la serie o línea de productos | `Jinko Tiger Pro` |
 | `categoria` | `enum` | Categoría del producto | `paneles` |
 | `fabricante` | `string` | Marca o fabricante | `Jinko` |
-|  |
-| `ruta_s3` | `string` | Ruta relativa en S3 | `raw/paneles/Jinko Tiger Pro 460W.pdf` |
-| `variantes` | `array` | Lista de variantes del producto contenidas en la ficha | Cada item tiene `modelo` y `parametros_clave` |
+| `ruta_s3` | `string` | Ruta relativa en S3 | `raw/paneles/Jinko Tiger Pro.pdf` |
+| `variantes` | `array` | Lista de variantes del producto, cada una con `modelo` y `parametros_clave` diferenciales | Cada item tiene `modelo` y `parametros_clave` |
 
 **Campos opcionales (todas las categorías):**
 
 | Campo | Tipo | Descripción |
 |-------|------|-------------|
+| `parametros_comunes` | `object` | Parámetros técnicos compartidos por todas las variantes de la serie. Estructura definida por categoría |
 | `descripcion` | `string` | Descripción breve del producto |
 | `fecha_ingesta` | `string` | ISO 8601 timestamp de cuando se ingirió el documento |
 | `version_ficha` | `string` | Versión de la ficha técnica si el fabricante la publica |
 | `url_fabricante` | `string` | URL oficial del producto en el sitio del fabricante |
 
-**Parámetros específicos por categoría:**
+**Parámetros compartidos por categoría (`parametros_comunes`):**
 
-| Categoría | Campo requerido | Campos condicionales |
-|-----------|-----------------|---------------------|
-| `paneles` | `tipo_celda`, `potencia_w` | — |
-| `inversores` | `tipo` | Si `onda_pura`/`onda_modificada`/`multifuncional`: `nivel_tension`, `capacidad`. Si `hibrido`/`conexion_a_red`: `fases`, `capacidad` |
-| `controladores` | `tipo`, `tension_v`, `capacidad_a` | — |
-| `baterias` | `tipo` | Si `Gel`: `capacidad`. Si `Litio`: `nivel_tension`, `capacidad` |
+| Categoría | Campos requeridos en `parametros_comunes` | Campos condicionales |
+|-----------|-------------------------------------------|---------------------|
+| `paneles` | `tipo_celda` | — |
+| `inversores` | `tipo` | Si `onda_pura`/`onda_modificada`/`multifuncional`: `nivel_tension`. Si `hibrido`/`conexion_a_red`: `fases` |
+| `controladores` | `tipo`, `tension_v` | — |
+| `baterias` | `tipo` | Si `Litio`: `nivel_tension` |
+
+**Parámetros diferenciales por variante (`parametros_clave`):**
+
+| Categoría | Campo requerido en `parametros_clave` | Campos opcionales (override) |
+|-----------|---------------------------------------|------------------------------|
+| `paneles` | `potencia_w` | `tipo_celda` |
+| `inversores` | `capacidad` | `tipo`, `nivel_tension`, `fases` |
+| `controladores` | `capacidad_a` | `tipo`, `tension_v` |
+| `baterias` | `capacidad` | `tipo`, `nivel_tension` |
 
 **Detalle de tipos de parámetro:**
 
 ```json
-// Paneles
-"variantes": [
-  {
-    "modelo": "Tiger Pro 460W",
-    "parametros_clave": {
-      "tipo_celda": "monocristalino | policristalino",
-      "potencia_w": 460
+// Paneles — serie con múltiples potencias
+{
+  "nombre_comercial": "Jinko Tiger Pro",
+  "parametros_comunes": {
+    "tipo_celda": "monocristalino"
+  },
+  "variantes": [
+    {
+      "modelo": "Tiger Pro 460W",
+      "parametros_clave": { "potencia_w": 460 }
+    },
+    {
+      "modelo": "Tiger Pro 470W",
+      "parametros_clave": { "potencia_w": 470 }
     }
-  }
-]
+  ]
+}
 
-// Inversores - Onda pura / Onda modificada / Multifuncional
-"variantes": [
-  {
-    "modelo": "5000S",
-    "parametros_clave": {
-      "tipo": "onda_pura | onda_modificada | multifuncional",
-      "nivel_tension": 48,
-      "capacidad": 5000
+// Inversores — serie multifuncional con diferentes capacidades
+{
+  "nombre_comercial": "Growatt SP S",
+  "parametros_comunes": {
+    "tipo": "multifuncional",
+    "nivel_tension": 48
+  },
+  "variantes": [
+    {
+      "modelo": "3000S",
+      "parametros_clave": { "capacidad": 3000 }
+    },
+    {
+      "modelo": "5000S",
+      "parametros_clave": { "capacidad": 5000 }
     }
-  }
-]
+  ]
+}
 
-// Inversores - Híbrido / Conexión a red
-"variantes": [
-  {
-    "modelo": "SPA 5000TL",
-    "parametros_clave": {
-      "tipo": "hibrido | conexion_a_red",
-      "fases": "bifasico | trifasico",
-      "capacidad": 5000
+// Inversores — serie conexión a red
+{
+  "nombre_comercial": "Growatt SPA TL",
+  "parametros_comunes": {
+    "tipo": "conexion_a_red",
+    "fases": "trifasico"
+  },
+  "variantes": [
+    {
+      "modelo": "SPA 5000TL",
+      "parametros_clave": { "capacidad": 5000 }
     }
-  }
-]
+  ]
+}
 
-// Controladores
-"variantes": [
-  {
-    "modelo": "SmartSolar MPPT 150-70",
-    "parametros_clave": {
-      "tipo": "mppt | pwm",
-      "tension_v": 48,
-      "capacidad_a": 30
+// Controladores — serie MPPT con diferentes amperajes
+{
+  "nombre_comercial": "Victron SmartSolar MPPT",
+  "parametros_comunes": {
+    "tipo": "mppt",
+    "tension_v": 150
+  },
+  "variantes": [
+    {
+      "modelo": "SmartSolar MPPT 150/35",
+      "parametros_clave": { "capacidad_a": 35 }
+    },
+    {
+      "modelo": "SmartSolar MPPT 150/70",
+      "parametros_clave": { "capacidad_a": 70 }
     }
-  }
-]
+  ]
+}
 
-// Baterías - Gel
-"variantes": [
-  {
-    "modelo": "Gel 250Ah",
-    "parametros_clave": {
-      "tipo": "Gel",
-      "capacidad": 250
+// Baterías — serie Litio con diferentes capacidades
+{
+  "nombre_comercial": "Huawei LUNA2000",
+  "parametros_comunes": {
+    "tipo": "Litio",
+    "nivel_tension": 48
+  },
+  "variantes": [
+    {
+      "modelo": "LUNA2000-5 kWh",
+      "parametros_clave": { "capacidad": 5 }
+    },
+    {
+      "modelo": "LUNA2000-10 kWh",
+      "parametros_clave": { "capacidad": 10 }
     }
-  }
-]
+  ]
+}
 
-// Baterías - Litio
-"variantes": [
-  {
-    "modelo": "LUNA2000-10 kWh",
-    "parametros_clave": {
-      "tipo": "Litio",
-      "nivel_tension": 48,
-      "capacidad": 10
+// Baterías — serie Gel con diferentes capacidades
+{
+  "nombre_comercial": "Sunset Gel",
+  "parametros_comunes": {
+    "tipo": "Gel"
+  },
+  "variantes": [
+    {
+      "modelo": "Gel 100Ah",
+      "parametros_clave": { "capacidad": 100 }
+    },
+    {
+      "modelo": "Gel 250Ah",
+      "parametros_clave": { "capacidad": 250 }
     }
-  }
-]
+  ]
+}
 ```
 
 ---
@@ -298,3 +345,13 @@ El schema JSON (`catalog_index.schema.json`) debe versionarse con el campo `$sch
 ### Integración con el System Prompt
 
 El contenido de `catalog_index.json` (sin los PDFs) será inyectado en el System Prompt del LLM como contexto del catálogo disponible. La estructura debe optimizarse para legibilidad por parte del LLM, evitando campos anidados excesivos o metadatos innecesarios.
+
+### Patrón de herencia con overrides
+
+El schema implementa un patrón de herencia donde:
+
+1. **`parametros_comunes`** (nivel producto): Define los parámetros técnicos que aplican a todas las variantes de la serie (e.g., tipo de celda, tipo de inversor, voltaje nominal).
+2. **`parametros_clave`** (nivel variante): Solo especifica los parámetros que difieren entre variantes (e.g., potencia en watts, capacidad en amperios).
+3. **Override opcional**: Una variante puede incluir en `parametros_clave` campos que ya existen en `parametros_comunes` para indicar que esa variante particular difiere del valor común.
+
+Este patrón reduce la redundancia de datos cuando un mismo PDF de ficha técnica contiene múltiples variantes de la misma serie (e.g., un datasheet de "Victron SmartSolar MPPT" que cubre los modelos 150/35, 150/45 y 150/70, donde solo varía la capacidad en amperios).

--- a/docs/data/catalog_index.example.json
+++ b/docs/data/catalog_index.example.json
@@ -1,104 +1,149 @@
 {
   "version": "1.0.0",
-  "generado_en": "2026-03-23T12:09:39-05:00",
+  "generado_en": "2026-03-23T14:30:00-05:00",
   "generado_por": "manual",
   "productos": [
     {
-      "id": "jinko-tiger-pro-460w",
-      "nombre_comercial": "Jinko Tiger Pro 460W",
+      "id": "jinko-tiger-pro",
+      "nombre_comercial": "Jinko Tiger Pro",
       "categoria": "paneles",
       "fabricante": "Jinko",
-      "ruta_s3": "raw/paneles/Jinko Tiger Pro 460W.pdf",
-      "descripcion": "M\u00f3dulo fotovoltaico monocristalino de alta eficiencia con tecnolog\u00eda Half-Cell.",
+      "ruta_s3": "raw/paneles/Jinko Tiger Pro.pdf",
+      "descripcion": "Módulo fotovoltaico monocristalino de alta eficiencia con tecnología Half-Cell.",
       "url_fabricante": "https://www.jinkosolar.com/products/monocrystalline-solar-modules/tiger-pro",
+      "parametros_comunes": {
+        "tipo_celda": "monocristalino"
+      },
       "variantes": [
         {
           "modelo": "Tiger Pro 460W",
           "parametros_clave": {
-            "tipo_celda": "monocristalino",
             "potencia_w": 460
           }
         },
         {
           "modelo": "Tiger Pro 470W",
           "parametros_clave": {
-            "tipo_celda": "monocristalino",
             "potencia_w": 470
+          }
+        },
+        {
+          "modelo": "Tiger Pro 480W",
+          "parametros_clave": {
+            "potencia_w": 480
           }
         }
       ]
     },
     {
-      "id": "growatt-spa-5000tl",
-      "nombre_comercial": "Growatt SPA 5000TL",
+      "id": "growatt-spa-tl",
+      "nombre_comercial": "Growatt SPA TL",
       "categoria": "inversores",
       "fabricante": "Growatt",
-      "ruta_s3": "raw/inversores/Growatt SPA 5000TL.pdf",
-      "descripcion": "Inversor trif\u00e1sico con conexi\u00f3n a red para instalaciones residenciales.",
+      "ruta_s3": "raw/inversores/Growatt SPA TL.pdf",
+      "descripcion": "Inversor trifásico con conexión a red para instalaciones residenciales.",
       "url_fabricante": "https://www.growatt.com/products/on-grid-inverter/spa-tl",
+      "parametros_comunes": {
+        "tipo": "conexion_a_red",
+        "fases": "trifasico"
+      },
       "variantes": [
+        {
+          "modelo": "SPA 3000TL",
+          "parametros_clave": {
+            "capacidad": 3000
+          }
+        },
         {
           "modelo": "SPA 5000TL",
           "parametros_clave": {
-            "tipo": "conexion_a_red",
-            "fases": "trifasico",
             "capacidad": 5000
           }
         }
       ]
     },
     {
-      "id": "growatt-5000s",
-      "nombre_comercial": "Growatt 5000S",
+      "id": "growatt-sp-s",
+      "nombre_comercial": "Growatt SP S",
       "categoria": "inversores",
       "fabricante": "Growatt",
-      "ruta_s3": "raw/inversores/Growatt 5000S.pdf",
+      "ruta_s3": "raw/inversores/Growatt SP S.pdf",
       "descripcion": "Inversor multifuncional para sistema off-grid.",
       "url_fabricante": "https://www.growatt.com/products/off-grid-inverter/sp-s",
+      "parametros_comunes": {
+        "tipo": "multifuncional",
+        "nivel_tension": 48
+      },
       "variantes": [
+        {
+          "modelo": "3000S",
+          "parametros_clave": {
+            "capacidad": 3000
+          }
+        },
         {
           "modelo": "5000S",
           "parametros_clave": {
-            "tipo": "multifuncional",
-            "nivel_tension": 48,
             "capacidad": 5000
           }
         }
       ]
     },
     {
-      "id": "victron-smartsolar-mppt-150-70",
-      "nombre_comercial": "Victron SmartSolar MPPT 150-70",
+      "id": "victron-smartsolar-mppt",
+      "nombre_comercial": "Victron SmartSolar MPPT",
       "categoria": "controladores",
       "fabricante": "Victron",
-      "ruta_s3": "raw/controladores/Victron SmartSolar MPPT 150-70.pdf",
+      "ruta_s3": "raw/controladores/Victron SmartSolar MPPT.pdf",
       "descripcion": "Controlador de carga MPPT con Bluetooth integrado para monitoreo remoto.",
-      "url_fabricante": "https://www.victronenergy.com/solar-charge-controllers/smartsolar-mppt-150-70",
+      "url_fabricante": "https://www.victronenergy.com/solar-charge-controllers/smartsolar-mppt",
+      "parametros_comunes": {
+        "tipo": "mppt",
+        "tension_v": 150
+      },
       "variantes": [
         {
-          "modelo": "SmartSolar MPPT 150-70",
+          "modelo": "SmartSolar MPPT 150/35",
           "parametros_clave": {
-            "tipo": "mppt",
-            "tension_v": 150,
+            "capacidad_a": 35
+          }
+        },
+        {
+          "modelo": "SmartSolar MPPT 150/45",
+          "parametros_clave": {
+            "capacidad_a": 45
+          }
+        },
+        {
+          "modelo": "SmartSolar MPPT 150/70",
+          "parametros_clave": {
             "capacidad_a": 70
           }
         }
       ]
     },
     {
-      "id": "victron-blueSolar-pwm",
-      "nombre_comercial": "Victron BlueSolar PWM 12/24/48V-30A",
+      "id": "victron-bluesolar-pwm",
+      "nombre_comercial": "Victron BlueSolar PWM",
       "categoria": "controladores",
       "fabricante": "Victron",
       "ruta_s3": "raw/controladores/Victron BlueSolar PWM.pdf",
-      "descripcion": "Controlador de carga PWM econ\u00f3mico para peque\u00f1as instalaciones.",
-      "url_fabricante": "https://www.victronenergy.com/solar-charge-controllers/blueSolar-pwm",
+      "descripcion": "Controlador de carga PWM económico para pequeñas instalaciones.",
+      "url_fabricante": "https://www.victronenergy.com/solar-charge-controllers/bluesolar-pwm",
+      "parametros_comunes": {
+        "tipo": "pwm",
+        "tension_v": 48
+      },
       "variantes": [
         {
-          "modelo": "BlueSolar PWM 12/24/48V-30A",
+          "modelo": "BlueSolar PWM 48V-20A",
           "parametros_clave": {
-            "tipo": "pwm",
-            "tension_v": 48,
+            "capacidad_a": 20
+          }
+        },
+        {
+          "modelo": "BlueSolar PWM 48V-30A",
+          "parametros_clave": {
             "capacidad_a": 30
           }
         }
@@ -106,36 +151,58 @@
     },
     {
       "id": "huawei-luna2000",
-      "nombre_comercial": "Huawei LUNA2000-10 kWh",
+      "nombre_comercial": "Huawei LUNA2000",
       "categoria": "baterias",
       "fabricante": "Huawei",
-      "ruta_s3": "raw/baterias/Huawei LUNA2000-10 kWh.pdf",
-      "descripcion": "Bater\u00eda de litio LiFePO4 modular con sistema de gesti\u00f3n de bater\u00eda integrado.",
+      "ruta_s3": "raw/baterias/Huawei LUNA2000.pdf",
+      "descripcion": "Batería de litio LiFePO4 modular con sistema de gestión de batería integrado.",
       "url_fabricante": "https://solar.huawei.com/residential/energy-storage",
+      "parametros_comunes": {
+        "tipo": "Litio",
+        "nivel_tension": 48
+      },
       "variantes": [
+        {
+          "modelo": "LUNA2000-5 kWh",
+          "parametros_clave": {
+            "capacidad": 5
+          }
+        },
         {
           "modelo": "LUNA2000-10 kWh",
           "parametros_clave": {
-            "tipo": "Litio",
-            "nivel_tension": 48,
             "capacidad": 10
+          }
+        },
+        {
+          "modelo": "LUNA2000-15 kWh",
+          "parametros_clave": {
+            "capacidad": 15
           }
         }
       ]
     },
     {
-      "id": "sunset-gel-250ah",
-      "nombre_comercial": "Sunset Gel 250Ah",
+      "id": "sunset-gel",
+      "nombre_comercial": "Sunset Gel",
       "categoria": "baterias",
       "fabricante": "Sunset",
-      "ruta_s3": "raw/baterias/Sunset Gel 250Ah.pdf",
-      "descripcion": "Bater\u00eda solar de ciclo profundo tipo Gel para instalaciones aisladas.",
+      "ruta_s3": "raw/baterias/Sunset Gel.pdf",
+      "descripcion": "Batería solar de ciclo profundo tipo Gel para instalaciones aisladas.",
       "url_fabricante": "https://www.sunset-solar.com/gel-batteries",
+      "parametros_comunes": {
+        "tipo": "Gel"
+      },
       "variantes": [
+        {
+          "modelo": "Gel 100Ah",
+          "parametros_clave": {
+            "capacidad": 100
+          }
+        },
         {
           "modelo": "Gel 250Ah",
           "parametros_clave": {
-            "tipo": "Gel",
             "capacidad": 250
           }
         }

--- a/docs/schemas/catalog_index.schema.json
+++ b/docs/schemas/catalog_index.schema.json
@@ -1,14 +1,10 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/creep1ng/arte-chatbot/schemas/catalog_index.schema.json",
-  "title": "Arte Chatbot - Cat\u00e1logo de Fichas T\u00e9cnicas",
-  "description": "Schema para el archivo catalog_index.json que contiene los metadatos de las fichas t\u00e9cnicas de productos almacenados en S3. Definido en ADR-004.",
+  "title": "Arte Chatbot - Catálogo de Fichas Técnicas",
+  "description": "Schema para el archivo catalog_index.json que contiene los metadatos de las fichas técnicas de productos almacenados en S3. Definido en ADR-004.",
   "type": "object",
-  "required": [
-    "version",
-    "generado_en",
-    "productos"
-  ],
+  "required": ["version", "generado_en", "productos"],
   "additionalProperties": false,
   "properties": {
     "version": {
@@ -26,34 +22,32 @@
       "type": "array",
       "items": {
         "oneOf": [
-          {
-            "$ref": "#/$defs/panel"
-          },
-          {
-            "$ref": "#/$defs/inversor"
-          },
-          {
-            "$ref": "#/$defs/controlador"
-          },
-          {
-            "$ref": "#/$defs/bateria"
-          }
+          { "$ref": "#/$defs/panel" },
+          { "$ref": "#/$defs/inversor" },
+          { "$ref": "#/$defs/controlador" },
+          { "$ref": "#/$defs/bateria" }
         ]
       },
       "minItems": 1
     }
   },
   "$defs": {
+    "variante_base": {
+      "type": "object",
+      "required": ["modelo"],
+      "properties": {
+        "modelo": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 150,
+          "description": "Nombre del modelo específico de la variante"
+        }
+      },
+      "description": "Estructura base de una variante. Cada categoría extiende esta definición con sus parámetros diferenciales."
+    },
     "base_producto": {
       "type": "object",
-      "required": [
-        "id",
-        "nombre_comercial",
-        "categoria",
-        "fabricante",
-        "ruta_s3",
-        "variantes"
-      ],
+      "required": ["id", "nombre_comercial", "categoria", "fabricante", "ruta_s3", "variantes"],
       "additionalProperties": false,
       "properties": {
         "id": {
@@ -65,7 +59,12 @@
         "nombre_comercial": {
           "type": "string",
           "minLength": 3,
-          "maxLength": 200
+          "maxLength": 200,
+          "description": "Nombre de la serie o línea de productos"
+        },
+        "categoria": {
+          "type": "string",
+          "description": "Categoría del producto, restringida por cada tipo específico"
         },
         "fabricante": {
           "type": "string",
@@ -91,40 +90,26 @@
           "type": "string",
           "format": "uri"
         },
+        "parametros_comunes": {
+          "type": "object",
+          "description": "Parámetros técnicos compartidos por todas las variantes de la serie. Cada categoría define su estructura específica."
+        },
         "variantes": {
           "type": "array",
           "minItems": 1,
           "items": {
-            "type": "object",
-            "required": [
-              "modelo",
-              "parametros_clave"
-            ],
-            "properties": {
-              "modelo": {
-                "type": "string",
-                "minLength": 2,
-                "maxLength": 150
-              },
-              "parametros_clave": {
-                "type": "object"
-              }
-            }
-          }
+            "$ref": "#/$defs/variante_base"
+          },
+          "description": "Lista de variantes del producto. Cada variante solo especifica los parámetros que difieren de parametros_comunes."
         }
       }
     },
     "panel": {
       "allOf": [
-        {
-          "$ref": "#/$defs/base_producto"
-        },
+        { "$ref": "#/$defs/base_producto" },
         {
           "type": "object",
-          "required": [
-            "categoria",
-            "variantes"
-          ],
+          "required": ["categoria", "variantes"],
           "properties": {
             "categoria": {
               "type": "string",
@@ -134,34 +119,53 @@
               "type": "string",
               "pattern": "^raw/paneles/.+\\.pdf$"
             },
+            "parametros_comunes": {
+              "$ref": "#/$defs/parametros_comunes_panel"
+            },
             "variantes": {
               "type": "array",
               "items": {
-                "type": "object",
-                "properties": {
-                  "parametros_clave": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "required": [
-                      "tipo_celda",
-                      "potencia_w"
-                    ],
-                    "properties": {
-                      "tipo_celda": {
-                        "type": "string",
-                        "enum": [
-                          "monocristalino",
-                          "policristalino"
-                        ],
-                        "description": "Tipo de celda solar"
-                      },
-                      "potencia_w": {
-                        "type": "number",
-                        "minimum": 0,
-                        "description": "Potencia nominal en Watts"
-                      }
-                    }
-                  }
+                "$ref": "#/$defs/variante_panel"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "parametros_comunes_panel": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Parámetros compartidos por todas las variantes de un panel solar",
+      "required": ["tipo_celda"],
+      "properties": {
+        "tipo_celda": {
+          "type": "string",
+          "enum": ["monocristalino", "policristalino"],
+          "description": "Tipo de celda solar"
+        }
+      }
+    },
+    "variante_panel": {
+      "allOf": [
+        { "$ref": "#/$defs/variante_base" },
+        {
+          "type": "object",
+          "required": ["parametros_clave"],
+          "properties": {
+            "parametros_clave": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["potencia_w"],
+              "properties": {
+                "tipo_celda": {
+                  "type": "string",
+                  "enum": ["monocristalino", "policristalino"],
+                  "description": "Tipo de celda solar (override del valor en parametros_comunes)"
+                },
+                "potencia_w": {
+                  "type": "number",
+                  "minimum": 0,
+                  "description": "Potencia nominal en Watts"
                 }
               }
             }
@@ -171,15 +175,10 @@
     },
     "inversor": {
       "allOf": [
-        {
-          "$ref": "#/$defs/base_producto"
-        },
+        { "$ref": "#/$defs/base_producto" },
         {
           "type": "object",
-          "required": [
-            "categoria",
-            "variantes"
-          ],
+          "required": ["categoria", "variantes"],
           "properties": {
             "categoria": {
               "type": "string",
@@ -189,96 +188,99 @@
               "type": "string",
               "pattern": "^raw/inversores/.+\\.pdf$"
             },
+            "parametros_comunes": {
+              "$ref": "#/$defs/parametros_comunes_inversor"
+            },
             "variantes": {
               "type": "array",
               "items": {
-                "type": "object",
-                "properties": {
-                  "parametros_clave": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "required": [
-                      "tipo"
-                    ],
-                    "properties": {
-                      "tipo": {
-                        "type": "string",
-                        "enum": [
-                          "onda_pura",
-                          "onda_modificada",
-                          "multifuncional",
-                          "hibrido",
-                          "conexion_a_red"
-                        ],
-                        "description": "Tipo de inversor"
-                      },
-                      "nivel_tension": {
-                        "type": "number",
-                        "minimum": 0,
-                        "description": "Nivel de tensi\u00f3n en Voltios (para onda_pura, onda_modificada, multifuncional)"
-                      },
-                      "capacidad": {
-                        "type": "number",
-                        "minimum": 0,
-                        "description": "Capacidad en Watts o kVA"
-                      },
-                      "fases": {
-                        "type": "string",
-                        "enum": [
-                          "bifasico",
-                          "trifasico"
-                        ],
-                        "description": "Tipo de fases (para hibrido o conexion_a_red)"
-                      }
-                    },
-                    "allOf": [
-                      {
-                        "description": "Onda pura, onda modificada o multifuncional requieren nivel_tension y capacidad",
-                        "if": {
-                          "properties": {
-                            "tipo": {
-                              "enum": [
-                                "onda_pura",
-                                "onda_modificada",
-                                "multifuncional"
-                              ]
-                            }
-                          },
-                          "required": [
-                            "tipo"
-                          ]
-                        },
-                        "then": {
-                          "required": [
-                            "nivel_tension",
-                            "capacidad"
-                          ]
-                        }
-                      },
-                      {
-                        "description": "Hibrido o conexion_a_red requieren fases y capacidad",
-                        "if": {
-                          "properties": {
-                            "tipo": {
-                              "enum": [
-                                "hibrido",
-                                "conexion_a_red"
-                              ]
-                            }
-                          },
-                          "required": [
-                            "tipo"
-                          ]
-                        },
-                        "then": {
-                          "required": [
-                            "fases",
-                            "capacidad"
-                          ]
-                        }
-                      }
-                    ]
-                  }
+                "$ref": "#/$defs/variante_inversor"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "parametros_comunes_inversor": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Parámetros compartidos por todas las variantes de un inversor",
+      "required": ["tipo"],
+      "properties": {
+        "tipo": {
+          "type": "string",
+          "enum": ["onda_pura", "onda_modificada", "multifuncional", "hibrido", "conexion_a_red"],
+          "description": "Tipo de inversor"
+        },
+        "nivel_tension": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Nivel de tensión en Voltios (para onda_pura, onda_modificada, multifuncional)"
+        },
+        "fases": {
+          "type": "string",
+          "enum": ["bifasico", "trifasico"],
+          "description": "Tipo de fases (para hibrido o conexion_a_red)"
+        }
+      },
+      "allOf": [
+        {
+          "description": "Onda pura, onda modificada o multifuncional requieren nivel_tension",
+          "if": {
+            "properties": {
+              "tipo": { "enum": ["onda_pura", "onda_modificada", "multifuncional"] }
+            },
+            "required": ["tipo"]
+          },
+          "then": {
+            "required": ["nivel_tension"]
+          }
+        },
+        {
+          "description": "Hibrido o conexion_a_red requieren fases",
+          "if": {
+            "properties": {
+              "tipo": { "enum": ["hibrido", "conexion_a_red"] }
+            },
+            "required": ["tipo"]
+          },
+          "then": {
+            "required": ["fases"]
+          }
+        }
+      ]
+    },
+    "variante_inversor": {
+      "allOf": [
+        { "$ref": "#/$defs/variante_base" },
+        {
+          "type": "object",
+          "required": ["parametros_clave"],
+          "properties": {
+            "parametros_clave": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["capacidad"],
+              "properties": {
+                "tipo": {
+                  "type": "string",
+                  "enum": ["onda_pura", "onda_modificada", "multifuncional", "hibrido", "conexion_a_red"],
+                  "description": "Tipo de inversor (override del valor en parametros_comunes)"
+                },
+                "nivel_tension": {
+                  "type": "number",
+                  "minimum": 0,
+                  "description": "Nivel de tensión en Voltios (override del valor en parametros_comunes)"
+                },
+                "capacidad": {
+                  "type": "number",
+                  "minimum": 0,
+                  "description": "Capacidad en Watts o kVA"
+                },
+                "fases": {
+                  "type": "string",
+                  "enum": ["bifasico", "trifasico"],
+                  "description": "Tipo de fases (override del valor en parametros_comunes)"
                 }
               }
             }
@@ -288,15 +290,10 @@
     },
     "controlador": {
       "allOf": [
-        {
-          "$ref": "#/$defs/base_producto"
-        },
+        { "$ref": "#/$defs/base_producto" },
         {
           "type": "object",
-          "required": [
-            "categoria",
-            "variantes"
-          ],
+          "required": ["categoria", "variantes"],
           "properties": {
             "categoria": {
               "type": "string",
@@ -306,40 +303,63 @@
               "type": "string",
               "pattern": "^raw/controladores/.+\\.pdf$"
             },
+            "parametros_comunes": {
+              "$ref": "#/$defs/parametros_comunes_controlador"
+            },
             "variantes": {
               "type": "array",
               "items": {
-                "type": "object",
-                "properties": {
-                  "parametros_clave": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "required": [
-                      "tipo",
-                      "tension_v",
-                      "capacidad_a"
-                    ],
-                    "properties": {
-                      "tipo": {
-                        "type": "string",
-                        "enum": [
-                          "mppt",
-                          "pwm"
-                        ],
-                        "description": "Tipo de controlador"
-                      },
-                      "tension_v": {
-                        "type": "number",
-                        "minimum": 0,
-                        "description": "Tensi\u00f3n en Voltios"
-                      },
-                      "capacidad_a": {
-                        "type": "number",
-                        "minimum": 0,
-                        "description": "Capacidad en Amperios"
-                      }
-                    }
-                  }
+                "$ref": "#/$defs/variante_controlador"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "parametros_comunes_controlador": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Parámetros compartidos por todas las variantes de un controlador",
+      "required": ["tipo", "tension_v"],
+      "properties": {
+        "tipo": {
+          "type": "string",
+          "enum": ["mppt", "pwm"],
+          "description": "Tipo de controlador"
+        },
+        "tension_v": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Tensión en Voltios"
+        }
+      }
+    },
+    "variante_controlador": {
+      "allOf": [
+        { "$ref": "#/$defs/variante_base" },
+        {
+          "type": "object",
+          "required": ["parametros_clave"],
+          "properties": {
+            "parametros_clave": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["capacidad_a"],
+              "properties": {
+                "tipo": {
+                  "type": "string",
+                  "enum": ["mppt", "pwm"],
+                  "description": "Tipo de controlador (override del valor en parametros_comunes)"
+                },
+                "tension_v": {
+                  "type": "number",
+                  "minimum": 0,
+                  "description": "Tensión en Voltios (override del valor en parametros_comunes)"
+                },
+                "capacidad_a": {
+                  "type": "number",
+                  "minimum": 0,
+                  "description": "Capacidad en Amperios"
                 }
               }
             }
@@ -349,15 +369,10 @@
     },
     "bateria": {
       "allOf": [
-        {
-          "$ref": "#/$defs/base_producto"
-        },
+        { "$ref": "#/$defs/base_producto" },
         {
           "type": "object",
-          "required": [
-            "categoria",
-            "variantes"
-          ],
+          "required": ["categoria", "variantes"],
           "properties": {
             "categoria": {
               "type": "string",
@@ -367,77 +382,77 @@
               "type": "string",
               "pattern": "^raw/baterias/.+\\.pdf$"
             },
+            "parametros_comunes": {
+              "$ref": "#/$defs/parametros_comunes_bateria"
+            },
             "variantes": {
               "type": "array",
               "items": {
-                "type": "object",
-                "properties": {
-                  "parametros_clave": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "required": [
-                      "tipo"
-                    ],
-                    "properties": {
-                      "tipo": {
-                        "type": "string",
-                        "enum": [
-                          "Gel",
-                          "Litio"
-                        ],
-                        "description": "Tipo de bater\u00eda"
-                      },
-                      "nivel_tension": {
-                        "type": "number",
-                        "minimum": 0,
-                        "description": "Nivel de tensi\u00f3n en Voltios (para Litio)"
-                      },
-                      "capacidad": {
-                        "type": "number",
-                        "minimum": 0,
-                        "description": "Capacidad en Ah o kWh"
-                      }
-                    },
-                    "allOf": [
-                      {
-                        "description": "Bater\u00edas Gel solo requieren capacidad",
-                        "if": {
-                          "properties": {
-                            "tipo": {
-                              "const": "Gel"
-                            }
-                          },
-                          "required": [
-                            "tipo"
-                          ]
-                        },
-                        "then": {
-                          "required": [
-                            "capacidad"
-                          ]
-                        }
-                      },
-                      {
-                        "description": "Bater\u00edas Litio requieren nivel_tension y capacidad",
-                        "if": {
-                          "properties": {
-                            "tipo": {
-                              "const": "Litio"
-                            }
-                          },
-                          "required": [
-                            "tipo"
-                          ]
-                        },
-                        "then": {
-                          "required": [
-                            "nivel_tension",
-                            "capacidad"
-                          ]
-                        }
-                      }
-                    ]
-                  }
+                "$ref": "#/$defs/variante_bateria"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "parametros_comunes_bateria": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Parámetros compartidos por todas las variantes de una batería",
+      "required": ["tipo"],
+      "properties": {
+        "tipo": {
+          "type": "string",
+          "enum": ["Gel", "Litio"],
+          "description": "Tipo de batería"
+        },
+        "nivel_tension": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Nivel de tensión en Voltios (para Litio)"
+        }
+      },
+      "allOf": [
+        {
+          "description": "Baterías Litio requieren nivel_tension",
+          "if": {
+            "properties": {
+              "tipo": { "const": "Litio" }
+            },
+            "required": ["tipo"]
+          },
+          "then": {
+            "required": ["nivel_tension"]
+          }
+        }
+      ]
+    },
+    "variante_bateria": {
+      "allOf": [
+        { "$ref": "#/$defs/variante_base" },
+        {
+          "type": "object",
+          "required": ["parametros_clave"],
+          "properties": {
+            "parametros_clave": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["capacidad"],
+              "properties": {
+                "tipo": {
+                  "type": "string",
+                  "enum": ["Gel", "Litio"],
+                  "description": "Tipo de batería (override del valor en parametros_comunes)"
+                },
+                "nivel_tension": {
+                  "type": "number",
+                  "minimum": 0,
+                  "description": "Nivel de tensión en Voltios (override del valor en parametros_comunes)"
+                },
+                "capacidad": {
+                  "type": "number",
+                  "minimum": 0,
+                  "description": "Capacidad en Ah o kWh"
                 }
               }
             }


### PR DESCRIPTION
## Summary

- **Schema change**: Implement `parametros_comunes` at the product level so common parameters (e.g., `tipo_celda`, `tipo`, `tension_v`) are defined once per series, while variant `parametros_clave` only contains differential fields (e.g., `potencia_w`, `capacidad`, `capacidad_a`).
- **Example data**: Updated `catalog_index.example.json` with series-level entries demonstrating the new pattern across all 4 categories (7 products, 17 total variants).
- **ADR-004**: Updated documentation to describe the inheritance-with-overrides pattern, split parameter tables into shared vs differential, and added concrete examples.
- **New `$defs`**: `variante_base`, `parametros_comunes_*`, `variante_*` for each category (panel, inversor, controlador, bateria).

## Motivation

When a single PDF datasheet covers multiple variants of the same series (e.g., Victron SmartSolar MPPT 150/35, 150/45, 150/70), the previous schema required duplicating all parameters in every variant entry. The new design follows [Idea A](https://github.com/creep1ng/arte-chatbot/issues/15) — an inheritance-with-overrides pattern where `parametros_comunes` holds shared attributes and each variant only specifies what differs.

## BREAKING CHANGE

Existing `catalog_index.json` files must be migrated to the new structure:
- Move shared parameters from `parametros_clave` in each variant to a new `parametros_comunes` object at the product level
- Keep only differential parameters in each variant's `parametros_clave`

## Closes

- Part of #15 (TS-03 · Pipeline de indexación del catálogo)
- Follows up on #77 (strategy documentation)

## Documentation

Updated ADR-004 with:
- New parameter tables distinguishing `parametros_comunes` from `parametros_clave`
- Full code examples for all 4 categories
- "Patrón de herencia con overrides" section in Notas adicionales

📄 [ADR-004](docs/adr/004.md)