### PR TITLE
feat: [TS-089] Sistema de logging estructurado con niveles y contexto de depuración

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,6 @@ AWS_REGION=us-east-1
 # API Key for authenticating with the /chat endpoint
 # Generate it with openssl:
 # echo CHAT_API_KEY=$(openssl rand -base64 32) >> .env
+
+# Logging level: DEBUG, INFO, WARNING, ERROR, CRITICAL (default: INFO)
+LOG_LEVEL=INFO

--- a/backend/app/file_inputs.py
+++ b/backend/app/file_inputs.py
@@ -56,7 +56,12 @@ class FileInputsClient:
             FileUploadError: If the upload fails.
         """
         try:
-            logger.info(f"Uploading PDF to OpenAI Files API: {filename}")
+            logger.debug(
+                "File upload initiated: filename=%s, size_bytes=%d",
+                filename,
+                len(pdf_bytes),
+            )
+            logger.info("Uploading PDF to OpenAI Files API: %s", filename)
             import io
 
             # Create a file-like object from bytes
@@ -70,20 +75,25 @@ class FileInputsClient:
             )
 
             file_id = response.id
-            logger.info(f"Successfully uploaded file with ID: {file_id}")
+            logger.debug(
+                "File upload complete: file_id=%s, filename=%s",
+                file_id,
+                filename,
+            )
+            logger.info("Successfully uploaded file with ID: %s", file_id)
             return file_id
 
         except AuthenticationError as e:
-            logger.error(f"OpenAI authentication error: {e}")
+            logger.error("OpenAI authentication error: %s", e)
             raise FileUploadError("Invalid OpenAI API key") from e
         except BadRequestError as e:
-            logger.error(f"OpenAI bad request error: {e}")
+            logger.error("OpenAI bad request error: %s", e)
             raise FileUploadError(f"Invalid file format or request: {e}") from e
         except APIError as e:
-            logger.error(f"OpenAI API error: {e}")
+            logger.error("OpenAI API error: %s", e)
             raise FileUploadError(f"OpenAI API error: {e}") from e
         except Exception as e:
-            logger.exception(f"Unexpected error uploading file: {e}")
+            logger.exception("Unexpected error uploading file: %s", e)
             raise FileUploadError(f"Unexpected error: {e}") from e
 
     def delete_file(self, file_id: str) -> None:
@@ -96,15 +106,17 @@ class FileInputsClient:
             FileUploadError: If the deletion fails.
         """
         try:
-            logger.info(f"Deleting OpenAI file: {file_id}")
+            logger.debug("File deletion initiated: file_id=%s", file_id)
+            logger.info("Deleting OpenAI file: %s", file_id)
             self.client.files.delete(file_id)
-            logger.info(f"Successfully deleted file: {file_id}")
+            logger.debug("File deletion complete: file_id=%s", file_id)
+            logger.info("Successfully deleted file: %s", file_id)
         except AuthenticationError as e:
-            logger.error(f"OpenAI authentication error: {e}")
+            logger.error("OpenAI authentication error: %s", e)
             raise FileUploadError("Invalid OpenAI API key") from e
         except APIError as e:
-            logger.error(f"OpenAI API error deleting file: {e}")
+            logger.error("OpenAI API error deleting file: %s", e)
             raise FileUploadError(f"Error deleting file: {e}") from e
         except Exception as e:
-            logger.exception(f"Unexpected error deleting file: {e}")
+            logger.exception("Unexpected error deleting file: %s", e)
             raise FileUploadError(f"Unexpected error: {e}") from e

--- a/backend/app/llm_client.py
+++ b/backend/app/llm_client.py
@@ -98,6 +98,13 @@ class LLMClient:
 
         prompt = system_prompt or self.default_system_prompt
 
+        logger.debug(
+            "LLM call (legacy): model=%s, session_id=%s, message_preview=%s",
+            self.model,
+            session_id,
+            message[:100],
+        )
+
         headers = {
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
@@ -124,8 +131,14 @@ class LLMClient:
         except requests.exceptions.Timeout:
             raise LLMServiceError("LLM service timed out")
         except requests.exceptions.RequestException as e:
+            logger.error("LLM request failed: session_id=%s, error=%s", session_id, e)
             raise LLMServiceError(f"LLM service error: {e}")
         except (KeyError, IndexError) as e:
+            logger.error(
+                "Unexpected LLM response format: session_id=%s, error=%s",
+                session_id,
+                e,
+            )
             raise LLMServiceError(f"Unexpected LLM response format: {e}")
 
     def get_llm_response_with_tools(
@@ -155,6 +168,15 @@ class LLMClient:
 
         prompt = system_prompt or self.default_system_prompt
         tools = get_tool_definitions()
+
+        logger.debug(
+            "LLM call with tools: model=%s, session_id=%s, message_preview=%s, "
+            "num_tools=%d",
+            self.model,
+            session_id,
+            message[:100],
+            len(tools),
+        )
 
         try:
             response = self.openai_client.chat.completions.create(
@@ -198,13 +220,13 @@ class LLMClient:
             return result
 
         except AuthenticationError as e:
-            logger.error(f"OpenAI authentication error: {e}")
+            logger.error("OpenAI authentication error: %s", e)
             raise LLMServiceError("Invalid OpenAI API key") from e
         except APIError as e:
-            logger.error(f"OpenAI API error: {e}")
+            logger.error("OpenAI API error: %s", e)
             raise LLMServiceError(f"OpenAI API error: {e}") from e
         except Exception as e:
-            logger.exception(f"Unexpected error calling OpenAI API: {e}")
+            logger.exception("Unexpected error calling OpenAI API: %s", e)
             raise LLMServiceError(f"LLM service error: {e}") from e
 
     def get_llm_response_with_file(
@@ -236,6 +258,15 @@ class LLMClient:
 
         prompt = system_prompt or DATASHEET_SYSTEM_PROMPT
 
+        logger.debug(
+            "LLM call with file: model=%s, session_id=%s, file_id=%s, "
+            "message_preview=%s",
+            self.model,
+            session_id,
+            file_id,
+            message[:100],
+        )
+
         try:
             response = self.openai_client.chat.completions.create(
                 model=self.model,
@@ -257,11 +288,11 @@ class LLMClient:
             return response.choices[0].message.content or ""
 
         except AuthenticationError as e:
-            logger.error(f"OpenAI authentication error: {e}")
+            logger.error("OpenAI authentication error (file): %s", e)
             raise LLMServiceError("Invalid OpenAI API key") from e
         except APIError as e:
-            logger.error(f"OpenAI API error: {e}")
+            logger.error("OpenAI API error (file): %s", e)
             raise LLMServiceError(f"OpenAI API error: {e}") from e
         except Exception as e:
-            logger.exception(f"Unexpected error calling OpenAI API: {e}")
+            logger.exception("Unexpected error calling OpenAI API (file): %s", e)
             raise LLMServiceError(f"LLM service error: {e}") from e

--- a/backend/app/logging_config.py
+++ b/backend/app/logging_config.py
@@ -1,0 +1,68 @@
+"""Centralized logging configuration for ARTE Chatbot.
+
+Provides structured logging with configurable levels via the LOG_LEVEL
+environment variable. Configures a single StreamHandler for stdout output,
+compatible with Docker and containerized deployments.
+"""
+
+import logging
+import os
+import sys
+
+
+LOG_FORMAT = "[%(asctime)s] %(levelname)-8s %(name)s - %(message)s"
+DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+_DEFAULT_LOG_LEVEL = "INFO"
+
+_VALID_LOG_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+
+
+def get_log_level() -> int:
+    """Resolve the log level from the LOG_LEVEL environment variable.
+
+    Returns:
+        The numeric log level (e.g., logging.INFO). Defaults to INFO
+        if the env var is not set or contains an invalid value.
+    """
+    level_str = os.getenv("LOG_LEVEL", _DEFAULT_LOG_LEVEL).upper().strip()
+    if level_str not in _VALID_LOG_LEVELS:
+        level_str = _DEFAULT_LOG_LEVEL
+    return getattr(logging, level_str)
+
+
+def setup_logging() -> logging.Logger:
+    """Configure the root logger and all application loggers.
+
+    Sets up a StreamHandler to stdout with the project's standard format.
+    The log level is controlled via the LOG_LEVEL environment variable
+    (default: INFO). Safe to call multiple times — idempotent.
+
+    Returns:
+        The configured root logger instance.
+    """
+    root_logger = logging.getLogger()
+    log_level = get_log_level()
+
+    # Idempotent: avoid duplicate handlers on repeated calls
+    if root_logger.handlers:
+        root_logger.setLevel(log_level)
+        return root_logger
+
+    root_logger.setLevel(log_level)
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(log_level)
+    handler.setFormatter(logging.Formatter(fmt=LOG_FORMAT, datefmt=DATE_FORMAT))
+
+    root_logger.addHandler(handler)
+
+    # Suppress noisy third-party loggers in production
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("httpcore").setLevel(logging.WARNING)
+    logging.getLogger("openai").setLevel(logging.WARNING)
+    logging.getLogger("botocore").setLevel(logging.WARNING)
+    logging.getLogger("boto3").setLevel(logging.WARNING)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+    return root_logger

--- a/backend/app/s3_client.py
+++ b/backend/app/s3_client.py
@@ -38,7 +38,9 @@ class S3Client:
             aws_secret_access_key: AWS secret access key. Defaults to AWS_SECRET_ACCESS_KEY env var.
             aws_region: AWS region. Defaults to AWS_REGION env var.
         """
-        self.bucket_name = bucket_name if bucket_name is not None else os.getenv("AWS_BUCKET_NAME", "")
+        self.bucket_name = (
+            bucket_name if bucket_name is not None else os.getenv("AWS_BUCKET_NAME", "")
+        )
         self.aws_access_key_id = aws_access_key_id or os.getenv("AWS_ACCESS_KEY_ID")
         self.aws_secret_access_key = aws_secret_access_key or os.getenv(
             "AWS_SECRET_ACCESS_KEY"
@@ -79,26 +81,32 @@ class S3Client:
             raise S3DownloadError("S3 bucket name not configured")
 
         try:
-            logger.info(f"Downloading S3 object: {self.bucket_name}/{s3_key}")
+            logger.debug(
+                "S3 download initiated: bucket=%s, key=%s",
+                self.bucket_name,
+                s3_key,
+            )
+            logger.info("Downloading S3 object: %s/%s", self.bucket_name, s3_key)
             response = self.client.get_object(Bucket=self.bucket_name, Key=s3_key)
             pdf_bytes = response["Body"].read()
-            logger.info(
-                f"Downloaded {len(pdf_bytes)} bytes from {s3_key}"
+            logger.debug(
+                "S3 download complete: key=%s, size_bytes=%d",
+                s3_key,
+                len(pdf_bytes),
             )
+            logger.info("Downloaded %d bytes from %s", len(pdf_bytes), s3_key)
             return pdf_bytes
         except ClientError as e:
             error_code = e.response.get("Error", {}).get("Code", "Unknown")
-            logger.error(f"S3 client error ({error_code}): {e}")
+            logger.error("S3 client error (%s): %s", error_code, e)
             if error_code == "NoSuchKey":
-                raise S3DownloadError(
-                    f"File not found in S3: {s3_key}"
-                ) from e
+                raise S3DownloadError(f"File not found in S3: {s3_key}") from e
             raise S3DownloadError(f"S3 download failed: {e}") from e
         except NoCredentialsError:
             logger.error("AWS credentials not available")
             raise S3DownloadError("AWS credentials not configured") from None
         except Exception as e:
-            logger.exception(f"Unexpected error downloading from S3: {e}")
+            logger.exception("Unexpected error downloading from S3: %s", e)
             raise S3DownloadError(f"Unexpected S3 error: {e}") from e
 
     def file_exists(self, s3_key: str) -> bool:
@@ -115,6 +123,10 @@ class S3Client:
 
         try:
             self.client.head_object(Bucket=self.bucket_name, Key=s3_key)
+            logger.debug("S3 file exists: bucket=%s, key=%s", self.bucket_name, s3_key)
             return True
         except ClientError:
+            logger.debug(
+                "S3 file not found: bucket=%s, key=%s", self.bucket_name, s3_key
+            )
             return False

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,6 +12,11 @@ from dotenv import load_dotenv
 
 load_dotenv(override=False)
 
+from backend.app.logging_config import setup_logging
+
+# Configure logging before anything else
+setup_logging()
+
 from fastapi import FastAPI, HTTPException, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -120,10 +125,15 @@ def _process_tool_call(
     fabricante = arguments.get("fabricante")
     modelo = arguments.get("modelo")
 
-    logger.info(
-        f"Processing tool call: {function_name} - "
-        f"ruta_s3={ruta_s3}, categoria={categoria}, "
-        f"fabricante={fabricante}, modelo={modelo}"
+    logger.debug(
+        "Tool call parameters: function=%s, ruta_s3=%s, categoria=%s, "
+        "fabricante=%s, modelo=%s, session_id=%s",
+        function_name,
+        ruta_s3,
+        categoria,
+        fabricante,
+        modelo,
+        session_id,
     )
 
     if not ruta_s3:
@@ -151,7 +161,12 @@ def _process_tool_call(
         try:
             file_inputs_client.delete_file(file_id)
         except Exception as e:
-            logger.warning(f"Failed to delete file {file_id}: {e}")
+            logger.warning(
+                "Failed to delete file: file_id=%s, session_id=%s, error=%s",
+                file_id,
+                session_id,
+                e,
+            )
 
 
 @app.post("/chat", response_model=ChatResponse)
@@ -164,6 +179,14 @@ def chat_endpoint(request: ChatRequest, api_key: str = Depends(verify_api_key)):
     2. If tool call present, process it and make second call
     """
     session_id = request.session_id or str(uuid.uuid4())
+    request_id = str(uuid.uuid4())
+
+    logger.debug(
+        "Incoming request: request_id=%s, session_id=%s, message_preview=%s",
+        request_id,
+        session_id,
+        request.message[:100],
+    )
 
     # Initialize session if needed
     if session_id not in _sessions:
@@ -173,6 +196,12 @@ def chat_endpoint(request: ChatRequest, api_key: str = Depends(verify_api_key)):
     escalation_result = default_detector.detect(request.message)
 
     if escalation_result.escalate:
+        logger.info(
+            "Escalation detected: request_id=%s, session_id=%s, reason=%s",
+            request_id,
+            session_id,
+            escalation_result.reason,
+        )
         return ChatResponse(
             response=DEFAULT_ESCALATION_MESSAGE,
             escalate=True,
@@ -182,6 +211,12 @@ def chat_endpoint(request: ChatRequest, api_key: str = Depends(verify_api_key)):
 
     try:
         # First LLM call with tools
+        logger.debug(
+            "Calling LLM with tools: request_id=%s, session_id=%s, model=%s",
+            request_id,
+            session_id,
+            llm_client.model,
+        )
         llm_response = llm_client.get_llm_response_with_tools(
             message=request.message,
             session_id=session_id,
@@ -222,7 +257,12 @@ def chat_endpoint(request: ChatRequest, api_key: str = Depends(verify_api_key)):
                         session_id=session_id,
                     )
                 except S3DownloadError as e:
-                    logger.error(f"S3 download error: {e}")
+                    logger.error(
+                        "S3 download error: request_id=%s, session_id=%s, error=%s",
+                        request_id,
+                        session_id,
+                        e,
+                    )
                     return ChatResponse(
                         response=(
                             "Lo siento, no pude acceder a la ficha técnica del "
@@ -234,7 +274,12 @@ def chat_endpoint(request: ChatRequest, api_key: str = Depends(verify_api_key)):
                         session_id=session_id,
                     )
                 except FileUploadError as e:
-                    logger.error(f"File upload error: {e}")
+                    logger.error(
+                        "File upload error: request_id=%s, session_id=%s, error=%s",
+                        request_id,
+                        session_id,
+                        e,
+                    )
                     return ChatResponse(
                         response=(
                             "Lo siento, tuve problemas al procesar la ficha técnica. "
@@ -244,7 +289,12 @@ def chat_endpoint(request: ChatRequest, api_key: str = Depends(verify_api_key)):
                         session_id=session_id,
                     )
                 except Exception as e:
-                    logger.exception(f"Error processing tool call: {e}")
+                    logger.exception(
+                        "Error processing tool call: request_id=%s, session_id=%s, error=%s",
+                        request_id,
+                        session_id,
+                        e,
+                    )
                     return ChatResponse(
                         response=(
                             "Ocurrió un error al procesar tu solicitud. "
@@ -262,10 +312,19 @@ def chat_endpoint(request: ChatRequest, api_key: str = Depends(verify_api_key)):
         )
 
     except LLMServiceError as e:
-        logger.error(f"LLM service error: {e}")
+        logger.error(
+            "LLM service error: request_id=%s, session_id=%s, error=%s",
+            request_id,
+            session_id,
+            e,
+        )
         raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
-        logger.exception(f"Unexpected error in chat endpoint: {e}")
+        logger.exception(
+            "Unexpected error in chat endpoint: request_id=%s, session_id=%s",
+            request_id,
+            session_id,
+        )
         raise HTTPException(status_code=500, detail="Internal server error")
 
 

--- a/backend/tests/test_logging.py
+++ b/backend/tests/test_logging.py
@@ -1,0 +1,137 @@
+"""
+Tests for the centralized logging configuration module.
+"""
+
+import logging
+import os
+
+import pytest
+
+from backend.app.logging_config import (
+    LOG_FORMAT,
+    DATE_FORMAT,
+    _DEFAULT_LOG_LEVEL,
+    _VALID_LOG_LEVELS,
+    get_log_level,
+    setup_logging,
+)
+
+
+class TestGetLogLevel:
+    """Tests for get_log_level() function."""
+
+    def test_default_level_is_info(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that INFO is the default log level when LOG_LEVEL is unset."""
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        assert get_log_level() == logging.INFO
+
+    def test_reads_debug_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test reading DEBUG level from environment."""
+        monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+        assert get_log_level() == logging.DEBUG
+
+    def test_reads_warning_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test reading WARNING level from environment."""
+        monkeypatch.setenv("LOG_LEVEL", "WARNING")
+        assert get_log_level() == logging.WARNING
+
+    def test_reads_error_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test reading ERROR level from environment."""
+        monkeypatch.setenv("LOG_LEVEL", "ERROR")
+        assert get_log_level() == logging.ERROR
+
+    def test_reads_critical_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test reading CRITICAL level from environment."""
+        monkeypatch.setenv("LOG_LEVEL", "CRITICAL")
+        assert get_log_level() == logging.CRITICAL
+
+    def test_case_insensitive(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that log level parsing is case-insensitive."""
+        monkeypatch.setenv("LOG_LEVEL", "debug")
+        assert get_log_level() == logging.DEBUG
+
+    def test_strips_whitespace(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that surrounding whitespace is stripped."""
+        monkeypatch.setenv("LOG_LEVEL", "  WARNING  ")
+        assert get_log_level() == logging.WARNING
+
+    def test_invalid_level_falls_back_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that an invalid level string falls back to INFO."""
+        monkeypatch.setenv("LOG_LEVEL", "INVALID_LEVEL")
+        assert get_log_level() == logging.INFO
+
+    def test_empty_string_falls_back_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that an empty LOG_LEVEL falls back to INFO."""
+        monkeypatch.setenv("LOG_LEVEL", "")
+        assert get_log_level() == logging.INFO
+
+
+class TestSetupLogging:
+    """Tests for setup_logging() function."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_root_logger(self) -> None:
+        """Remove handlers from root logger before each test."""
+        root = logging.getLogger()
+        original_handlers = root.handlers[:]
+        original_level = root.level
+        yield
+        # Restore original state
+        root.handlers = original_handlers
+        root.setLevel(original_level)
+
+    def test_returns_root_logger(self) -> None:
+        """Test that setup_logging returns the root logger."""
+        root = logging.getLogger()
+        root.handlers.clear()
+        result = setup_logging()
+        assert result is root
+
+    def test_configures_handler(self) -> None:
+        """Test that a StreamHandler is added to the root logger."""
+        root = logging.getLogger()
+        root.handlers.clear()
+        setup_logging()
+        assert len(root.handlers) == 1
+        assert isinstance(root.handlers[0], logging.StreamHandler)
+
+    def test_handler_format(self) -> None:
+        """Test that the handler uses the expected format string."""
+        root = logging.getLogger()
+        root.handlers.clear()
+        setup_logging()
+        formatter = root.handlers[0].formatter
+        assert formatter is not None
+        assert formatter._fmt == LOG_FORMAT
+        assert formatter.datefmt == DATE_FORMAT
+
+    def test_idempotent(self) -> None:
+        """Test that calling setup_logging() multiple times does not add duplicate handlers."""
+        root = logging.getLogger()
+        root.handlers.clear()
+        setup_logging()
+        setup_logging()
+        setup_logging()
+        assert len(root.handlers) == 1
+
+    def test_respects_log_level_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that the root logger level is set from LOG_LEVEL env var."""
+        monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+        root = logging.getLogger()
+        root.handlers.clear()
+        setup_logging()
+        assert root.level == logging.DEBUG
+
+    def test_suppresses_noisy_loggers(self) -> None:
+        """Test that noisy third-party loggers are suppressed."""
+        root = logging.getLogger()
+        root.handlers.clear()
+        setup_logging()
+
+        noisy_loggers = ["httpx", "httpcore", "openai", "botocore", "boto3", "urllib3"]
+        for name in noisy_loggers:
+            assert logging.getLogger(name).level == logging.WARNING

--- a/evaluation/harness/run.py
+++ b/evaluation/harness/run.py
@@ -7,6 +7,7 @@ against the /chat endpoint and record the results.
 
 import csv
 import json
+import logging
 import os
 import sys
 from datetime import datetime
@@ -19,6 +20,8 @@ from dotenv import load_dotenv
 # Load environment variables from .env file if present
 load_dotenv()
 
+logger = logging.getLogger(__name__)
+
 # Configuration with environment variable support
 API_BASE_URL = os.getenv("API_BASE_URL", "http://localhost:8000")
 CHAT_ENDPOINT = f"{API_BASE_URL}/chat"
@@ -29,7 +32,7 @@ OUTPUT_DIR = Path(os.getenv("OUTPUT_DIR", Path(__file__).parent / "output"))
 def load_dataset() -> list[dict[str, Any]]:
     """Load the test dataset from JSON file."""
     if not DATASET_PATH.exists():
-        print(f"Error: Dataset not found at {DATASET_PATH}")
+        logger.error("Dataset not found at %s", DATASET_PATH)
         sys.exit(1)
 
     with open(DATASET_PATH, encoding="utf-8") as f:
@@ -158,6 +161,7 @@ def run_harness() -> list[dict[str, Any]]:
 
     # Load dataset
     dataset = load_dataset()
+    logger.info("Loaded %d test queries", len(dataset))
     print(f"Loaded {len(dataset)} test queries")
     print()
 
@@ -166,10 +170,16 @@ def run_harness() -> list[dict[str, Any]]:
         with httpx.Client() as client:
             health_response = client.get(f"{API_BASE_URL}/health", timeout=5.0)
             if health_response.status_code == 200:
+                logger.info("API health check passed")
                 print("✓ API is healthy")
             else:
+                logger.warning(
+                    "API health check returned status %d",
+                    health_response.status_code,
+                )
                 print(f"⚠ API returned status {health_response.status_code}")
     except httpx.ConnectError:
+        logger.error("Cannot connect to API at %s", API_BASE_URL)
         print(f"✗ Error: Cannot connect to API at {API_BASE_URL}")
         print("  Make sure the backend is running (docker compose up)")
         sys.exit(1)
@@ -185,14 +195,21 @@ def run_harness() -> list[dict[str, Any]]:
             query_id = query_data.get("id", f"q{i:03d}")
             query_preview = query_data.get("query", "")[:50]
 
+            logger.debug("Running query %d/%d: %s", i, len(dataset), query_id)
             print(f"[{i}/{len(dataset)}] {query_id}: {query_preview}...")
 
             result = run_single_query(client, query_data)
             results.append(result)
 
             if result["error"]:
+                logger.error("Query %s failed: %s", query_id, result["error"])
                 print(f"    ✗ Error: {result['error']}")
             else:
+                logger.debug(
+                    "Query %s completed: %.2fms",
+                    query_id,
+                    result["latency_ms"],
+                )
                 print(f"    ✓ Latency: {result['latency_ms']:.2f}ms")
 
     print()
@@ -207,6 +224,13 @@ def run_harness() -> list[dict[str, Any]]:
     avg_latency = sum(latencies) / len(latencies) if latencies else 0
     min_latency = min(latencies) if latencies else 0
     max_latency = max(latencies) if latencies else 0
+
+    logger.info(
+        "Evaluation complete: successful=%d, failed=%d, avg_latency=%.2fms",
+        successful,
+        failed,
+        avg_latency,
+    )
 
     print(f"Successful: {successful}")
     print(f"Failed: {failed}")


### PR DESCRIPTION
## Descripción

Implementa el sistema de logging estructurado centralizado para ARTE Chatbot según lo definido en [#89](https://github.com/creep1ng/arte-chatbot/issues/89).

## Cambios

### Archivos nuevos
- **`backend/app/logging_config.py`** — Módulo de configuración centralizada de logging con:
  - `setup_logging()` que configura root logger con StreamHandler a stdout
  - Formato: `[%(asctime)s] %(levelname)-8s %(name)s - %(message)s`
  - Nivel configurable via `LOG_LEVEL` env var (default: `INFO`)
  - Supresión de loggers ruidosos (httpx, httpcore, openai, botocore, boto3, urllib3)
  - Idempotente (safe para múltiples llamadas)

- **`backend/tests/test_logging.py`** — Tests unitarios del módulo de logging (15 tests)

### Archivos modificados
- **`backend/main.py`** — Integración de `setup_logging()` al arranque + logs enriquecidos:
  - Generación de `request_id` (UUID) por cada request
  - DEBUG logs: incoming requests (preview), LLM calls, tool call parameters
  - INFO logs: escalation detection
  - Logs de error con `request_id` y `session_id` para trazabilidad

- **`backend/app/llm_client.py`** — Logs DEBUG con parámetros de cada método:
  - `get_llm_response()`: model, session_id, message_preview
  - `get_llm_response_with_tools()`: model, session_id, message_preview, num_tools
  - `get_llm_response_with_file()`: model, session_id, file_id, message_preview
  - Migración de f-strings a lazy `%` formatting en logs

- **`backend/app/s3_client.py`** — Logs DEBUG enriquecidos:
  - Antes de descarga: bucket, key
  - Después de descarga: key, size_bytes
  - `file_exists()`: log de existencia/no existencia del archivo

- **`backend/app/file_inputs.py`** — Logs DEBUG enriquecidos:
  - Upload: filename, size_bytes, file_id
  - Delete: file_id (inicio y fin)

- **`evaluation/harness/run.py`** — Migración de `print()` a logging:
  - `import logging` + `logger = logging.getLogger(__name__)`
  - `print("Error: ...")` → `logger.error()`
  - Progreso de queries → `logger.debug()`
  - API health → `logger.info()` / `logger.warning()`
  - Resultados finales se mantienen como `print()` (output de usuario)

- **`.env.example`** — Agregado `LOG_LEVEL=INFO`

## Criterios de Aceptación cumplidos

- [x] `setup_logging()` configura logger con formato `[%(asctime)s] %(levelname)-8s %(name)s - %(message)s`
- [x] Nivel de logging controlado via `LOG_LEVEL` env var (default `INFO`)
- [x] En nivel DEBUG se loggean: peticiones HTTP, parámetros de tool calls, detalles de llamadas al LLM, operaciones S3 y OpenAI Files
- [x] Los logs incluyen `session_id` y `request_id` cuando están disponibles
- [x] No hay `print()` en código de producción backend (solo en evaluation harness para output de usuario)
- [x] Tests existentes pasan (94/94 no-integration tests)
- [x] `LOG_LEVEL` documentado en `.env.example`

## Tests

```bash
pytest
# 94 passed (excl. integration tests requiring live API)
```