### PR TITLE
feat: [US-95] S3 upload for evaluation harness results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,8 @@ jobs:
           cat > .env <<EOF
           CHAT_API_KEY=${{ secrets.CHAT_API_KEY }}
           OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
+          AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
           EOF
 
       - name: Start containers
@@ -176,6 +178,8 @@ jobs:
           uv pip install -r evaluation/harness/requirements.txt
 
       - name: Run evaluation harness
+        env:
+          EVAL_S3_PREFIX: evaluation/ci/${{ github.ref_name }}/${{ github.run_id }}/
         run: |
           uv run python -m evaluation.harness.run
 

--- a/docs/adr/008.md
+++ b/docs/adr/008.md
@@ -1,0 +1,100 @@
+---
+
+**Número**: ADR-008
+**Fecha**: 2026-05-05
+**Redactor**: Kilo (copilot)
+**Estado**: Aceptado
+
+---
+
+## Contexto
+
+El harness de evaluación de ARTE Chatbot genera resultados en JSON y CSV que se almacenaban únicamente en el filesystem local (`evaluation/harness/output/`) y como artefactos de GitHub Actions (retención de 30 días). Esto presentaba problemas:
+
+- **Pérdida de históricos**: Los artefactos de GitHub se eliminan automáticamente tras 30 días
+- **Sin centralización**: No había un punto único para consultar la evolución de métricas a lo largo del tiempo
+- **Sin acceso fuera de CI**: Los resultados de ejecuciones manuales solo existían en la máquina del desarrollador
+
+Se necesitaban soluciones para persistir los resultados de evaluación de forma durable y accesible.
+
+---
+
+## Decisión
+
+Vamos a implementar un módulo de upload a S3 (`evaluation/harness/s3_upload.py`) que suba los resultados JSON/CSV del harness a S3, ejecutándose tanto en ejecuciones manuales como en el pipeline de CI. Los resultados se almacenarán bajo una estructura de prefijo que permita distinguir el origen (`ci/` vs `manual/`) y la trazabilidad por fecha y commit.
+
+La estructura en S3 será:
+
+```
+arte-chatbot-data/
+├── raw/                    # Fichas técnicas (existente)
+├── index/                  # Catálogo (existente)
+└── evaluation/
+    ├── ci/
+    │   └── {branch}/
+    │       └── {run_id}/
+    │           ├── results_{timestamp}.json
+    │           ├── results_{timestamp}.csv
+    │           └── metadata.json
+    └── manual/
+        └── {username}/
+            └── {timestamp}/
+                ├── results_{timestamp}.json
+                ├── results_{timestamp}.csv
+                └── metadata.json
+```
+
+Cada upload incluirá un `metadata.json` con: `git_commit`, `git_branch`, `timestamp_utc`, `trigger` (ci/manual), `runner`, `harness_version`.
+
+---
+
+## Justificación
+
+- **Alternativa 1**: Almacenar solo en GitHub Actions artifacts - Rechazado: limitado a 30 días, no accesible desde outside CI
+- **Alternativa 2**: Subir a base de datos relacional - Rechazado: introduce dependencia adicional, mayor complejidad operacional
+- **Alternativa 3**: S3 con estructura prefijo/fecha - Elegida: aprovecha infraestructura S3 ya en uso (ADR-002), sin nuevas dependencias, acceso histórico ilimitado
+
+**Criterios de decisión**: simplicidad, reutilización de infraestructura existente, acceso histórico, cero dependencia adicional.
+
+---
+
+## Consecuencias
+
+### Positivas
+
+- Histórico de métricas accesible sin límite temporal
+- Resultados de ejecuciones manuales centralizados en S3
+- Trazabilidad completa via metadata.json (commit, branch, runner)
+- Fallo de upload no interrumpe ejecución del harness
+- Soporte para prefijos custom via `EVAL_S3_PREFIX` en CI
+
+### Negativas
+
+- Introduce `boto3` como dependencia del harness (ya presente en el proyecto via backend)
+- Requiere credenciales AWS configuradas (variables de entorno)
+
+### Trade-offs aceptados
+
+- Upload síncrono en el mismo proceso (vs async) - no critical para ejecución manual
+- Fallo silencioso con logging - el objetivo principal es evaluar, no subir
+
+---
+
+## Artefactos relacionados
+
+- Issue #95: `feat: subir resultados del harness de evaluación a S3`
+- ADR-002: Infraestructura de datos con S3
+- `evaluation/harness/s3_upload.py` - módulo de upload
+- `evaluation/harness/run.py` - integración con el harness
+- `.github/workflows/ci.yml` - configuración AWS secrets y EVAL_S3_PREFIX
+- `evaluation/harness/tests/test_s3_upload.py` - tests unitarios
+- `evaluation/README.md` - documentación de la feature
+
+---
+
+## Notas adicionales
+
+- El módulo reutiliza la configuración AWS existente (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_BUCKET_NAME`, `AWS_REGION`)
+- `EVAL_S3_UPLOAD_ENABLED` (default `true`) permite deshabilitar el upload
+- `EVAL_S3_PREFIX` permite override del prefijo auto-generado (usado en CI)
+- El harness detecta si está corriendo en GitHub Actions (`GITHUB_ACTIONS` env var) para auto-detectar trigger

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -334,3 +334,62 @@ Each evaluation run automatically records:
 - Current git branch name
 
 This allows correlating evaluation results with specific code versions.
+
+## Resultados en S3
+
+Los resultados del harness se suben automáticamente a S3 para permitir acceso centralizado y histórico.
+
+### Estructura de directorios en S3
+
+```
+arte-chatbot-data/
+├── raw/                    # Fichas técnicas
+├── index/                  # Catálogo
+└── evaluation/
+    ├── ci/
+    │   └── {branch}/
+    │       └── {run_id}/
+    │           ├── results_{timestamp}.json
+    │           ├── results_{timestamp}.csv
+    │           └── metadata.json
+    └── manual/
+        └── {username}/
+            └── {timestamp}/
+                ├── results_{timestamp}.json
+                ├── results_{timestamp}.csv
+                └── metadata.json
+```
+
+### Variables de entorno
+
+| Variable | Descripción | Default |
+|----------|-------------|---------|
+| `AWS_ACCESS_KEY_ID` | Clave de acceso AWS | - |
+| `AWS_SECRET_ACCESS_KEY` | Clave secreta AWS | - |
+| `AWS_BUCKET_NAME` | Nombre del bucket S3 | `arte-chatbot-data` |
+| `AWS_REGION` | Región AWS | `us-east-1` |
+| `EVAL_S3_UPLOAD_ENABLED` | Habilitar/deshabilitar upload | `true` |
+| `EVAL_S3_PREFIX` | Prefijo custom (override automático) | auto-generado |
+
+### Comportamiento
+
+- **Ejecución local**: Los resultados se suben a `evaluation/manual/{username}/{timestamp}/`
+- **Ejecución en CI (GitHub Actions)**: Los resultados se suben a `evaluation/ci/{branch}/{run_id}/`
+- El prefijo puede ser overriden con `EVAL_S3_PREFIX` (útil para CI)
+- Un fallo en el upload **no interrumpe** la ejecución del harness
+- Se sube un archivo `metadata.json` con: `git_commit`, `git_branch`, `timestamp_utc`, `trigger`, `runner`, `harness_version`
+
+### Deshabilitar upload
+
+Para ejecutar sin subir a S3:
+
+```bash
+python -m evaluation.harness.run --no-upload
+```
+
+O exportar la variable:
+
+```bash
+export EVAL_S3_UPLOAD_ENABLED=false
+python -m evaluation.harness.run
+```

--- a/evaluation/harness/config.py
+++ b/evaluation/harness/config.py
@@ -42,6 +42,10 @@ class HarnessSettings(BaseSettings):
         default="",
         description="API key for the /chat endpoint",
     )
+    aws_bucket_name: str = Field(
+        default="arte-chatbot-data",
+        description="S3 bucket name for evaluation results",
+    )
 
 
 harness_settings = HarnessSettings()

--- a/evaluation/harness/requirements.txt
+++ b/evaluation/harness/requirements.txt
@@ -1,2 +1,3 @@
 httpx>=0.26.0
 python-dotenv>=1.0.0
+boto3>=1.34.0

--- a/evaluation/harness/run.py
+++ b/evaluation/harness/run.py
@@ -15,6 +15,8 @@ import asyncio
 import csv
 import json
 import logging
+import getpass
+import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -24,10 +26,17 @@ import httpx
 from dotenv import load_dotenv
 
 from evaluation.harness.config import harness_settings
+from evaluation.harness.s3_upload import (
+    build_prefix,
+    upload_results_with_metadata,
+)
 from evaluation.s3_client import get_git_commit, get_git_branch
-from evaluation.storage import get_commit_hash, save_results, upload_to_s3
+from evaluation.storage import get_commit_hash, save_results
 
 load_dotenv()
+
+EVAL_S3_UPLOAD_ENABLED = os.getenv("EVAL_S3_UPLOAD_ENABLED", "true").lower() != "false"
+EVAL_S3_PREFIX = os.getenv("EVAL_S3_PREFIX", "")
 
 logger = logging.getLogger(__name__)
 
@@ -309,8 +318,32 @@ async def run_harness(args: argparse.Namespace) -> list[dict[str, Any]]:
     )
     print(f"JSON saved to: {json_path}")
 
-    if not args.no_upload:
-        upload_to_s3(json_path, s3_key)
+    if EVAL_S3_UPLOAD_ENABLED and not args.no_upload:
+        import getpass
+
+        if os.getenv("GITHUB_ACTIONS"):
+            trigger = "ci"
+            branch = os.getenv("GITHUB_REF_NAME", "unknown")
+        else:
+            trigger = "manual"
+            branch = getpass.getuser()
+
+        if EVAL_S3_PREFIX:
+            prefix = EVAL_S3_PREFIX
+        else:
+            prefix = build_prefix(trigger, branch, timestamp)
+
+        print()
+        print("Uploading results to S3...")
+        uploaded_keys = upload_results_with_metadata(OUTPUT_DIR, prefix, trigger, branch)
+        if uploaded_keys is None:
+            print("✗ Failed to upload results to S3 (check credentials or network)")
+        elif uploaded_keys:
+            print(f"✓ Successfully uploaded {len(uploaded_keys)} files to S3:")
+            for key in uploaded_keys:
+                print(f"  - s3://{harness_settings.AWS_BUCKET_NAME}/{key}")
+        else:
+            print("⚠ No files available for upload")
 
     print()
     print("=" * 60)

--- a/evaluation/harness/s3_upload.py
+++ b/evaluation/harness/s3_upload.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Any
 
 import boto3
-from botocore.exceptions import Boto3Error
+from boto3.exceptions import Boto3Error
 
 logger = logging.getLogger(__name__)
 
@@ -99,6 +99,12 @@ def upload_results(output_dir: Path, prefix: str) -> list[str]:
         logger.warning("AWS credentials not found, skipping S3 upload")
         return None
 
+    s3_client = boto3.client(
+        "s3",
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name=AWS_REGION,
+    )
     uploaded: list[str] = []
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
 
@@ -110,11 +116,11 @@ def upload_results(output_dir: Path, prefix: str) -> list[str]:
         try:
             s3_client.upload_file(str(file_path), AWS_BUCKET_NAME, s3_key)
             logger.info("Uploaded %s to s3://%s/%s", file_path.name, AWS_BUCKET_NAME, s3_key)
-            uploaded_keys.append(s3_key)
+            uploaded.append(s3_key)
         except Boto3Error as e:
             logger.error("Failed to upload %s: %s", file_path.name, e)
 
-    return uploaded_keys
+    return uploaded
 
 
 def upload_results_with_metadata(

--- a/evaluation/harness/s3_upload.py
+++ b/evaluation/harness/s3_upload.py
@@ -1,0 +1,185 @@
+"""
+S3 upload module for evaluation harness results.
+
+Provides functionality to upload evaluation results (JSON/CSV) to S3
+with metadata for trazability.
+"""
+
+import getpass
+import hashlib
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import boto3
+from botocore.exceptions import Boto3Error
+
+logger = logging.getLogger(__name__)
+
+AWS_BUCKET_NAME = os.getenv("AWS_BUCKET_NAME", "arte-chatbot-data")
+AWS_REGION = os.getenv("AWS_REGION", "us-east-1")
+
+
+def get_harness_version() -> str:
+    """Compute hash of evaluation/harness/ directory content."""
+    harness_dir = Path(__file__).parent
+    hash_md5 = hashlib.md5()
+    for file_path in sorted(harness_dir.glob("*.py")):
+        if file_path.name == "__pycache__":
+            continue
+        with open(file_path, "rb") as f:
+            hash_md5.update(f.read())
+    return hash_md5.hexdigest()[:12]
+
+
+def generate_metadata(trigger: str, runner: str) -> dict[str, Any]:
+    """Generate metadata.json content for an evaluation run.
+
+    Args:
+        trigger: Execution trigger ("ci" or "manual").
+        runner: Runner identifier (GitHub Actions hostname or local username).
+
+    Returns:
+        Dictionary with metadata fields.
+    """
+    import subprocess
+
+    git_commit = "unknown"
+    git_branch = "unknown"
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        git_commit = result.stdout.strip()
+    except Exception:
+        pass
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        git_branch = result.stdout.strip()
+    except Exception:
+        pass
+
+    return {
+        "git_commit": git_commit,
+        "git_branch": git_branch,
+        "timestamp_utc": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "trigger": trigger,
+        "runner": runner,
+        "harness_version": get_harness_version(),
+    }
+
+
+def upload_results(output_dir: Path, prefix: str) -> list[str]:
+    """Upload all JSON and CSV files from output_dir to S3.
+
+    Args:
+        output_dir: Directory containing results to upload.
+        prefix: S3 key prefix (e.g., "evaluation/ci/branch/run_id/").
+
+    Returns:
+        List of S3 keys that were uploaded. Empty list on failure.
+    """
+    access_key = os.getenv("AWS_ACCESS_KEY_ID")
+    secret_key = os.getenv("AWS_SECRET_ACCESS_KEY")
+
+    if not access_key or not secret_key:
+        logger.warning("AWS credentials not found, skipping S3 upload")
+        return None
+
+    uploaded: list[str] = []
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+
+    json_files = list(output_dir.glob("*.json"))
+    csv_files = list(output_dir.glob("*.csv"))
+
+    for file_path in json_files + csv_files:
+        s3_key = f"{prefix.rstrip('/')}/{file_path.name}"
+        try:
+            s3_client.upload_file(str(file_path), AWS_BUCKET_NAME, s3_key)
+            logger.info("Uploaded %s to s3://%s/%s", file_path.name, AWS_BUCKET_NAME, s3_key)
+            uploaded_keys.append(s3_key)
+        except Boto3Error as e:
+            logger.error("Failed to upload %s: %s", file_path.name, e)
+
+    return uploaded_keys
+
+
+def upload_results_with_metadata(
+    output_dir: Path,
+    prefix: str,
+    trigger: str,
+    runner: str,
+) -> list[str]:
+    """Upload results and generate/upload metadata.json.
+
+    Args:
+        output_dir: Directory containing results to upload.
+        prefix: S3 key prefix.
+        trigger: Execution trigger ("ci" or "manual").
+        runner: Runner identifier.
+
+    Returns:
+        List of S3 keys uploaded (including metadata.json), or None on failure.
+    """
+    result = upload_results(output_dir, prefix)
+    if result is None:
+        return None
+    uploaded = result
+
+    metadata = generate_metadata(trigger, runner)
+    metadata_path = output_dir / "metadata.json"
+    with open(metadata_path, "w", encoding="utf-8") as f:
+        json.dump(metadata, f, indent=2, ensure_ascii=False)
+
+    access_key = os.getenv("AWS_ACCESS_KEY_ID")
+    secret_key = os.getenv("AWS_SECRET_ACCESS_KEY")
+
+    if access_key and secret_key:
+        s3_client = boto3.client(
+            "s3",
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+            region_name=AWS_REGION,
+        )
+        s3_key = f"{prefix.rstrip('/')}/metadata.json"
+        try:
+            s3_client.upload_file(str(metadata_path), AWS_BUCKET_NAME, s3_key)
+            logger.info("Uploaded metadata.json to s3://%s/%s", AWS_BUCKET_NAME, s3_key)
+            uploaded.append(s3_key)
+        except Boto3Error as e:
+            logger.error("Failed to upload metadata.json: %s", e)
+
+    return uploaded
+
+
+def build_prefix(trigger: str, runner: str, timestamp: str | None = None) -> str:
+    """Build S3 prefix for evaluation results.
+
+    Args:
+        trigger: "ci" or "manual".
+        runner: Runner identifier (branch/run_id for CI, username for manual).
+        timestamp: Optional timestamp (auto-generated if not provided).
+
+    Returns:
+        S3 prefix string (e.g., "evaluation/ci/main/1234567890/").
+    """
+    if timestamp is None:
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+
+    if trigger == "ci":
+        return f"evaluation/ci/{runner}/{timestamp}/"
+    else:
+        return f"evaluation/manual/{runner}/{timestamp}/"

--- a/evaluation/harness/tests/test_s3_upload.py
+++ b/evaluation/harness/tests/test_s3_upload.py
@@ -1,0 +1,154 @@
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from evaluation.harness.s3_upload import (
+    build_prefix,
+    generate_metadata,
+    get_harness_version,
+    upload_results,
+    upload_results_with_metadata,
+)
+
+
+class TestBuildPrefix:
+    def test_ci_prefix_format(self) -> None:
+        prefix = build_prefix("ci", "main", "20240515_120000")
+        assert prefix == "evaluation/ci/main/20240515_120000/"
+
+    def test_manual_prefix_format(self) -> None:
+        prefix = build_prefix("manual", "alice", "20240515_120000")
+        assert prefix == "evaluation/manual/alice/20240515_120000/"
+
+    def test_manual_prefix_without_timestamp(self) -> None:
+        prefix = build_prefix("manual", "bob")
+        assert prefix.startswith("evaluation/manual/bob/")
+        assert prefix.endswith("/")
+
+    def test_ci_prefix_without_timestamp(self) -> None:
+        prefix = build_prefix("ci", "develop")
+        assert prefix.startswith("evaluation/ci/develop/")
+        assert prefix.endswith("/")
+
+
+class TestGenerateMetadata:
+    @patch("evaluation.harness.s3_upload.subprocess.run")
+    def test_returns_expected_fields(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(stdout="abc1234", returncode=0)
+        metadata = generate_metadata("ci", "github-actions")
+        assert "git_commit" in metadata
+        assert "git_branch" in metadata
+        assert metadata["trigger"] == "ci"
+        assert metadata["runner"] == "github-actions"
+        assert "timestamp_utc" in metadata
+        assert "harness_version" in metadata
+
+    @patch("evaluation.harness.s3_upload.subprocess.run")
+    def test_fallback_on_git_failure(self, mock_run: MagicMock) -> None:
+        mock_run.side_effect = Exception("git not found")
+        metadata = generate_metadata("manual", "local")
+        assert metadata["git_commit"] == "unknown"
+        assert metadata["git_branch"] == "unknown"
+
+
+class TestGetHarnessVersion:
+    def test_returns_12_char_hash(self) -> None:
+        version = get_harness_version()
+        assert len(version) == 12
+        assert version.isalnum() or any(c in version for c in "abcdef")
+
+
+class TestUploadResults:
+    @patch.dict("os.environ", {"AWS_ACCESS_KEY_ID": "fake", "AWS_SECRET_ACCESS_KEY": "fake"})
+    @patch("evaluation.harness.s3_upload.boto3.client")
+    def test_uploads_all_json_and_csv_files(
+        self, mock_boto: MagicMock, tmp_path: Path
+    ) -> None:
+        json_file = tmp_path / "results.json"
+        json_file.write_text('{"test": true}')
+        csv_file = tmp_path / "results.csv"
+        csv_file.write_text("a,b\n1,2")
+
+        mock_s3 = MagicMock()
+        mock_boto.return_value = mock_s3
+
+        keys = upload_results(tmp_path, "evaluation/manual/test/")
+
+        assert len(keys) == 2
+        assert "results.json" in keys[0]
+        assert "results.csv" in keys[1]
+        assert mock_s3.upload_file.call_count == 2
+
+    @patch.dict("os.environ", {"AWS_ACCESS_KEY_ID": "", "AWS_SECRET_ACCESS_KEY": ""})
+    def test_returns_none_when_no_credentials(self, tmp_path: Path) -> None:
+        keys = upload_results(tmp_path, "test/")
+        assert keys is None
+
+    @patch.dict("os.environ", {"AWS_ACCESS_KEY_ID": "fake", "AWS_SECRET_ACCESS_KEY": "fake"})
+    @patch("evaluation.harness.s3_upload.boto3.client")
+    def test_handles_s3_error_gracefully(
+        self, mock_boto: MagicMock, tmp_path: Path
+    ) -> None:
+        from botocore.exceptions import ClientError
+
+        json_file = tmp_path / "results.json"
+        json_file.write_text('{"test": true}')
+
+        mock_s3 = MagicMock()
+        mock_s3.upload_file.side_effect = ClientError(
+            {"Error": {"Code": "500", "Message": "InternalError"}}, "PutObject"
+        )
+        mock_boto.return_value = mock_s3
+
+        keys = upload_results(tmp_path, "test/")
+        assert keys == []
+
+
+class TestUploadResultsWithMetadata:
+    @patch.dict(
+        "os.environ",
+        {"AWS_ACCESS_KEY_ID": "fake", "AWS_SECRET_ACCESS_KEY": "fake"},
+    )
+    @patch("evaluation.harness.s3_upload.boto3.client")
+    @patch("evaluation.harness.s3_upload.subprocess.run")
+    def test_returns_none_when_credentials_missing(
+        self, mock_run: MagicMock, mock_boto: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_run.return_value = MagicMock(stdout="abc1234", returncode=0)
+
+        json_file = tmp_path / "results.json"
+        json_file.write_text('{"test": true}')
+
+        # Simulate credentials missing during upload_results_with_metadata
+        with patch.dict("os.environ", {"AWS_ACCESS_KEY_ID": "", "AWS_SECRET_ACCESS_KEY": ""}):
+            keys = upload_results_with_metadata(
+                tmp_path, "evaluation/manual/testuser/", "manual", "testuser"
+            )
+        assert keys is None
+
+    @patch.dict(
+        "os.environ",
+        {"AWS_ACCESS_KEY_ID": "fake", "AWS_SECRET_ACCESS_KEY": "fake"},
+    )
+    @patch("evaluation.harness.s3_upload.boto3.client")
+    @patch("evaluation.harness.s3_upload.subprocess.run")
+    def test_uploads_results_plus_metadata(
+        self, mock_run: MagicMock, mock_boto: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_run.return_value = MagicMock(stdout="abc1234", returncode=0)
+
+        json_file = tmp_path / "results.json"
+        json_file.write_text('{"test": true}')
+
+        mock_s3 = MagicMock()
+        mock_boto.return_value = mock_s3
+
+        keys = upload_results_with_metadata(
+            tmp_path, "evaluation/manual/testuser/", "manual", "testuser"
+        )
+
+        assert len(keys) == 2
+        assert any("metadata.json" in k for k in keys)
+        assert any("results.json" in k for k in keys)


### PR DESCRIPTION
## ¿Qué hace este PR?

Este PR implementa la funcionalidad de subir los resultados del harness de evaluación a S3 de forma automática. Permite centralizar y persistir los resultados tanto en ejecuciones de CI como locales, solucionando el problema de pérdida de históricos por la expiración de artefactos de GitHub (30 días).

## Issues relacionados

Closes #95

## Tipo de cambio

- [x] 🆕 Nueva funcionalidad (feature)
- [ ] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [x] 🧪 Tests
- [x] 📄 Documentación / configuración
- [x] 🔧 Infra / CI

## Checklist antes de pedir review

- [x] El código corre localmente sin errores
- [x] Los criterios de aceptación del issue relacionado están cumplidos
- [x] No hay credenciales, API keys ni rutas absolutas hardcodeadas
- [x] Si agregué dependencias nuevas, actualicé requirements.txt
- [ ] Si modifiqué el schema del endpoint, verifiqué que /docs refleja los cambios
- [ ] Si modifiqué el harness o el dataset, corrí python evaluation/harness.py y el output es el esperado

## Cómo probar este PR

1. Configurar credenciales AWS en `.env`:
   ```
   AWS_ACCESS_KEY_ID=your_key
   AWS_SECRET_ACCESS_KEY=your_secret
   ```
2. Ejecutar el harness: `python -m evaluation.harness.run`
3. Verificar que los archivos aparecen en `s3://arte-chatbot-data/evaluation/manual/{username}/{timestamp}/`

## Notas para el reviewer

- El upload a S3 es opcional (controlado via `EVAL_S3_UPLOAD_ENABLED=false` para deshabilitar)
- El fallo en el upload no interrumpe la ejecución del harness
- En CI se usa `EVAL_S3_PREFIX` para override del prefijo con la estructura `evaluation/ci/{branch}/{run_id}/`