### PR TITLE
fix(llm): access _WHATSAPP_SPLIT_INSTRUCTIONS based on env var

### DIFF
--- a/backend/app/llm_client.py
+++ b/backend/app/llm_client.py
@@ -144,7 +144,17 @@ class LLMClient:
             api_key if api_key is not None else os.getenv("OPENAI_API_KEY", "")
         )
         self.model = model
-        self.default_system_prompt = ARTE_SYSTEM_PROMPT
+
+        # Build system prompt: base + WhatsApp formatting when enabled
+        whatsapp_enabled = os.getenv("WHATSAPP_FORMATTER_ENABLED", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        if whatsapp_enabled:
+            self.default_system_prompt = ARTE_SYSTEM_PROMPT + _WHATSAPP_SPLIT_INSTRUCTIONS
+        else:
+            self.default_system_prompt = ARTE_SYSTEM_PROMPT
 
         # OpenAI SDK client
         self._openai_client: Optional[OpenAI] = None

--- a/backend/app/llm_client.py
+++ b/backend/app/llm_client.py
@@ -146,13 +146,17 @@ class LLMClient:
         self.model = model
 
         # Build system prompt: base + WhatsApp formatting when enabled
-        whatsapp_enabled = os.getenv("WHATSAPP_FORMATTER_ENABLED", "").lower() in (
+        whatsapp_enabled = os.getenv(
+            "WHATSAPP_FORMATTER_ENABLED", ""
+        ).strip().lower() in (
             "1",
             "true",
             "yes",
         )
         if whatsapp_enabled:
-            self.default_system_prompt = ARTE_SYSTEM_PROMPT + _WHATSAPP_SPLIT_INSTRUCTIONS
+            self.default_system_prompt = (
+                ARTE_SYSTEM_PROMPT + _WHATSAPP_SPLIT_INSTRUCTIONS
+            )
         else:
             self.default_system_prompt = ARTE_SYSTEM_PROMPT
 


### PR DESCRIPTION
## ¿Qué hace este PR?

Corrige el acceso a `_WHATSAPP_SPLIT_INSTRUCTIONS` en `LLMClient.__init__`. Antes, esta constante se definía pero nunca se usaba — el system prompt siempre era solo `ARTE_SYSTEM_PROMPT`. Ahora, cuando la variable de entorno `WHATSAPP_FORMATTER_ENABLED` está configurada con valores como `"1"`, `"true"` o `"yes"`, se appenden las instrucciones de formato y división de mensajes para WhatsApp al system prompt.

## Issues relacionados

Closes #98
Part of #158

## Tipo de cambio

- [ ] 🆕 Nueva funcionalidad (feature)
- [x] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [ ] 🧪 Tests
- [ ] 📄 Documentación / configuración
- [ ] 🔧 Infra / CI

## Checklist antes de pedir review

- [x] El código corre localmente sin errores (`uvicorn` levanta, tests pasan)
- [x] Los criterios de aceptación del issue relacionado están cumplidos
- [x] No hay credenciales, API keys ni rutas absolutas hardcodeadas
- [ ] Si agregué dependencias nuevas, actualicé `requirements.txt` / `pyproject.toml`
- [ ] Si modifiqué el schema del endpoint, verifiqué que `/docs` refleja los cambios
- [ ] Si modifiqué el harness o el dataset, corrí `python evaluation/harness.py` y el output es el esperado

## Cómo probar este PR

1. Sin `WHATSAPP_FORMATTER_ENABLED` configurada, verificar que `LLMClient().default_system_prompt == ARTE_SYSTEM_PROMPT`
2. Con `WHATSAPP_FORMATTER_ENABLED=true`, verificar que `LLMClient().default_system_prompt == ARTE_SYSTEM_PROMPT + _WHATSAPP_SPLIT_INSTRUCTIONS`
3. Verificar que la respuesta del LLM no incluye formato WhatsApp cuando la variable está deshabilitada

## Notas para el reviewer

Sin notas.