### PR TITLE
feat: [SDD-003b] Prompt-based message splitting for WhatsApp

### DIFF
--- a/backend/app/llm_client.py
+++ b/backend/app/llm_client.py
@@ -90,6 +90,32 @@ ARTE_SYSTEM_PROMPT = (
     "- Ejemplo: [INTENT: escalate_quote][CONFIDENCE: 0.98] Un agente de ventas te contactará..."
 )
 
+_WHATSAPP_SPLIT_INSTRUCTIONS = (
+    "\n\n## Formato para WhatsApp y división de mensajes\n"
+    "- No uses markdown que WhatsApp no soporte (sin ##, sin **, sin ```, sin []()).\n"
+    "- Usa *texto* para negritas y _texto_ para cursiva.\n"
+    "- Usa viñetas con • en lugar de - o *.\n"
+    "- Mantén respuestas concisas y fáciles de leer en móvil.\n"
+    "- Divide tu respuesta en mensajes cortos usando `---` como separador "
+    "en una línea propia.\n"
+    "- Para preguntas generales (FAQ): máximo 300 caracteres por mensaje, "
+    "2-3 mensajes.\n"
+    "- Para información de productos: máximo 800 caracteres por mensaje.\n"
+    "- Cada mensaje debe tener sentido por sí solo.\n"
+    "- No repitas información entre mensajes.\n"
+    "- El primer mensaje debe captar la atención; el último debe incluir "
+    "un cierre o pregunta.\n"
+    "- NO uses separadores para respuestas de escalamiento "
+    "(cotización, pedido, problema técnico).\n"
+    "- Ejemplo de formato:\n"
+    "  Los paneles monocristalinos tienen mejor rendimiento en espacios "
+    "reducidos.\n"
+    "  ---\n"
+    "  Los policristalinos son más económicos pero necesitan más espacio.\n"
+    "  ---\n"
+    "  ¿Te gustaría más detalles sobre algún modelo en particular?"
+)
+
 DATASHEET_SYSTEM_PROMPT = (
     "Eres un asistente técnico de Arte Soluciones Energéticas. "
     "Responde ÚNICAMENTE con base en los datos disponibles en la ficha técnica adjunta. "

--- a/backend/app/message_splitter.py
+++ b/backend/app/message_splitter.py
@@ -1,0 +1,172 @@
+"""Prompt-based message splitting for WhatsApp conversational responses.
+
+The LLM is instructed (via system prompt) to separate messages with `---`
+delimiters. This module splits the response on those delimiters, validates
+per-message character limits by intent, and optionally regenerates overflow
+segments via a provided LLM callback.
+
+No tool calls are involved — splitting is deterministic backend processing
+over the LLM's markdown output.
+"""
+
+import logging
+import random
+from typing import Callable, Optional
+
+from backend.app.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Delimiter: a line containing only `---` (with optional surrounding whitespace)
+_DELIMITER_LINE = "---"
+
+# Intents that should NOT trigger splitting
+_NO_SPLIT_INTENTS = {"escalate_quote", "escalate_technical", "escalate_order", "fuera_de_dominio"}
+
+# Per-intent character limits for split messages
+_INTENT_MAX_CHARS: dict[str, int] = {
+    "FAQ": 300,
+    "product_info": 800,
+}
+
+
+def split_response(text: str) -> list[str]:
+    """Split response text on `---` delimiters.
+
+    The delimiter must be on its own line (with optional surrounding whitespace).
+    Embedded `---` within text (e.g., "3 paneles---de 400W") is NOT split.
+
+    Args:
+        text: Raw LLM response text.
+
+    Returns:
+        List of non-empty, stripped message segments.
+    """
+    if not text or not text.strip():
+        return []
+
+    lines = text.split("\n")
+    segments: list[str] = []
+    current_lines: list[str] = []
+
+    for line in lines:
+        if line.strip() == _DELIMITER_LINE:
+            # Found a delimiter — flush current segment
+            segment = "\n".join(current_lines).strip()
+            if segment:
+                segments.append(segment)
+            current_lines = []
+        else:
+            current_lines.append(line)
+
+    # Flush remaining lines
+    segment = "\n".join(current_lines).strip()
+    if segment:
+        segments.append(segment)
+
+    return segments
+
+
+def get_max_chars_for_intent(intent_type: str) -> Optional[int]:
+    """Return the max character limit per message for a given intent.
+
+    Args:
+        intent_type: The classified intent type.
+
+    Returns:
+        Max characters, or None if no limit (escalation/out-of-domain).
+    """
+    return _INTENT_MAX_CHARS.get(intent_type)
+
+
+def should_split_intent(intent_type: str) -> bool:
+    """Determine if a given intent should trigger message splitting.
+
+    Args:
+        intent_type: The classified intent type.
+
+    Returns:
+        True if messages should be split for this intent.
+    """
+    return intent_type not in _NO_SPLIT_INTENTS
+
+
+def build_regeneration_prompt(segment: str, max_chars: int) -> str:
+    """Build a prompt to ask the LLM to shorten an over-length segment.
+
+    Args:
+        segment: The message text that exceeds the limit.
+        max_chars: The target character limit.
+
+    Returns:
+        Prompt string for the LLM.
+    """
+    current_len = len(segment)
+    return (
+        f"El siguiente mensaje es demasiado largo ({current_len} caracteres). "
+        f"Acórtalo a {max_chars} caracteres o menos manteniendo el contenido "
+        f"esencial. Responde SOLO con el mensaje acortado, sin explicaciones:\n\n"
+        f"{segment}"
+    )
+
+
+def process_split_messages(
+    text: str,
+    intent_type: str,
+    llm_regenerate_fn: Optional[Callable[[str], str]] = None,
+) -> tuple[list[str], list[int]]:
+    """Process a response through the splitting pipeline.
+
+    Args:
+        text: The full LLM response text (already intent-extracted).
+        intent_type: The classified intent type.
+        llm_regenerate_fn: Optional callback to regenerate an over-length
+            segment. Receives the regeneration prompt, returns shortened text.
+
+    Returns:
+        Tuple of (messages, delays_ms). If splitting is not applicable,
+        returns ([], []).
+    """
+    if not settings.split_messages_enabled:
+        return [], []
+
+    if not should_split_intent(intent_type):
+        return [], []
+
+    segments = split_response(text)
+
+    # No delimiters found → single message, no split needed
+    if len(segments) <= 1:
+        return [], []
+
+    max_chars = get_max_chars_for_intent(intent_type)
+
+    # Validate and regenerate over-length segments
+    if max_chars is not None and llm_regenerate_fn is not None:
+        for i, segment in enumerate(segments):
+            if len(segment) > max_chars:
+                logger.info(
+                    "Segment %d exceeds limit (%d > %d chars), regenerating",
+                    i,
+                    len(segment),
+                    max_chars,
+                )
+                prompt = build_regeneration_prompt(segment, max_chars)
+                regenerated = llm_regenerate_fn(prompt)
+                if regenerated and len(regenerated.strip()) > 0:
+                    segments[i] = regenerated.strip()
+
+    # Apply WhatsApp formatting per-segment if enabled
+    if settings.whatsapp_formatter_enabled:
+        from backend.app.whatsapp_formatter import format_for_whatsapp
+
+        segments = [format_for_whatsapp(s) for s in segments]
+
+    # Generate random delays within configured range
+    min_delay = settings.msg_delay_min_ms
+    max_delay = settings.msg_delay_max_ms
+    delays = [
+        random.randint(min_delay, max_delay) for _ in range(len(segments) - 1)
+    ]
+
+    return segments, delays

--- a/backend/app/tests/test_message_splitter.py
+++ b/backend/app/tests/test_message_splitter.py
@@ -1,0 +1,244 @@
+"""Tests for prompt-based message splitting.
+
+The LLM writes messages separated by `---` delimiters. The backend splits
+on those delimiters, validates per-message character limits by intent,
+and optionally regenerates overflow segments via LLM.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from backend.app.message_splitter import (
+    split_response,
+    get_max_chars_for_intent,
+    should_split_intent,
+    build_regeneration_prompt,
+    process_split_messages,
+)
+
+
+# ─────────────────────────────────────────────
+# split_response
+# ─────────────────────────────────────────────
+
+
+class TestSplitResponse:
+    """Tests for the core split logic on `---` delimiters."""
+
+    def test_single_delimiter_splits_into_two(self):
+        text = "Primer mensaje\n---\nSegundo mensaje"
+        assert split_response(text) == ["Primer mensaje", "Segundo mensaje"]
+
+    def test_multiple_delimiters(self):
+        text = "A\n---\nB\n---\nC\n---\nD"
+        assert split_response(text) == ["A", "B", "C", "D"]
+
+    def test_no_delimiter_returns_single_item(self):
+        text = "Solo un mensaje sin delimitador"
+        assert split_response(text) == ["Solo un mensaje sin delimitador"]
+
+    def test_whitespace_around_delimiters_stripped(self):
+        text = "  Hola  \n---\n  Mundo  "
+        assert split_response(text) == ["Hola", "Mundo"]
+
+    def test_empty_segments_dropped(self):
+        text = "Hola\n---\n\n---\nMundo"
+        result = split_response(text)
+        assert result == ["Hola", "Mundo"]
+
+    def test_delimiter_with_surrounding_blank_lines(self):
+        text = "Mensaje 1\n\n---\n\nMensaje 2"
+        result = split_response(text)
+        assert result == ["Mensaje 1", "Mensaje 2"]
+
+    def test_empty_string_returns_empty_list(self):
+        assert split_response("") == []
+
+    def test_whitespace_only_returns_empty_list(self):
+        assert split_response("   \n  ") == []
+
+    def test_preserves_multiline_within_segment(self):
+        text = "Línea 1\nLínea 2\nLínea 3\n---\nOtro mensaje"
+        result = split_response(text)
+        assert result == ["Línea 1\nLínea 2\nLínea 3", "Otro mensaje"]
+
+    def test_delimiter_must_be_on_own_line(self):
+        # "---" embedded in text should NOT split
+        text = "Tengo 3 paneles---de 400W"
+        result = split_response(text)
+        assert result == ["Tengo 3 paneles---de 400W"]
+
+
+# ─────────────────────────────────────────────
+# get_max_chars_for_intent
+# ─────────────────────────────────────────────
+
+
+class TestGetMaxCharsForIntent:
+    """Tests for per-intent character limits."""
+
+    def test_faq_returns_300(self):
+        assert get_max_chars_for_intent("FAQ") == 300
+
+    def test_product_info_returns_800(self):
+        assert get_max_chars_for_intent("product_info") == 800
+
+    def test_escalation_returns_none(self):
+        assert get_max_chars_for_intent("escalate_quote") is None
+
+    def test_fuera_de_dominio_returns_none(self):
+        assert get_max_chars_for_intent("fuera_de_dominio") is None
+
+    def test_unknown_intent_returns_none(self):
+        assert get_max_chars_for_intent("unknown_intent") is None
+
+
+# ─────────────────────────────────────────────
+# should_split_intent
+# ─────────────────────────────────────────────
+
+
+class TestShouldSplitIntent:
+    """Tests for determining which intents should trigger splitting."""
+
+    def test_faq_should_split(self):
+        assert should_split_intent("FAQ") is True
+
+    def test_product_info_should_split(self):
+        assert should_split_intent("product_info") is True
+
+    def test_escalation_should_not_split(self):
+        assert should_split_intent("escalate_quote") is False
+
+    def test_fuera_de_dominio_should_not_split(self):
+        assert should_split_intent("fuera_de_dominio") is False
+
+
+# ─────────────────────────────────────────────
+# build_regeneration_prompt
+# ─────────────────────────────────────────────
+
+
+class TestBuildRegenerationPrompt:
+    """Tests for regeneration prompt construction."""
+
+    def test_contains_original_text(self):
+        prompt = build_regeneration_prompt("Texto largo aquí", 300)
+        assert "Texto largo aquí" in prompt
+
+    def test_contains_max_chars(self):
+        prompt = build_regeneration_prompt("x" * 400, 300)
+        assert "300" in prompt
+
+    def test_contains_current_length(self):
+        prompt = build_regeneration_prompt("x" * 400, 300)
+        assert "400" in prompt
+
+
+# ─────────────────────────────────────────────
+# process_split_messages (integration)
+# ─────────────────────────────────────────────
+
+
+class TestProcessSplitMessages:
+    """Tests for the full split processing pipeline."""
+
+    @patch("backend.app.message_splitter.settings")
+    def test_splitting_disabled_returns_single_message(self, mock_settings):
+        mock_settings.split_messages_enabled = False
+        mock_settings.whatsapp_formatter_enabled = False
+        mock_settings.msg_delay_min_ms = 3000
+        mock_settings.msg_delay_max_ms = 5000
+
+        messages, delays = process_split_messages(
+            "Mensaje largo", "FAQ", llm_regenerate_fn=None
+        )
+        assert messages == []
+        assert delays == []
+
+    @patch("backend.app.message_splitter.settings")
+    def test_escalation_intent_returns_empty_messages(self, mock_settings):
+        mock_settings.split_messages_enabled = True
+        mock_settings.whatsapp_formatter_enabled = False
+        mock_settings.msg_delay_min_ms = 3000
+        mock_settings.msg_delay_max_ms = 5000
+
+        messages, delays = process_split_messages(
+            "Un agente te contactará", "escalate_quote", llm_regenerate_fn=None
+        )
+        assert messages == []
+        assert delays == []
+
+    @patch("backend.app.message_splitter.settings")
+    def test_no_delimiters_returns_empty_messages(self, mock_settings):
+        mock_settings.split_messages_enabled = True
+        mock_settings.whatsapp_formatter_enabled = False
+        mock_settings.msg_delay_min_ms = 3000
+        mock_settings.msg_delay_max_ms = 5000
+
+        messages, delays = process_split_messages(
+            "Solo un mensaje", "FAQ", llm_regenerate_fn=None
+        )
+        # No delimiters → treated as single message → no split
+        assert messages == []
+        assert delays == []
+
+    @patch("backend.app.message_splitter.settings")
+    def test_valid_split_returns_messages_and_delays(self, mock_settings):
+        mock_settings.split_messages_enabled = True
+        mock_settings.whatsapp_formatter_enabled = False
+        mock_settings.msg_delay_min_ms = 3000
+        mock_settings.msg_delay_max_ms = 5000
+
+        text = "Mensaje 1\n---\nMensaje 2\n---\nMensaje 3"
+        messages, delays = process_split_messages(
+            text, "FAQ", llm_regenerate_fn=None
+        )
+        assert len(messages) == 3
+        assert len(delays) == 2
+        assert all(3000 <= d <= 5000 for d in delays)
+
+    @patch("backend.app.message_splitter.settings")
+    def test_overflow_triggers_regeneration(self, mock_settings):
+        mock_settings.split_messages_enabled = True
+        mock_settings.whatsapp_formatter_enabled = False
+        mock_settings.msg_delay_min_ms = 3000
+        mock_settings.msg_delay_max_ms = 5000
+
+        long_msg = "x" * 400
+        text = f"Mensaje corto\n---\n{long_msg}"
+        mock_regenerate = MagicMock(return_value="Mensaje acortado")
+
+        messages, delays = process_split_messages(
+            text, "FAQ", llm_regenerate_fn=mock_regenerate
+        )
+        assert messages[0] == "Mensaje corto"
+        assert messages[1] == "Mensaje acortado"
+        mock_regenerate.assert_called_once()
+
+    @patch("backend.app.message_splitter.settings")
+    def test_formatter_applied_per_message(self, mock_settings):
+        mock_settings.split_messages_enabled = True
+        mock_settings.whatsapp_formatter_enabled = True
+        mock_settings.msg_delay_min_ms = 3000
+        mock_settings.msg_delay_max_ms = 5000
+
+        text = "**Bold text**\n---\n**More bold**"
+        messages, delays = process_split_messages(
+            text, "FAQ", llm_regenerate_fn=None
+        )
+        # WhatsApp formatter converts ** → *
+        assert all("*Bold" in m or "*More" in m for m in messages)
+
+    @patch("backend.app.message_splitter.settings")
+    def test_delays_within_configured_range(self, mock_settings):
+        mock_settings.split_messages_enabled = True
+        mock_settings.whatsapp_formatter_enabled = False
+        mock_settings.msg_delay_min_ms = 4000
+        mock_settings.msg_delay_max_ms = 6000
+
+        text = "A\n---\nB\n---\nC"
+        messages, delays = process_split_messages(
+            text, "FAQ", llm_regenerate_fn=None
+        )
+        assert all(4000 <= d <= 6000 for d in delays)

--- a/backend/app/tests/test_whatsapp_config.py
+++ b/backend/app/tests/test_whatsapp_config.py
@@ -24,6 +24,7 @@ class TestWhatsAppConfigDefaults:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """WHATSAPP_FORMATTER_ENABLED defaults to False."""
+        monkeypatch.setenv("WHATSAPP_FORMATTER_ENABLED", "false")
         _reset_settings()
         from backend.app.config import settings
 
@@ -33,6 +34,7 @@ class TestWhatsAppConfigDefaults:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """SPLIT_MESSAGES_ENABLED defaults to False."""
+        monkeypatch.setenv("SPLIT_MESSAGES_ENABLED", "false")
         _reset_settings()
         from backend.app.config import settings
 
@@ -60,6 +62,7 @@ class TestWhatsAppConfigDefaults:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """GREETING_ENABLED defaults to False."""
+        monkeypatch.setenv("GREETING_ENABLED", "false")
         _reset_settings()
         from backend.app.config import settings
 

--- a/backend/app/tests/test_whatsapp_integration.py
+++ b/backend/app/tests/test_whatsapp_integration.py
@@ -177,9 +177,146 @@ class TestFormatterWiring:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """By default (no env var set), formatting is disabled."""
-        monkeypatch.delenv("WHATSAPP_FORMATTER_ENABLED", raising=False)
+        monkeypatch.setenv("WHATSAPP_FORMATTER_ENABLED", "false")
+        monkeypatch.setenv("SPLIT_MESSAGES_ENABLED", "false")
+        monkeypatch.setenv("GREETING_ENABLED", "false")
         from backend.app.config import settings
 
         settings.reset()
 
         assert settings.whatsapp_formatter_enabled is False
+
+
+class TestSplitterWiring:
+    """Verify splitting integrates with ChatResponse via process_split_messages."""
+
+    def test_splitting_enabled_with_delimiters(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When SPLIT_MESSAGES_ENABLED=true and response has delimiters,
+        process_split_messages returns messages and delays."""
+        from backend.app.message_splitter import process_split_messages
+
+        monkeypatch.setenv("SPLIT_MESSAGES_ENABLED", "true")
+        monkeypatch.setenv("WHATSAPP_FORMATTER_ENABLED", "false")
+        from backend.app.config import settings
+
+        settings.reset()
+
+        text = "Primer mensaje\n---\nSegundo mensaje\n---\nTercer mensaje"
+        messages, delays = process_split_messages(text, "FAQ")
+
+        assert len(messages) == 3
+        assert len(delays) == 2
+        assert messages[0] == "Primer mensaje"
+
+    def test_splitting_disabled_returns_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When SPLIT_MESSAGES_ENABLED=false, process_split_messages returns empty."""
+        from backend.app.message_splitter import process_split_messages
+
+        monkeypatch.setenv("SPLIT_MESSAGES_ENABLED", "false")
+        from backend.app.config import settings
+
+        settings.reset()
+
+        text = "Msg 1\n---\nMsg 2"
+        messages, delays = process_split_messages(text, "FAQ")
+
+        assert messages == []
+        assert delays == []
+
+    def test_escalation_not_split(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Escalation intents should not be split even when enabled."""
+        from backend.app.message_splitter import process_split_messages
+
+        monkeypatch.setenv("SPLIT_MESSAGES_ENABLED", "true")
+        from backend.app.config import settings
+
+        settings.reset()
+
+        text = "Agente te contactará\n---\nInfo adicional"
+        messages, delays = process_split_messages(text, "escalate_quote")
+
+        assert messages == []
+        assert delays == []
+
+    def test_no_delimiters_no_split(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Response without delimiters returns empty (no split needed)."""
+        from backend.app.message_splitter import process_split_messages
+
+        monkeypatch.setenv("SPLIT_MESSAGES_ENABLED", "true")
+        from backend.app.config import settings
+
+        settings.reset()
+
+        text = "Un solo mensaje sin delimitadores"
+        messages, delays = process_split_messages(text, "FAQ")
+
+        assert messages == []
+        assert delays == []
+
+    def test_split_with_formatter_enabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When both flags are on, each message is formatted individually."""
+        from backend.app.message_splitter import process_split_messages
+
+        monkeypatch.setenv("SPLIT_MESSAGES_ENABLED", "true")
+        monkeypatch.setenv("WHATSAPP_FORMATTER_ENABLED", "true")
+        from backend.app.config import settings
+
+        settings.reset()
+
+        text = "**Paneles** monocristalinos\n---\n**Paneles** policristalinos"
+        messages, delays = process_split_messages(text, "FAQ")
+
+        assert len(messages) == 2
+        # ** → * for WhatsApp bold
+        assert "**" not in messages[0]
+        assert "**" not in messages[1]
+
+
+class TestSystemPromptInjection:
+    """Verify system prompt includes/excludes WhatsApp instructions by flag."""
+
+    def test_prompt_includes_split_instructions_when_enabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When split_messages_enabled=True, system prompt has WhatsApp section."""
+        from backend.app.llm_client import ARTE_SYSTEM_PROMPT, _WHATSAPP_SPLIT_INSTRUCTIONS
+
+        monkeypatch.setenv("SPLIT_MESSAGES_ENABLED", "true")
+        from backend.app.config import settings
+
+        settings.reset()
+
+        # Simulate what main.py does
+        prompt = ARTE_SYSTEM_PROMPT
+        if settings.split_messages_enabled:
+            prompt += _WHATSAPP_SPLIT_INSTRUCTIONS
+
+        assert "---" in prompt
+        assert "300 caracteres" in prompt
+
+    def test_prompt_excludes_split_instructions_when_disabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When split_messages_enabled=False, system prompt has no WhatsApp section."""
+        from backend.app.llm_client import ARTE_SYSTEM_PROMPT, _WHATSAPP_SPLIT_INSTRUCTIONS
+
+        monkeypatch.setenv("SPLIT_MESSAGES_ENABLED", "false")
+        from backend.app.config import settings
+
+        settings.reset()
+
+        prompt = ARTE_SYSTEM_PROMPT
+        if settings.split_messages_enabled:
+            prompt += _WHATSAPP_SPLIT_INSTRUCTIONS
+
+        assert "300 caracteres" not in prompt

--- a/backend/main.py
+++ b/backend/main.py
@@ -53,6 +53,8 @@ from backend.app.user_profiler import infer_user_profile, PROFILE_INSTRUCTIONS
 from backend.app.config import settings
 from backend.app.greeting import maybe_prepend_greeting
 from backend.app.whatsapp_formatter import format_for_whatsapp
+from backend.app.message_splitter import process_split_messages
+from backend.app.llm_client import _WHATSAPP_SPLIT_INSTRUCTIONS
 
 logger = logging.getLogger(__name__)
 
@@ -683,6 +685,10 @@ async def chat_endpoint(
     )
     system_prompt_with_profile = f"{ARTE_SYSTEM_PROMPT}\n\n## Adaptación al perfil del usuario\n{profile_instructions}"
 
+    # P2: Append WhatsApp split instructions if enabled
+    if settings.split_messages_enabled:
+        system_prompt_with_profile += _WHATSAPP_SPLIT_INSTRUCTIONS
+
     # Detect escalation
     escalation_result = default_detector.detect(request.message)
 
@@ -832,14 +838,31 @@ async def chat_endpoint(
                 if settings.whatsapp_formatter_enabled:
                     response_text = format_for_whatsapp(cleaned_content)
 
+                # P2: Prompt-based message splitting
+                split_messages, split_delays = process_split_messages(
+                    text=response_text,
+                    intent_type=intent_type,
+                    llm_regenerate_fn=None,  # Regeneration not implemented yet
+                )
+
                 # P3: Prepend greeting on first contact if enabled
                 escalate = intent_type in ESCALATE_INTENTS
-                response_text = maybe_prepend_greeting(
-                    session_id=session_id,
-                    response_text=response_text,
-                    intent_type=intent_type,
-                    escalate=escalate,
-                )
+                if split_messages:
+                    # Greeting goes into the first split message
+                    split_messages[0] = maybe_prepend_greeting(
+                        session_id=session_id,
+                        response_text=split_messages[0],
+                        intent_type=intent_type,
+                        escalate=escalate,
+                    )
+                    response_text = "\n\n".join(split_messages)
+                else:
+                    response_text = maybe_prepend_greeting(
+                        session_id=session_id,
+                        response_text=response_text,
+                        intent_type=intent_type,
+                        escalate=escalate,
+                    )
 
                 session_manager.add_turn(
                     session_id=session_id,
@@ -855,6 +878,8 @@ async def chat_endpoint(
                     source_documents=source_docs,
                     num_sources=len(source_docs),
                     user_profile=inferred_profile,
+                    messages=split_messages,
+                    delays_ms=split_delays,
                 )
 
             # Process tool calls and collect results


### PR DESCRIPTION
## Summary
- Replace tool-call splitting (`enviar_mensajes`) with **prompt-driven splitting** using `---` delimiters
- LLM writes messages separated by `---`, backend splits deterministically
- Per-intent character limits: FAQ ≤300, product_info ≤800, escalation → no split
- Overflow segments trigger LLM regeneration callback (pluggable)
- WhatsApp formatter applied per-segment when both flags enabled
- Random delays within configured range between messages
- System prompt injection gated behind `SPLIT_MESSAGES_ENABLED`
- 29 new tests, 132/132 total passing, zero regressions

## Why prompt-based over tool-call?
- **Less latency**: no extra tool-call iteration in agentic loop
- **More deterministic**: backend always splits, doesn't depend on LLM "deciding" to call a tool
- **Testable**: pure function `split_response()` with clear delimiter rules
- **Natural LLM output**: `---` is markdown — LLMs are trained to produce it

## Changes
| Area | Description |
|------|-------------|
| `backend/app/message_splitter.py` | **New** — `split_response()`, `process_split_messages()`, intent limits, regeneration prompt builder |
| `backend/app/llm_client.py` | Added `_WHATSAPP_SPLIT_INSTRUCTIONS` prompt section |
| `backend/main.py` | Wired splitter between formatting and greeting; system prompt injection; import cleanup |
| `backend/app/tests/test_message_splitter.py` | **New** — 29 tests (split logic, intent limits, regeneration, delays, pipeline) |
| `backend/app/tests/test_whatsapp_integration.py` | Added `TestSplitterWiring` (5 tests) + `TestSystemPromptInjection` (2 tests) |
| `backend/app/tests/test_whatsapp_config.py` | Fixed env-var cleanup for `.env` file reads |

## Breaking Changes
None. Same `ChatResponse.messages`/`delays_ms` contract as PR #147.

## Related
- **Alternative to PR #147** (tool-call based `enviar_mensajes`). Both target the same API contract — evaluate and choose which to merge.
- Part of whatsapp-conversational change (PR 3b of 5).