### PR TITLE
fix(CI): corrige instalación de Kilo CLI en workflow update-agents-md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,10 +223,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Kilo CLI
-        uses: Kilo-Org/kilocode@v1
-        with:
-          version: latest
+      - name: Install Kilo CLI
+        run: npm install -g @kilocode/cli
+
+      - name: Install agents-md skill
+        run: npx skills add https://github.com/getsentry/skills --skill agents-md
 
       - name: Authenticate Kilo
         run: |


### PR DESCRIPTION
## ¿Qué hace este PR?

Corrige el workflow `update-agents-md` que utilizaba una GitHub Action inexistente (`Kilo-Org/kilocode@v1`). Se reemplaza por la instalación real via npm: `npm install -g @kilocode/cli`, y se agrega la instalación de la skill `agents-md` requerida para el refactor (`npx skills add https://github.com/getsentry/skills --skill agents-md`).

## Issues relacionados

Closes #

## Tipo de cambio

- [x] 🔧 Infra / CI

## Checklist antes de pedir review

- [x] Los cambios solo afectan al workflow de CI (no código de aplicación)
- [x] No hay credenciales, API keys ni rutas absolutas hardcodeadas
- [x] El workflow fue validado contra la sintaxis YAML

## Cómo probar este PR

1. Ir a la pestaña **Actions** en GitHub
2. Ejecutar manualmente el workflow `CI` en la rama `fix/update-agents-md-workflow`
3. Verificar que el job `update-agents-md` complete exitosamente sin errores de instalación

## Notas para el reviewer

El workflow original asumía la existencia de una acción GitHub oficial de Kilo que no existe. La instalación real del CLI se hace via npm global. La skill `agents-md` no se instalaba previamente y es requerida para que el comando `kilo-cli chat` pueda invocar la herramienta de refactorización.