### PR TITLE
feat: [SDD-004] Add multi-message input buffer for WhatsApp

### DIFF
--- a/backend/app/message_buffer.py
+++ b/backend/app/message_buffer.py
@@ -1,0 +1,137 @@
+"""Multi-message input buffer with debounce.
+
+Accumulates incoming messages per session during a configurable window,
+then flushes them as a single joined message. Used to handle WhatsApp
+users who send multiple short messages in rapid succession.
+
+Design: module-level dicts for buffer state (NOT in SessionManager).
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+# Buffer state per session: session_id -> list of (message, timestamp)
+_buffer: dict[str, list[tuple[str, datetime]]] = {}
+
+# Active debounce tasks per session
+_buffer_tasks: dict[str, asyncio.Task] = {}  # type: ignore[type-arg]
+
+
+async def add_to_buffer(
+    session_id: str, message: str, max_messages: int = 5
+) -> Optional[str]:
+    """Append message to session buffer.
+
+    Args:
+        session_id: The session identifier.
+        message: The message text to buffer.
+        max_messages: Maximum messages before overflow flush. Default 5.
+
+    Returns:
+        Joined text if overflow triggered, None if still buffering.
+    """
+    if session_id not in _buffer:
+        _buffer[session_id] = []
+    _buffer[session_id].append((message, datetime.now(timezone.utc)))
+
+    if len(_buffer[session_id]) >= max_messages:
+        # Overflow: flush immediately
+        logger.info(
+            "Buffer overflow for session %s: %d messages, flushing",
+            session_id,
+            len(_buffer[session_id]),
+        )
+        return await flush_buffer(session_id)
+    return None
+
+
+async def flush_buffer(session_id: str) -> Optional[str]:
+    """Flush buffer and return joined message. None if empty.
+
+    Args:
+        session_id: The session identifier.
+
+    Returns:
+        Messages joined with newline separator, or None if buffer empty.
+    """
+    messages = _buffer.pop(session_id, [])
+    task = _buffer_tasks.pop(session_id, None)
+    if task and not task.done():
+        task.cancel()
+    if not messages:
+        return None
+    return "\n".join(msg for msg, _ in messages)
+
+
+def is_buffering(session_id: str) -> bool:
+    """Check if session has buffered messages.
+
+    Args:
+        session_id: The session identifier.
+
+    Returns:
+        True if buffer has entries, False otherwise.
+    """
+    return session_id in _buffer and len(_buffer[session_id]) > 0
+
+
+def get_buffer_count(session_id: str) -> int:
+    """Get number of buffered messages for a session.
+
+    Args:
+        session_id: The session identifier.
+
+    Returns:
+        Number of buffered messages.
+    """
+    return len(_buffer.get(session_id, []))
+
+
+def clear_buffer(session_id: str) -> None:
+    """Clear buffer state for a session.
+
+    Cancels any active debounce task for the session.
+
+    Args:
+        session_id: The session identifier.
+    """
+    _buffer.pop(session_id, None)
+    task = _buffer_tasks.pop(session_id, None)
+    if task and not task.done():
+        task.cancel()
+
+
+FlushCallback = Callable[[str, str], Awaitable[None]]
+
+
+def schedule_flush(
+    session_id: str,
+    window_seconds: int,
+    callback: FlushCallback,
+) -> None:
+    """Schedule a flush after window_seconds. Cancels previous task.
+
+    Args:
+        session_id: The session identifier.
+        window_seconds: Seconds to wait before flushing.
+        callback: Async function called with (session_id, joined_message)
+                  when the window expires.
+    """
+    existing = _buffer_tasks.get(session_id)
+    if existing and not existing.done():
+        existing.cancel()
+
+    async def _flush_after_delay() -> None:
+        try:
+            await asyncio.sleep(window_seconds)
+        except asyncio.CancelledError:
+            return
+        message = await flush_buffer(session_id)
+        if message:
+            await callback(session_id, message)
+
+    _buffer_tasks[session_id] = asyncio.create_task(_flush_after_delay())

--- a/backend/app/tests/test_message_buffer.py
+++ b/backend/app/tests/test_message_buffer.py
@@ -1,0 +1,565 @@
+"""Unit tests for multi-message input buffer (P4).
+
+Tests buffer accumulation, flush, overflow, is_final hint,
+and debounce scheduling for the WhatsApp multi-message buffer feature.
+
+Strict TDD: tests written BEFORE implementation.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Imports — will fail until implementation exists
+# ---------------------------------------------------------------------------
+try:
+    from backend.app.message_buffer import (
+        add_to_buffer,
+        clear_buffer,
+        flush_buffer,
+        get_buffer_count,
+        is_buffering,
+        schedule_flush,
+    )
+except ImportError:
+    add_to_buffer = None  # type: ignore[assignment]
+    flush_buffer = None  # type: ignore[assignment]
+    is_buffering = None  # type: ignore[assignment]
+    get_buffer_count = None  # type: ignore[assignment]
+    clear_buffer = None  # type: ignore[assignment]
+    schedule_flush = None  # type: ignore[assignment]
+
+
+@pytest.fixture(autouse=True)
+def _require_message_buffer() -> None:
+    """Skip all tests in this module if message_buffer not yet implemented."""
+    if add_to_buffer is None:
+        pytest.skip("backend.app.message_buffer not yet implemented")
+
+
+@pytest.fixture(autouse=True)
+def _clean_buffer_state() -> None:
+    """Ensure clean buffer state between tests."""
+    try:
+        from backend.app import message_buffer
+
+        message_buffer._buffer.clear()
+        message_buffer._buffer_tasks.clear()
+    except ImportError:
+        pass
+    yield
+    try:
+        from backend.app import message_buffer
+
+        message_buffer._buffer.clear()
+        message_buffer._buffer_tasks.clear()
+    except ImportError:
+        pass
+
+
+# ===========================================================================
+# Task 5.1 — Core buffer operations
+# ===========================================================================
+
+
+class TestAddToBuffer:
+    """Test add_to_buffer accumulates messages per session."""
+
+    @pytest.mark.asyncio
+    async def test_add_single_message(self) -> None:
+        """Adding one message stores it in the buffer."""
+        await add_to_buffer("s1", "Hola")
+        assert is_buffering("s1") is True
+        assert get_buffer_count("s1") == 1
+
+    @pytest.mark.asyncio
+    async def test_add_multiple_messages(self) -> None:
+        """Adding multiple messages accumulates them in order."""
+        await add_to_buffer("s1", "Hola")
+        await add_to_buffer("s1", "quisiera info")
+        await add_to_buffer("s1", "sobre paneles")
+        assert get_buffer_count("s1") == 3
+
+    @pytest.mark.asyncio
+    async def test_different_sessions_independent(self) -> None:
+        """Buffers for different sessions are independent."""
+        await add_to_buffer("s1", "Hola")
+        await add_to_buffer("s2", "Buenos días")
+        assert get_buffer_count("s1") == 1
+        assert get_buffer_count("s2") == 1
+
+    @pytest.mark.asyncio
+    async def test_add_to_buffer_returns_none_below_max(self) -> None:
+        """add_to_buffer returns None when below max_messages threshold."""
+        result = await add_to_buffer("s1", "Hola", max_messages=5)
+        assert result is None
+
+
+# ===========================================================================
+# Task 5.1 — Flush buffer
+# ===========================================================================
+
+
+class TestFlushBuffer:
+    """Test flush_buffer joins and clears."""
+
+    @pytest.mark.asyncio
+    async def test_flush_joins_with_newline(self) -> None:
+        """Flush returns messages joined with newline separator."""
+        await add_to_buffer("s1", "Hola")
+        await add_to_buffer("s1", "quisiera info")
+        await add_to_buffer("s1", "sobre paneles")
+        result = await flush_buffer("s1")
+        assert result == "Hola\nquisiera info\nsobre paneles"
+
+    @pytest.mark.asyncio
+    async def test_flush_returns_none_when_empty(self) -> None:
+        """Flush returns None when buffer has no messages."""
+        result = await flush_buffer("s1")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_flush_clears_buffer(self) -> None:
+        """After flush, buffer is empty and is_buffering returns False."""
+        await add_to_buffer("s1", "Hola")
+        await flush_buffer("s1")
+        assert is_buffering("s1") is False
+        assert get_buffer_count("s1") == 0
+
+    @pytest.mark.asyncio
+    async def test_flush_single_message(self) -> None:
+        """Flush with single message returns that message without separator."""
+        await add_to_buffer("s1", "Hola")
+        result = await flush_buffer("s1")
+        assert result == "Hola"
+
+    @pytest.mark.asyncio
+    async def test_flush_preserves_order(self) -> None:
+        """Flush preserves the original message order."""
+        await add_to_buffer("s1", "primer mensaje")
+        await add_to_buffer("s1", "segundo mensaje")
+        result = await flush_buffer("s1")
+        lines = result.split("\n")
+        assert lines[0] == "primer mensaje"
+        assert lines[1] == "segundo mensaje"
+
+
+# ===========================================================================
+# Task 5.1 — is_buffering and get_buffer_count
+# ===========================================================================
+
+
+class TestIsBuffering:
+    """Test is_buffering state checks."""
+
+    def test_not_buffering_initially(self) -> None:
+        """No buffer state initially."""
+        assert is_buffering("s1") is False
+
+    @pytest.mark.asyncio
+    async def test_buffering_after_add(self) -> None:
+        """is_buffering returns True after adding a message."""
+        await add_to_buffer("s1", "Hola")
+        assert is_buffering("s1") is True
+
+    @pytest.mark.asyncio
+    async def test_not_buffering_after_flush(self) -> None:
+        """is_buffering returns False after flush."""
+        await add_to_buffer("s1", "Hola")
+        await flush_buffer("s1")
+        assert is_buffering("s1") is False
+
+
+class TestGetBufferCount:
+    """Test get_buffer_count."""
+
+    def test_zero_initially(self) -> None:
+        """Count is 0 initially."""
+        assert get_buffer_count("s1") == 0
+
+    @pytest.mark.asyncio
+    async def test_count_increments(self) -> None:
+        """Count increments with each add."""
+        await add_to_buffer("s1", "a")
+        assert get_buffer_count("s1") == 1
+        await add_to_buffer("s1", "b")
+        assert get_buffer_count("s1") == 2
+
+    @pytest.mark.asyncio
+    async def test_count_resets_after_flush(self) -> None:
+        """Count resets to 0 after flush."""
+        await add_to_buffer("s1", "a")
+        await add_to_buffer("s1", "b")
+        await flush_buffer("s1")
+        assert get_buffer_count("s1") == 0
+
+
+# ===========================================================================
+# Task 5.1 — clear_buffer
+# ===========================================================================
+
+
+class TestClearBuffer:
+    """Test clear_buffer resets state."""
+
+    @pytest.mark.asyncio
+    async def test_clear_removes_messages(self) -> None:
+        """clear_buffer removes all buffered messages."""
+        await add_to_buffer("s1", "Hola")
+        await add_to_buffer("s1", "mundo")
+        clear_buffer("s1")
+        assert is_buffering("s1") is False
+        assert get_buffer_count("s1") == 0
+
+    @pytest.mark.asyncio
+    async def test_clear_idempotent(self) -> None:
+        """clear_buffer on empty buffer is safe."""
+        clear_buffer("s1")
+        assert is_buffering("s1") is False
+
+
+# ===========================================================================
+# Task 5.3 — Debounce: schedule_flush
+# ===========================================================================
+
+
+class TestDebounce:
+    """Test schedule_flush timer behavior."""
+
+    @pytest.mark.asyncio
+    async def test_schedule_flush_fires_callback(self) -> None:
+        """After window_seconds, callback is invoked with joined message."""
+        results: list[tuple[str, str]] = []
+
+        async def _on_flush(sid: str, msg: str) -> None:
+            results.append((sid, msg))
+
+        await add_to_buffer("s1", "Hola")
+        await add_to_buffer("s1", "mundo")
+        schedule_flush("s1", window_seconds=1, callback=_on_flush)
+
+        # Wait for the timer to fire
+        await asyncio.sleep(1.5)
+
+        assert len(results) == 1
+        assert results[0] == ("s1", "Hola\nmundo")
+
+    @pytest.mark.asyncio
+    async def test_schedule_flush_resets_timer(self) -> None:
+        """Each call to schedule_flush cancels the previous timer."""
+        results: list[str] = []
+
+        async def _on_flush(sid: str, msg: str) -> None:
+            results.append(msg)
+
+        await add_to_buffer("s1", "Hola")
+        schedule_flush("s1", window_seconds=1, callback=_on_flush)
+
+        # Add more messages and reschedule before first timer fires
+        await asyncio.sleep(0.3)
+        await add_to_buffer("s1", "mundo")
+        schedule_flush("s1", window_seconds=1, callback=_on_flush)
+
+        # Wait for the second timer
+        await asyncio.sleep(1.5)
+
+        # Only the second timer should have fired, with all messages
+        assert len(results) == 1
+        assert results[0] == "Hola\nmundo"
+
+    @pytest.mark.asyncio
+    async def test_schedule_flush_no_callback_when_empty(self) -> None:
+        """Callback is NOT invoked if buffer is empty when timer fires."""
+        results: list[str] = []
+
+        async def _on_flush(sid: str, msg: str) -> None:
+            results.append(msg)
+
+        # Schedule flush without adding messages — buffer is empty
+        from backend.app import message_buffer
+
+        # Manually set up a task without buffer entries
+        schedule_flush("s1", window_seconds=1, callback=_on_flush)
+
+        await asyncio.sleep(1.5)
+        assert len(results) == 0
+
+    @pytest.mark.asyncio
+    async def test_schedule_flush_clears_buffer_state(self) -> None:
+        """After timer fires and processes, buffer state is cleared."""
+        results: list[str] = []
+
+        async def _on_flush(sid: str, msg: str) -> None:
+            results.append(msg)
+
+        await add_to_buffer("s1", "test")
+        schedule_flush("s1", window_seconds=1, callback=_on_flush)
+        await asyncio.sleep(1.5)
+
+        assert is_buffering("s1") is False
+        assert get_buffer_count("s1") == 0
+
+
+# ===========================================================================
+# Task 5.5 — Overflow: max_messages triggers immediate flush
+# ===========================================================================
+
+
+class TestOverflow:
+    """Test buffer overflow behavior."""
+
+    @pytest.mark.asyncio
+    async def test_overflow_at_max_messages(self) -> None:
+        """When max_messages is reached, add_to_buffer returns joined text."""
+        # Fill buffer to 4 (below max)
+        for i in range(4):
+            result = await add_to_buffer("s1", f"msg{i}", max_messages=5)
+            assert result is None  # Still buffering
+
+        # 5th message triggers overflow
+        result = await add_to_buffer("s1", "msg4", max_messages=5)
+        assert result is not None
+        assert "msg0" in result
+        assert "msg4" in result
+        # Buffer is now empty
+        assert is_buffering("s1") is False
+
+    @pytest.mark.asyncio
+    async def test_overflow_joins_all_messages(self) -> None:
+        """Overflow returns all accumulated messages joined with newline."""
+        messages = [f"message {i}" for i in range(5)]
+        for msg in messages[:4]:
+            await add_to_buffer("s1", msg, max_messages=5)
+
+        result = await add_to_buffer("s1", messages[4], max_messages=5)
+        for msg in messages:
+            assert msg in result
+        # Check newline separation
+        assert result.count("\n") == 4
+
+    @pytest.mark.asyncio
+    async def test_overflow_with_custom_max(self) -> None:
+        """Overflow respects custom max_messages value."""
+        await add_to_buffer("s1", "a", max_messages=2)
+        result = await add_to_buffer("s1", "b", max_messages=2)
+        assert result == "a\nb"
+        assert is_buffering("s1") is False
+
+    @pytest.mark.asyncio
+    async def test_no_overflow_below_max(self) -> None:
+        """No overflow when below max_messages."""
+        for i in range(4):
+            result = await add_to_buffer("s1", f"msg{i}", max_messages=5)
+            assert result is None
+        assert is_buffering("s1") is True
+
+
+# ===========================================================================
+# Task 5.7 — Endpoint integration tests
+# ===========================================================================
+
+
+class TestEndpointBufferIntegration:
+    """Test buffer wiring in the /chat endpoint."""
+
+    def _make_client(self, monkeypatch: pytest.MonkeyPatch, enabled: bool = True):
+        """Create a TestClient with buffer settings patched.
+
+        Returns (client, app) tuple.
+        """
+        monkeypatch.setenv("MULTI_MESSAGE_BUFFER_ENABLED", str(enabled).lower())
+        monkeypatch.setenv("BUFFER_WINDOW_SECONDS", "1")
+        # Required for module-level client instantiation
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        monkeypatch.setenv("CHAT_API_KEY", "test-key")
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
+        monkeypatch.setenv("AWS_BUCKET_NAME", "test-bucket")
+        monkeypatch.setenv("GREETING_ENABLED", "false")
+        monkeypatch.setenv("SPLIT_MESSAGES_ENABLED", "false")
+        monkeypatch.setenv("WHATSAPP_FORMATTER_ENABLED", "false")
+
+        # Reset settings proxy so new env vars take effect
+        from backend.app.config import settings
+
+        settings.reset()
+
+        from fastapi.testclient import TestClient
+
+        # Import app fresh — settings proxy will read new env vars
+        from backend.main import app
+        from backend.app.auth import verify_api_key
+
+        app.dependency_overrides[verify_api_key] = lambda: "test_key"
+        client = TestClient(app)
+        return client, app
+
+    def test_buffer_returns_202_when_enabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When multi_message_buffer_enabled=True, first message returns 202."""
+        client, app = self._make_client(monkeypatch, enabled=True)
+
+        from backend.app import message_buffer
+
+        message_buffer._buffer.clear()
+        message_buffer._buffer_tasks.clear()
+
+        response = client.post(
+            "/chat",
+            json={"message": "Hola", "session_id": "test-buffer-1"},
+        )
+        assert response.status_code == 202
+        data = response.json()
+        assert data["status"] == "buffering"
+        assert data["session_id"] == "test-buffer-1"
+
+        # Cleanup
+        message_buffer._buffer.clear()
+        message_buffer._buffer_tasks.clear()
+
+    def test_buffer_returns_202_on_subsequent_messages(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Subsequent messages within window also return 202."""
+        client, app = self._make_client(monkeypatch, enabled=True)
+
+        from backend.app import message_buffer
+
+        message_buffer._buffer.clear()
+        message_buffer._buffer_tasks.clear()
+
+        # First message
+        r1 = client.post(
+            "/chat",
+            json={"message": "Hola", "session_id": "test-buffer-2"},
+        )
+        assert r1.status_code == 202
+
+        # Second message — still buffering
+        r2 = client.post(
+            "/chat",
+            json={"message": "quisiera info", "session_id": "test-buffer-2"},
+        )
+        assert r2.status_code == 202
+
+        # Cleanup
+        message_buffer._buffer.clear()
+        message_buffer._buffer_tasks.clear()
+
+    @patch("backend.main.llm_client.get_llm_response_with_tools")
+    def test_is_final_bypasses_buffer(
+        self,
+        mock_llm: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When is_final=True, message is processed immediately, not buffered."""
+        mock_llm.return_value = {
+            "output_text": "[INTENT: FAQ] Aquí tienes la información solicitada.",
+        }
+
+        client, app = self._make_client(monkeypatch, enabled=True)
+
+        from backend.app import message_buffer
+
+        message_buffer._buffer.clear()
+        message_buffer._buffer_tasks.clear()
+
+        # First message — starts buffering
+        r1 = client.post(
+            "/chat",
+            json={"message": "Hola", "session_id": "test-buffer-3"},
+        )
+        assert r1.status_code == 202
+
+        # Second message with is_final — should process
+        r2 = client.post(
+            "/chat",
+            json={
+                "message": "sobre paneles",
+                "session_id": "test-buffer-3",
+                "is_final": True,
+            },
+        )
+        assert r2.status_code == 200
+        data = r2.json()
+        # Should contain joined message (original + is_final)
+        assert "response" in data
+        assert data["session_id"] == "test-buffer-3"
+
+        # Cleanup
+        message_buffer._buffer.clear()
+        message_buffer._buffer_tasks.clear()
+        app.dependency_overrides.clear()
+
+    @patch("backend.main.llm_client.get_llm_response_with_tools")
+    def test_overflow_flushes_and_processes(
+        self,
+        mock_llm: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When buffer reaches max (5), 6th message triggers flush + process."""
+        mock_llm.return_value = {
+            "output_text": "[INTENT: FAQ] Respuesta consolidada.",
+        }
+
+        client, app = self._make_client(monkeypatch, enabled=True)
+
+        from backend.app import message_buffer
+
+        message_buffer._buffer.clear()
+        message_buffer._buffer_tasks.clear()
+
+        session_id = "test-buffer-overflow"
+
+        # Send 4 messages — all should buffer
+        for i in range(4):
+            r = client.post(
+                "/chat",
+                json={"message": f"msg{i}", "session_id": session_id},
+            )
+            assert r.status_code == 202, f"Message {i} should return 202"
+
+        # 5th message triggers overflow → processes
+        r5 = client.post(
+            "/chat",
+            json={"message": "msg4", "session_id": session_id},
+        )
+        assert r5.status_code == 200
+        data = r5.json()
+        assert "response" in data
+
+        # Verify LLM was called with joined message
+        mock_llm.assert_called_once()
+        call_args = mock_llm.call_args
+        # The message passed to LLM should contain all buffered messages
+        called_message = call_args.kwargs.get("message", call_args[1].get("message", ""))
+        assert "msg0" in called_message
+        assert "msg4" in called_message
+
+        # Cleanup
+        message_buffer._buffer.clear()
+        message_buffer._buffer_tasks.clear()
+        app.dependency_overrides.clear()
+
+    def test_buffer_disabled_passes_through(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When multi_message_buffer_enabled=False, no buffering occurs."""
+        client, app = self._make_client(monkeypatch, enabled=False)
+
+        with patch("backend.main.llm_client") as mock_llm:
+            mock_llm.get_llm_response_with_tools.return_value = {
+                "output_text": "[INTENT: FAQ] Respuesta directa.",
+            }
+            response = client.post(
+                "/chat",
+                json={"message": "Hola", "session_id": "test-buffer-disabled"},
+            )
+            # When disabled, message goes straight through — should be 200
+            # (may be 200 or error depending on mock coverage, but NOT 202)
+            assert response.status_code != 202
+
+        app.dependency_overrides.clear()

--- a/backend/main.py
+++ b/backend/main.py
@@ -54,6 +54,13 @@ from backend.app.config import settings
 from backend.app.greeting import maybe_prepend_greeting
 from backend.app.whatsapp_formatter import format_for_whatsapp
 from backend.app.message_splitter import process_split_messages
+from backend.app.message_buffer import (
+    add_to_buffer,
+    flush_buffer,
+    get_buffer_count,
+    is_buffering,
+    schedule_flush,
+)
 from backend.app.llm_client import _WHATSAPP_SPLIT_INSTRUCTIONS
 
 logger = logging.getLogger(__name__)
@@ -636,6 +643,23 @@ async def _process_leer_ficha_tecnica(
 _process_tool_call = _process_leer_ficha_tecnica
 
 
+async def _on_buffer_window_expired(
+    session_id: str, joined_message: str
+) -> None:
+    """V1 callback when buffer window expires.
+
+    In V1, the client is responsible for sending is_final=true to trigger
+    processing. When the window expires without is_final, buffered messages
+    are discarded. This is acceptable for V1 — the client must cooperate.
+    """
+    logger.info(
+        "Buffer window expired for session %s: %d chars accumulated, "
+        "discarded (V1 — client must send is_final=true)",
+        session_id,
+        len(joined_message),
+    )
+
+
 @app.post("/chat", response_model=ChatResponse)
 async def chat_endpoint(
     request: ChatRequest,
@@ -655,6 +679,38 @@ async def chat_endpoint(
     """
     session_id = request.session_id or str(uuid.uuid4())
     request_id = str(uuid.uuid4())
+
+    # P4: Multi-message buffer — intercept before normal processing
+    if settings.multi_message_buffer_enabled:
+        current_count = get_buffer_count(session_id)
+
+        if request.is_final or current_count >= 4:
+            # is_final or overflow → flush buffer + current message, process.
+            # add_to_buffer returns the joined text on overflow (>= max_messages),
+            # or None if below max (is_final case — flush manually).
+            overflow_result = await add_to_buffer(session_id, request.message)
+            joined = overflow_result or await flush_buffer(session_id)
+            if joined:
+                # Replace message with joined buffer for normal processing
+                request = ChatRequest(
+                    message=joined,
+                    session_id=session_id,
+                    is_final=request.is_final,
+                )
+        else:
+            # First message or already buffering → buffer and return 202
+            await add_to_buffer(session_id, request.message)
+            schedule_flush(
+                session_id,
+                settings.buffer_window_seconds,
+                _on_buffer_window_expired,
+            )
+            return JSONResponse(
+                status_code=202,
+                content=BufferingResponse(
+                    session_id=session_id,
+                ).model_dump(),
+            )
 
     logger.debug(
         "Incoming request: request_id=%s, session_id=%s, message_preview=%s",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [dependency-groups]
 dev = [
   "pytest",
-  "httpx"
+  "httpx",
+  "pytest-asyncio>=1.3.0",
 ]
 lint = [
   "ruff"

--- a/uv.lock
+++ b/uv.lock
@@ -60,6 +60,7 @@ dependencies = [
 dev = [
     { name = "httpx" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
 ]
 lint = [
     { name = "ruff" },
@@ -88,6 +89,7 @@ requires-dist = [
 dev = [
     { name = "httpx" },
     { name = "pytest" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
 ]
 lint = [{ name = "ruff" }]
 typecheck = [{ name = "mypy" }]
@@ -1042,6 +1044,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add debounce-based multi-message input buffering for WhatsApp
- Buffer accumulates messages within configurable window (default 5s)
- Each new message resets the timer (debounce pattern)
- Returns HTTP 202 BufferingResponse while buffering
- `is_final=true` triggers immediate flush and normal processing
- Overflow at 5 messages triggers immediate flush
- Timer expiry discards buffer (client must send `is_final`)
- 30 new tests, 162/162 total passing, zero regressions

## Changes
| Area | Description |
|------|-------------|
| `backend/app/message_buffer.py` | **New** — Buffer core: add/flush/count/clear/schedule_flush with asyncio debounce |
| `backend/main.py` | Buffer intercept at top of `chat_endpoint`, `_on_buffer_window_expired` callback |
| `backend/app/tests/test_message_buffer.py` | **New** — 30 tests (buffer ops, debounce, overflow, endpoint integration) |
| `pyproject.toml` | Added `pytest-asyncio` dev dependency |

## How it works
1. First message → add to buffer, start timer, return 202
2. Subsequent messages within window → add to buffer, restart timer, return 202
3. `is_final=true` → flush buffer, process joined message through normal endpoint
4. Buffer overflow (5 messages) → flush immediately, process
5. Timer expiry → discard buffer (client cooperation required for V1)

## Breaking Changes
None. Buffer gated by `MULTI_MESSAGE_BUFFER_ENABLED` (default: false).

## Depends On
PR #149 (Prompt-based splitting) — merged.

## Related
Part of whatsapp-conversational change (PR 4 of 5). Next: P5 (evaluation harness).