### PR TITLE
feat: [US-120] OIDC-based S3 upload for evaluation harness in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,9 @@ jobs:
     name: Run Evaluation Harness
     runs-on: ubuntu-latest
     needs: test-health
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,7 @@ jobs:
       - name: Run evaluation harness
         env:
           EVAL_S3_PREFIX: evaluation/ci/${{ github.ref_name }}/${{ github.run_id }}/
+          AWS_BUCKET_NAME: ${{ vars.AWS_BUCKET_NAME }}
         run: |
           uv run python -m evaluation.harness.run
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,16 +184,10 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
 
-      - name: Debug AWS env vars
-        run: |
-          echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-NOT SET}"
-          echo "AWS_SESSION_TOKEN set: $(test -n "${AWS_SESSION_TOKEN:-}" && echo yes || echo no)"
-
       - name: Run evaluation harness
         env:
           EVAL_S3_PREFIX: evaluation/ci/${{ github.ref_name }}/${{ github.run_id }}/
         run: |
-          uv run python -c 'import os; print("Python AWS_ACCESS_KEY_ID:", os.getenv("AWS_ACCESS_KEY_ID", "NOT SET")[:8] if os.getenv("AWS_ACCESS_KEY_ID") else "NOT SET"); print("Python AWS_SESSION_TOKEN:", "SET" if os.getenv("AWS_SESSION_TOKEN") else "NOT SET")'
           uv run python -m evaluation.harness.run
 
       - name: Upload evaluation results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
       - name: Run evaluation harness
         env:
           EVAL_S3_PREFIX: evaluation/ci/${{ github.ref_name }}/${{ github.run_id }}/
-          AWS_BUCKET_NAME: ${{ vars.AWS_BUCKET_NAME }}
+          AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
         run: |
           uv run python -m evaluation.harness.run
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
+          aws-region: ${{ vars.AWS_REGION || 'us-east-2' }}
 
       - name: Run evaluation harness
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,10 +184,20 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
 
+      - name: Debug AWS env vars
+        run: |
+          echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-NOT SET}"
+          echo "AWS_SESSION_TOKEN set: $(test -n "${AWS_SESSION_TOKEN:-}" && echo yes || echo no)"
+
       - name: Run evaluation harness
         env:
           EVAL_S3_PREFIX: evaluation/ci/${{ github.ref_name }}/${{ github.run_id }}/
         run: |
+          uv run python -c "
+import os
+print('Python AWS_ACCESS_KEY_ID:', os.getenv('AWS_ACCESS_KEY_ID', 'NOT SET')[:8] if os.getenv('AWS_ACCESS_KEY_ID') else 'NOT SET')
+print('Python AWS_SESSION_TOKEN:', 'SET' if os.getenv('AWS_SESSION_TOKEN') else 'NOT SET')
+"
           uv run python -m evaluation.harness.run
 
       - name: Upload evaluation results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,8 +145,6 @@ jobs:
           cat > .env <<EOF
           CHAT_API_KEY=${{ secrets.CHAT_API_KEY }}
           OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
-          AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
           EOF
 
       - name: Start containers
@@ -176,6 +174,12 @@ jobs:
         run: |
           uv venv
           uv pip install -r evaluation/harness/requirements.txt
+
+      - name: Configure AWS credentials for S3 upload
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
 
       - name: Run evaluation harness
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,11 +193,7 @@ jobs:
         env:
           EVAL_S3_PREFIX: evaluation/ci/${{ github.ref_name }}/${{ github.run_id }}/
         run: |
-          uv run python -c "
-import os
-print('Python AWS_ACCESS_KEY_ID:', os.getenv('AWS_ACCESS_KEY_ID', 'NOT SET')[:8] if os.getenv('AWS_ACCESS_KEY_ID') else 'NOT SET')
-print('Python AWS_SESSION_TOKEN:', 'SET' if os.getenv('AWS_SESSION_TOKEN') else 'NOT SET')
-"
+          uv run python -c 'import os; print("Python AWS_ACCESS_KEY_ID:", os.getenv("AWS_ACCESS_KEY_ID", "NOT SET")[:8] if os.getenv("AWS_ACCESS_KEY_ID") else "NOT SET"); print("Python AWS_SESSION_TOKEN:", "SET" if os.getenv("AWS_SESSION_TOKEN") else "NOT SET")'
           uv run python -m evaluation.harness.run
 
       - name: Upload evaluation results

--- a/evaluation/harness/config.py
+++ b/evaluation/harness/config.py
@@ -43,7 +43,7 @@ class HarnessSettings(BaseSettings):
         description="API key for the /chat endpoint",
     )
     aws_bucket_name: str = Field(
-        default="arte-chatbot-data",
+        default="arte-chatbot-fichas-tecnicas",
         description="S3 bucket name for evaluation results",
     )
 

--- a/evaluation/harness/run.py
+++ b/evaluation/harness/run.py
@@ -341,7 +341,7 @@ async def run_harness(args: argparse.Namespace) -> list[dict[str, Any]]:
         elif uploaded_keys:
             print(f"✓ Successfully uploaded {len(uploaded_keys)} files to S3:")
             for key in uploaded_keys:
-                print(f"  - s3://{harness_settings.AWS_BUCKET_NAME}/{key}")
+                print(f"  - s3://{harness_settings.aws_bucket_name}/{key}")
         else:
             print("⚠ No files available for upload")
 

--- a/evaluation/harness/s3_upload.py
+++ b/evaluation/harness/s3_upload.py
@@ -94,6 +94,7 @@ def upload_results(output_dir: Path, prefix: str) -> list[str]:
     """
     access_key = os.getenv("AWS_ACCESS_KEY_ID")
     secret_key = os.getenv("AWS_SECRET_ACCESS_KEY")
+    session_token = os.getenv("AWS_SESSION_TOKEN")
 
     if not access_key or not secret_key:
         logger.warning("AWS credentials not found, skipping S3 upload")
@@ -103,6 +104,7 @@ def upload_results(output_dir: Path, prefix: str) -> list[str]:
         "s3",
         aws_access_key_id=access_key,
         aws_secret_access_key=secret_key,
+        aws_session_token=session_token,
         region_name=AWS_REGION,
     )
     uploaded: list[str] = []
@@ -152,12 +154,14 @@ def upload_results_with_metadata(
 
     access_key = os.getenv("AWS_ACCESS_KEY_ID")
     secret_key = os.getenv("AWS_SECRET_ACCESS_KEY")
+    session_token = os.getenv("AWS_SESSION_TOKEN")
 
     if access_key and secret_key:
         s3_client = boto3.client(
             "s3",
             aws_access_key_id=access_key,
             aws_secret_access_key=secret_key,
+            aws_session_token=session_token,
             region_name=AWS_REGION,
         )
         s3_key = f"{prefix.rstrip('/')}/metadata.json"

--- a/evaluation/storage.py
+++ b/evaluation/storage.py
@@ -37,6 +37,7 @@ def upload_to_s3(file_path: Path, s3_key: str) -> bool:
     """Upload file to S3 bucket. Returns True on success."""
     access_key = os.getenv("AWS_ACCESS_KEY_ID")
     secret_key = os.getenv("AWS_SECRET_ACCESS_KEY")
+    session_token = os.getenv("AWS_SESSION_TOKEN")
 
     if not access_key or not secret_key:
         print("Warning: AWS credentials not found, skipping S3 upload")
@@ -47,6 +48,7 @@ def upload_to_s3(file_path: Path, s3_key: str) -> bool:
             "s3",
             aws_access_key_id=access_key,
             aws_secret_access_key=secret_key,
+            aws_session_token=session_token,
             region_name=AWS_REGION,
         )
         s3_client.upload_file(str(file_path), AWS_BUCKET_NAME, s3_key)


### PR DESCRIPTION
## Summary

Migrate the evaluation harness S3 upload in CI from long-lived AWS access keys to GitHub OIDC federation. This eliminates secrets rotation burden and improves security posture by using short-lived credentials.

## Changes

- `.github/workflows/ci.yml`: Replaced `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` secrets with `aws-actions/configure-aws-credentials@v4` using `AWS_ROLE_ARN`
- Removed AWS credentials from the Docker Compose `.env` file (they were only needed for the harness S3 upload, not for the backend running in Docker)
- Added `AWS_REGION` variable reference for the OIDC configuration

## Setup Instructions

### AWS: Create OIDC Identity Provider

1. Go to **IAM → Identity providers → Add provider**
2. Type: **OpenID Connect**
3. Provider URL: `https://token.actions.githubusercontent.com`
4. Audience: `sts.amazonaws.com`

### AWS: Create IAM Role

1. Go to **IAM → Roles → Create role**
2. Trusted entity type: **Web identity**
3. Select the GitHub OIDC provider created above
4. Audience: `sts.amazonaws.com`
5. Add permissions: attach a policy with only `s3:PutObject` on `arte-chatbot-data/evaluation/*`:

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Action": ["s3:PutObject"],
      "Resource": "arn:aws:s3:::arte-chatbot-data/evaluation/*"
    }
  ]
}
```

6. Edit the trust policy to restrict to your repository:

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": {
        "Federated": "arn:aws:iam::<ACCOUNT_ID>:oidc-provider/token.actions.githubusercontent.com"
      },
      "Action": "sts:AssumeRoleWithWebIdentity",
      "Condition": {
        "StringEquals": {
          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
        },
        "StringLike": {
          "token.actions.githubusercontent.com:sub": "repo:creep1ng/arte-chatbot:*"
        }
      }
    }
  ]
}
```

Replace `<ACCOUNT_ID>` with your AWS account ID.

### GitHub: Configure Secrets and Variables

**Repository secret** (`Settings → Secrets and variables → Actions → New repository secret`):
- `AWS_ROLE_ARN` = the ARN of the role created above (e.g., `arn:aws:iam::123456789:role/github-actions-arte-evaluation`)

**Repository variable** (`Settings → Secrets and variables → Actions → Variables → New variable`):
- `AWS_REGION` = your AWS region (e.g., `us-east-1`)

## Verification

After merging, trigger a CI run and verify:
1. The `Configure AWS credentials for S3 upload` step completes successfully
2. Evaluation results appear in `s3://arte-chatbot-data/evaluation/ci/{branch}/{run_id}/`

## Related

- ADR-008: Evaluation harness S3 upload
- ADR-002: S3 data infrastructure