### PR TITLE
feat(#170): foundation — deps, docker, config, schemas, ConfigProvider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,3 +61,28 @@ DATASET_PATH=evaluation/harness/dataset.json
 
 # Directory to save evaluation results.
 OUTPUT_DIR=evaluation/harness/output
+
+# --- Chatwoot Integration ---
+# Feature flag. Default: false (existing /chat endpoint remains active)
+CHATWOOT_ENABLED=false
+# URL of your self-hosted Chatwoot instance (no trailing slash)
+CHATWOOT_API_URL=https://chatwoot.your-domain.com
+# AgentBot access token from Chatwoot
+CHATWOOT_AGENT_BOT_TOKEN=
+# Numeric account ID
+CHATWOOT_ACCOUNT_ID=
+# Numeric inbox ID for WhatsApp
+CHATWOOT_INBOX_ID=
+# Webhook secret for HMAC signature verification
+CHATWOOT_WEBHOOK_SECRET=
+# Team ID for human escalation handoff
+CHATWOOT_HANDOFF_TEAM_ID=
+# Labels (comma-separated) assigned by the bot
+CHATWOOT_BOT_LABEL=bot
+CHATWOOT_ESCALATED_LABEL=escalated
+CHATWOOT_TECHNICAL_LABEL=technical
+
+# --- Redis ---
+# Redis URL. Default: redis://localhost:6379/0
+REDIS_URL=redis://localhost:6379/0
+REDIS_PASSWORD=

--- a/.kilo/package-lock.json
+++ b/.kilo/package-lock.json
@@ -5,22 +5,22 @@
   "packages": {
     "": {
       "dependencies": {
-        "@kilocode/plugin": "7.2.40"
+        "@kilocode/plugin": "7.3.0"
       }
     },
     "node_modules/@kilocode/plugin": {
-      "version": "7.2.40",
-      "resolved": "https://registry.npmjs.org/@kilocode/plugin/-/plugin-7.2.40.tgz",
-      "integrity": "sha512-m0/5LnQdKW+FJnv9sVbri4Cqw7vq2jy5xS7hdkWO0mbyPkjROcrXklnwuHk3bi32F5InnO4DUyKrkqfMFoMDgQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@kilocode/plugin/-/plugin-7.3.0.tgz",
+      "integrity": "sha512-DGM/6xWoEeQqI6nmLNOt39jLdQDQMZvHPb3L1ziuStHvl8WpU/BLgC+ThdYRxNZZgS1W6l9Vy58THFUkgVOHZg==",
       "license": "MIT",
       "dependencies": {
-        "@kilocode/sdk": "7.2.40",
+        "@kilocode/sdk": "7.3.0",
         "effect": "4.0.0-beta.57",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.1.105",
-        "@opentui/solid": ">=0.1.105"
+        "@opentui/core": ">=0.2.2",
+        "@opentui/solid": ">=0.2.2"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
@@ -32,9 +32,9 @@
       }
     },
     "node_modules/@kilocode/sdk": {
-      "version": "7.2.40",
-      "resolved": "https://registry.npmjs.org/@kilocode/sdk/-/sdk-7.2.40.tgz",
-      "integrity": "sha512-I/AWGE2EnM26/lWD/gf9T8QxuCB/YPZBQJ14M8D/SN4+rZKonyqz2Q6iIgQWqcX3B4LQLMWNFNh9rdvPaHN66Q==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@kilocode/sdk/-/sdk-7.3.0.tgz",
+      "integrity": "sha512-E3izR+Qu/Ku/y2Tu8Cy0AL+alYytq/Qm4VmmFmzSZZQVZVXmH74cXjOxSL6J15FZNUxuNGfDZM8u+Avbje/jMw==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/.kilocode/package-lock.json
+++ b/.kilocode/package-lock.json
@@ -5,22 +5,22 @@
   "packages": {
     "": {
       "dependencies": {
-        "@kilocode/plugin": "7.2.40"
+        "@kilocode/plugin": "7.3.0"
       }
     },
     "node_modules/@kilocode/plugin": {
-      "version": "7.2.40",
-      "resolved": "https://registry.npmjs.org/@kilocode/plugin/-/plugin-7.2.40.tgz",
-      "integrity": "sha512-m0/5LnQdKW+FJnv9sVbri4Cqw7vq2jy5xS7hdkWO0mbyPkjROcrXklnwuHk3bi32F5InnO4DUyKrkqfMFoMDgQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@kilocode/plugin/-/plugin-7.3.0.tgz",
+      "integrity": "sha512-DGM/6xWoEeQqI6nmLNOt39jLdQDQMZvHPb3L1ziuStHvl8WpU/BLgC+ThdYRxNZZgS1W6l9Vy58THFUkgVOHZg==",
       "license": "MIT",
       "dependencies": {
-        "@kilocode/sdk": "7.2.40",
+        "@kilocode/sdk": "7.3.0",
         "effect": "4.0.0-beta.57",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.1.105",
-        "@opentui/solid": ">=0.1.105"
+        "@opentui/core": ">=0.2.2",
+        "@opentui/solid": ">=0.2.2"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
@@ -32,9 +32,9 @@
       }
     },
     "node_modules/@kilocode/sdk": {
-      "version": "7.2.40",
-      "resolved": "https://registry.npmjs.org/@kilocode/sdk/-/sdk-7.2.40.tgz",
-      "integrity": "sha512-I/AWGE2EnM26/lWD/gf9T8QxuCB/YPZBQJ14M8D/SN4+rZKonyqz2Q6iIgQWqcX3B4LQLMWNFNh9rdvPaHN66Q==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@kilocode/sdk/-/sdk-7.3.0.tgz",
+      "integrity": "sha512-E3izR+Qu/Ku/y2Tu8Cy0AL+alYytq/Qm4VmmFmzSZZQVZVXmH74cXjOxSL6J15FZNUxuNGfDZM8u+Avbje/jMw==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -9,6 +9,7 @@ attribute access, which ensures environment variables patched by tests
 import time.
 """
 
+import warnings
 from typing import Any, Optional
 
 from pydantic import Field, model_validator
@@ -132,6 +133,58 @@ class Settings(BaseSettings):
         description="Git commit hash for traceability in conversation logs",
     )
 
+    # Chatwoot
+    chatwoot_enabled: bool = Field(
+        default=False,
+        description="Enable Chatwoot integration",
+    )
+    chatwoot_api_url: Optional[str] = Field(
+        default=None,
+        description="URL of the Chatwoot instance (no trailing slash)",
+    )
+    chatwoot_agent_bot_token: Optional[str] = Field(
+        default=None,
+        description="AgentBot access token from Chatwoot",
+    )
+    chatwoot_account_id: Optional[int] = Field(
+        default=None,
+        description="Numeric account ID",
+    )
+    chatwoot_inbox_id: Optional[int] = Field(
+        default=None,
+        description="Numeric inbox ID for WhatsApp",
+    )
+    chatwoot_webhook_secret: Optional[str] = Field(
+        default=None,
+        description="Webhook secret for HMAC signature verification",
+    )
+    chatwoot_handoff_team_id: Optional[int] = Field(
+        default=None,
+        description="Team ID for human escalation handoff",
+    )
+    chatwoot_bot_label: str = Field(
+        default="bot",
+        description="Label assigned by the bot",
+    )
+    chatwoot_escalated_label: str = Field(
+        default="escalated",
+        description="Label for escalated conversations",
+    )
+    chatwoot_technical_label: str = Field(
+        default="technical",
+        description="Label for technical conversations",
+    )
+
+    # Redis
+    redis_url: str = Field(
+        default="redis://localhost:6379/0",
+        description="Redis connection URL",
+    )
+    redis_password: Optional[str] = Field(
+        default=None,
+        description="Redis password",
+    )
+
     @model_validator(mode="after")
     def _validate_delay_bounds(self) -> "Settings":
         """Ensure msg_delay_min_ms <= msg_delay_max_ms."""
@@ -153,6 +206,33 @@ class Settings(BaseSettings):
             raise ValueError(
                 f"Invalid IANA timezone: {self.greeting_timezone}"
             )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_chatwoot_config(self) -> "Settings":
+        """Warn if Chatwoot is enabled but required fields are missing."""
+        if not self.chatwoot_enabled:
+            return self
+
+        missing: list[str] = []
+        if not self.chatwoot_api_url:
+            missing.append("CHATWOOT_API_URL")
+        if not self.chatwoot_agent_bot_token:
+            missing.append("CHATWOOT_AGENT_BOT_TOKEN")
+        if self.chatwoot_account_id is None:
+            missing.append("CHATWOOT_ACCOUNT_ID")
+        if self.chatwoot_inbox_id is None:
+            missing.append("CHATWOOT_INBOX_ID")
+        if not self.chatwoot_webhook_secret:
+            missing.append("CHATWOOT_WEBHOOK_SECRET")
+
+        if missing:
+            warnings.warn(
+                f"Chatwoot is enabled but the following required settings are missing: {', '.join(missing)}",
+                UserWarning,
+                stacklevel=2,
+            )
+
         return self
 
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -203,9 +203,7 @@ class Settings(BaseSettings):
         try:
             ZoneInfo(self.greeting_timezone)
         except (KeyError, ZoneInfoNotFoundError):
-            raise ValueError(
-                f"Invalid IANA timezone: {self.greeting_timezone}"
-            )
+            raise ValueError(f"Invalid IANA timezone: {self.greeting_timezone}")
         return self
 
     @model_validator(mode="after")

--- a/backend/app/config_provider.py
+++ b/backend/app/config_provider.py
@@ -1,0 +1,91 @@
+"""ConfigProvider abstraction and environment-based implementation.
+
+Provides a protocol/ABC for configuration access so that future
+admin-panel-backed providers can be swapped in without changing
+consumer code.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Optional, Protocol
+
+from backend.app.config import Settings, settings
+
+
+@dataclass
+class ChannelProfile:
+    """Simple channel profile with safe defaults."""
+
+    name: str = "default"
+    supports_html: bool = False
+    max_message_length: int = 4096
+
+
+class ConfigProvider(Protocol):
+    """Protocol for configuration providers.
+
+    Implementations may read from environment variables, Redis, or
+    an admin panel backend.
+    """
+
+    def get(self, key: str) -> Any:
+        """Return the raw value for a setting key, or None."""
+        ...
+
+    def get_label(self, name: str) -> str:
+        """Resolve a semantic label name to its configured value.
+
+        Supported names: ``bot``, ``escalated``, ``technical``.
+        """
+        ...
+
+    def get_channel_profile(self, inbox_id: str) -> ChannelProfile:
+        """Return the channel profile for the given inbox ID."""
+        ...
+
+    def get_handoff_target(self) -> Optional[int]:
+        """Return the team ID to assign on human handoff, if any."""
+        ...
+
+    def is_chatwoot_enabled(self) -> bool:
+        """Return whether the Chatwoot integration is active."""
+        ...
+
+
+class EnvConfigProvider:
+    """ConfigProvider backed by the existing Pydantic Settings.
+
+    Args:
+        settings_obj: A ``Settings`` instance (or the lazy ``settings`` proxy).
+            Defaults to the module-level ``settings`` singleton.
+    """
+
+    def __init__(self, settings_obj: Optional[Settings] = None) -> None:
+        self._settings = settings_obj or settings
+
+    def get(self, key: str) -> Any:
+        """Return the attribute named *key* from Settings, or None."""
+        return getattr(self._settings, key, None)
+
+    def get_label(self, name: str) -> str:
+        """Resolve label names using Settings fields."""
+        mapping = {
+            "bot": self._settings.chatwoot_bot_label,
+            "escalated": self._settings.chatwoot_escalated_label,
+            "technical": self._settings.chatwoot_technical_label,
+        }
+        return mapping.get(name, name)
+
+    def get_channel_profile(self, inbox_id: str) -> ChannelProfile:
+        """Return a default channel profile.
+
+        Future implementations may lookup per-inbox overrides.
+        """
+        return ChannelProfile()
+
+    def get_handoff_target(self) -> Optional[int]:
+        """Return the configured handoff team ID."""
+        return self._settings.chatwoot_handoff_team_id
+
+    def is_chatwoot_enabled(self) -> bool:
+        """Return whether Chatwoot integration is enabled."""
+        return self._settings.chatwoot_enabled

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -24,3 +24,59 @@ class LLMResponse(BaseModel):
 class SourceDocument(BaseModel):
     ruta: str
     contenido_relevante: Optional[str] = None
+
+
+class ChatwootMessage(BaseModel):
+    """Nested message object inside a Chatwoot webhook payload."""
+
+    id: int
+    content: Optional[str] = None
+    content_type: str = "text"
+    private: bool = False
+
+
+class ChatwootConversation(BaseModel):
+    """Nested conversation object inside a Chatwoot webhook payload."""
+
+    id: int
+    status: str
+    inbox_id: int
+    contact_id: int
+
+
+class ChatwootSender(BaseModel):
+    """Nested sender object inside a Chatwoot webhook payload."""
+
+    id: int
+    type: Literal["contact", "user", "agent_bot"]
+    name: Optional[str] = None
+
+
+class ChatwootWebhookPayload(BaseModel):
+    """Base schema for all Chatwoot webhook payloads."""
+
+    event: str
+    account: dict[str, Any]
+
+
+class MessageCreatedPayload(ChatwootWebhookPayload):
+    """Schema for the 'message_created' webhook event."""
+
+    conversation: ChatwootConversation
+    sender: ChatwootSender
+    message: ChatwootMessage
+
+
+class ConversationCreatedPayload(ChatwootWebhookPayload):
+    """Schema for the 'conversation_created' webhook event."""
+
+    conversation: ChatwootConversation
+    sender: ChatwootSender
+
+
+class ConversationStatusChangedPayload(ChatwootWebhookPayload):
+    """Schema for the 'conversation_status_changed' webhook event."""
+
+    conversation: ChatwootConversation
+    sender: ChatwootSender
+    status: str

--- a/backend/main.py
+++ b/backend/main.py
@@ -760,6 +760,7 @@ async def _process_leer_ficha_tecnica(
 # Alias for backward compatibility with tests
 _process_tool_call = _process_leer_ficha_tecnica
 
+
 async def _process_chat_message(
     session_id: str,
     message: str,

--- a/backend/main.py
+++ b/backend/main.py
@@ -36,6 +36,7 @@ from pydantic import BaseModel, Field
 from backend.app.auth import verify_api_key
 from backend.app.catalog import CatalogError, get_catalog
 from backend.app.config import settings
+from backend.app.config_provider import EnvConfigProvider
 from backend.app.conversation_logger import ConversationLogEntry, ConversationLogger
 from backend.app.file_inputs import FileInputsClient, FileUploadError
 from backend.app.greeting import maybe_prepend_greeting
@@ -194,6 +195,11 @@ def get_s3_client() -> S3Client:
 def get_file_inputs_client() -> FileInputsClient:
     """Dependency that provides a FileInputsClient instance."""
     return file_inputs_client
+
+
+def get_config_provider() -> EnvConfigProvider:
+    """Dependency that provides a ConfigProvider instance."""
+    return EnvConfigProvider()
 
 
 # Lazy-load catalog to allow /health to work without AWS credentials in CI

--- a/backend/tests/test_chatwoot_config.py
+++ b/backend/tests/test_chatwoot_config.py
@@ -1,0 +1,142 @@
+"""Tests for Chatwoot and Redis configuration settings.
+
+Validates new Settings fields, defaults, env mapping, and the
+model validator that warns when Chatwoot is enabled but misconfigured.
+"""
+
+import os
+import warnings
+from unittest.mock import patch
+
+import pytest
+
+from backend.app.config import Settings
+
+
+class TestChatwootSettingsDefaults:
+    """Settings must expose safe defaults when env vars are absent."""
+
+    def test_chatwoot_enabled_defaults_false(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            settings = Settings()
+            assert settings.chatwoot_enabled is False
+
+    def test_chatwoot_api_url_defaults_none(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            settings = Settings()
+            assert settings.chatwoot_api_url is None
+
+    def test_chatwoot_agent_bot_token_defaults_none(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            settings = Settings()
+            assert settings.chatwoot_agent_bot_token is None
+
+    def test_chatwoot_account_id_defaults_none(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            settings = Settings()
+            assert settings.chatwoot_account_id is None
+
+    def test_chatwoot_inbox_id_defaults_none(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            settings = Settings()
+            assert settings.chatwoot_inbox_id is None
+
+    def test_chatwoot_webhook_secret_defaults_none(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            settings = Settings()
+            assert settings.chatwoot_webhook_secret is None
+
+    def test_chatwoot_handoff_team_id_defaults_none(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            settings = Settings()
+            assert settings.chatwoot_handoff_team_id is None
+
+    def test_chatwoot_bot_label_defaults_bot(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            settings = Settings()
+            assert settings.chatwoot_bot_label == "bot"
+
+    def test_chatwoot_escalated_label_defaults_escalated(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            settings = Settings()
+            assert settings.chatwoot_escalated_label == "escalated"
+
+    def test_chatwoot_technical_label_defaults_technical(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            settings = Settings()
+            assert settings.chatwoot_technical_label == "technical"
+
+    def test_redis_url_defaults_localhost(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            settings = Settings()
+            assert settings.redis_url == "redis://localhost:6379/0"
+
+    def test_redis_password_defaults_none(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            settings = Settings()
+            assert settings.redis_password is None
+
+
+class TestChatwootSettingsFromEnv:
+    """Settings must read Chatwoot and Redis values from environment."""
+
+    def test_chatwoot_fields_from_env(self) -> None:
+        env = {
+            "CHATWOOT_ENABLED": "true",
+            "CHATWOOT_API_URL": "https://chatwoot.example.com",
+            "CHATWOOT_AGENT_BOT_TOKEN": "token123",
+            "CHATWOOT_ACCOUNT_ID": "42",
+            "CHATWOOT_INBOX_ID": "7",
+            "CHATWOOT_WEBHOOK_SECRET": "secret",
+            "CHATWOOT_HANDOFF_TEAM_ID": "3",
+            "CHATWOOT_BOT_LABEL": "bot_label",
+            "CHATWOOT_ESCALATED_LABEL": "esc_label",
+            "CHATWOOT_TECHNICAL_LABEL": "tech_label",
+            "REDIS_URL": "redis://redis:6379/1",
+            "REDIS_PASSWORD": "pass",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            settings = Settings()
+            assert settings.chatwoot_enabled is True
+            assert settings.chatwoot_api_url == "https://chatwoot.example.com"
+            assert settings.chatwoot_agent_bot_token == "token123"
+            assert settings.chatwoot_account_id == 42
+            assert settings.chatwoot_inbox_id == 7
+            assert settings.chatwoot_webhook_secret == "secret"
+            assert settings.chatwoot_handoff_team_id == 3
+            assert settings.chatwoot_bot_label == "bot_label"
+            assert settings.chatwoot_escalated_label == "esc_label"
+            assert settings.chatwoot_technical_label == "tech_label"
+            assert settings.redis_url == "redis://redis:6379/1"
+            assert settings.redis_password == "pass"
+
+
+class TestChatwootSettingsValidator:
+    """The model validator must warn when Chatwoot is enabled but missing core config."""
+
+    def test_chatwoot_enabled_warns_on_missing_required_fields(self) -> None:
+        env = {"CHATWOOT_ENABLED": "true"}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.warns(UserWarning, match="Chatwoot is enabled but"):
+                Settings()
+
+    def test_chatwoot_enabled_no_warning_when_fully_configured(self) -> None:
+        env = {
+            "CHATWOOT_ENABLED": "true",
+            "CHATWOOT_API_URL": "https://chatwoot.example.com",
+            "CHATWOOT_AGENT_BOT_TOKEN": "token",
+            "CHATWOOT_ACCOUNT_ID": "1",
+            "CHATWOOT_INBOX_ID": "1",
+            "CHATWOOT_WEBHOOK_SECRET": "secret",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                Settings()
+                chatwoot_warnings = [
+                    warning
+                    for warning in w
+                    if issubclass(warning.category, UserWarning)
+                    and "Chatwoot is enabled but" in str(warning.message)
+                ]
+                assert len(chatwoot_warnings) == 0

--- a/backend/tests/test_chatwoot_schemas.py
+++ b/backend/tests/test_chatwoot_schemas.py
@@ -1,0 +1,152 @@
+"""Tests for Chatwoot webhook payload Pydantic schemas.
+
+Validates correct parsing of Chatwoot webhook payloads and rejection
+of invalid data (e.g., unknown sender types).
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from backend.app.schemas import (
+    ChatwootConversation,
+    ChatwootMessage,
+    ChatwootSender,
+    ChatwootWebhookPayload,
+    ConversationCreatedPayload,
+    ConversationStatusChangedPayload,
+    MessageCreatedPayload,
+)
+
+
+class TestChatwootMessage:
+    """Unit tests for the ChatwootMessage schema."""
+
+    def test_valid_message(self) -> None:
+        msg = ChatwootMessage(
+            id=1,
+            content="hello",
+            content_type="text",
+            private=False,
+        )
+        assert msg.id == 1
+        assert msg.content == "hello"
+        assert msg.content_type == "text"
+        assert msg.private is False
+
+    def test_defaults(self) -> None:
+        msg = ChatwootMessage(id=42)
+        assert msg.content is None
+        assert msg.content_type == "text"
+        assert msg.private is False
+
+
+class TestChatwootConversation:
+    """Unit tests for the ChatwootConversation schema."""
+
+    def test_valid_conversation(self) -> None:
+        conv = ChatwootConversation(
+            id=10,
+            status="open",
+            inbox_id=5,
+            contact_id=20,
+        )
+        assert conv.id == 10
+        assert conv.status == "open"
+        assert conv.inbox_id == 5
+        assert conv.contact_id == 20
+
+
+class TestChatwootSender:
+    """Unit tests for the ChatwootSender schema."""
+
+    def test_valid_contact(self) -> None:
+        sender = ChatwootSender(id=30, type="contact", name="John")
+        assert sender.type == "contact"
+        assert sender.name == "John"
+
+    def test_valid_user(self) -> None:
+        sender = ChatwootSender(id=31, type="user")
+        assert sender.type == "user"
+        assert sender.name is None
+
+    def test_valid_agent_bot(self) -> None:
+        sender = ChatwootSender(id=32, type="agent_bot")
+        assert sender.type == "agent_bot"
+
+    def test_invalid_sender_type(self) -> None:
+        with pytest.raises(ValidationError):
+            ChatwootSender(id=33, type="invalid")
+
+
+class TestChatwootWebhookPayload:
+    """Unit tests for the base ChatwootWebhookPayload schema."""
+
+    def test_base_payload(self) -> None:
+        payload = ChatwootWebhookPayload(
+            event="message_created",
+            account={"id": 1},
+        )
+        assert payload.event == "message_created"
+        assert payload.account == {"id": 1}
+
+
+class TestMessageCreatedPayload:
+    """Unit tests for the MessageCreatedPayload schema."""
+
+    def test_valid_payload(self) -> None:
+        payload = MessageCreatedPayload(
+            event="message_created",
+            account={"id": 1},
+            conversation={
+                "id": 10,
+                "status": "open",
+                "inbox_id": 5,
+                "contact_id": 20,
+            },
+            sender={"id": 30, "type": "contact", "name": "John"},
+            message={"id": 100, "content": "Hello", "content_type": "text", "private": False},
+        )
+        assert payload.event == "message_created"
+        assert payload.message.content == "Hello"
+        assert payload.conversation.status == "open"
+        assert payload.sender.type == "contact"
+
+
+class TestConversationCreatedPayload:
+    """Unit tests for the ConversationCreatedPayload schema."""
+
+    def test_valid_payload(self) -> None:
+        payload = ConversationCreatedPayload(
+            event="conversation_created",
+            account={"id": 1},
+            conversation={
+                "id": 11,
+                "status": "open",
+                "inbox_id": 5,
+                "contact_id": 21,
+            },
+            sender={"id": 31, "type": "user"},
+        )
+        assert payload.event == "conversation_created"
+        assert payload.conversation.id == 11
+
+
+class TestConversationStatusChangedPayload:
+    """Unit tests for the ConversationStatusChangedPayload schema."""
+
+    def test_valid_payload(self) -> None:
+        payload = ConversationStatusChangedPayload(
+            event="conversation_status_changed",
+            account={"id": 1},
+            conversation={
+                "id": 12,
+                "status": "resolved",
+                "inbox_id": 5,
+                "contact_id": 22,
+            },
+            sender={"id": 32, "type": "agent_bot"},
+            status="resolved",
+        )
+        assert payload.event == "conversation_status_changed"
+        assert payload.status == "resolved"
+        assert payload.conversation.status == "resolved"

--- a/backend/tests/test_chatwoot_schemas.py
+++ b/backend/tests/test_chatwoot_schemas.py
@@ -104,7 +104,12 @@ class TestMessageCreatedPayload:
                 "contact_id": 20,
             },
             sender={"id": 30, "type": "contact", "name": "John"},
-            message={"id": 100, "content": "Hello", "content_type": "text", "private": False},
+            message={
+                "id": 100,
+                "content": "Hello",
+                "content_type": "text",
+                "private": False,
+            },
         )
         assert payload.event == "message_created"
         assert payload.message.content == "Hello"

--- a/backend/tests/test_config_provider.py
+++ b/backend/tests/test_config_provider.py
@@ -1,0 +1,96 @@
+"""Tests for ConfigProvider protocol and EnvConfigProvider implementation.
+
+Validates that EnvConfigProvider correctly delegates to Settings and
+provides sensible defaults for labels, channel profiles, and handoff.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from backend.app.config import Settings
+from backend.app.config_provider import ChannelProfile, ConfigProvider, EnvConfigProvider
+
+
+class TestChannelProfile:
+    """ChannelProfile must expose safe defaults."""
+
+    def test_defaults(self) -> None:
+        profile = ChannelProfile()
+        assert profile.name == "default"
+        assert profile.supports_html is False
+        assert profile.max_message_length == 4096
+
+
+class TestEnvConfigProvider:
+    """EnvConfigProvider must resolve values from Settings."""
+
+    def test_get_returns_setting_value(self) -> None:
+        settings = Settings()
+        provider = EnvConfigProvider(settings)
+        assert provider.get("escalation_confidence_threshold") == 0.4
+
+    def test_get_missing_key_returns_none(self) -> None:
+        settings = Settings()
+        provider = EnvConfigProvider(settings)
+        assert provider.get("nonexistent_key") is None
+
+    def test_get_label_bot(self) -> None:
+        settings = Settings()
+        provider = EnvConfigProvider(settings)
+        assert provider.get_label("bot") == "bot"
+
+    def test_get_label_escalated(self) -> None:
+        settings = Settings()
+        provider = EnvConfigProvider(settings)
+        assert provider.get_label("escalated") == "escalated"
+
+    def test_get_label_technical(self) -> None:
+        settings = Settings()
+        provider = EnvConfigProvider(settings)
+        assert provider.get_label("technical") == "technical"
+
+    def test_get_label_unknown_returns_name(self) -> None:
+        settings = Settings()
+        provider = EnvConfigProvider(settings)
+        assert provider.get_label("unknown") == "unknown"
+
+    def test_get_channel_profile_returns_default(self) -> None:
+        settings = Settings()
+        provider = EnvConfigProvider(settings)
+        profile = provider.get_channel_profile("1")
+        assert isinstance(profile, ChannelProfile)
+        assert profile.name == "default"
+
+    def test_get_handoff_target_defaults_none(self) -> None:
+        settings = Settings()
+        provider = EnvConfigProvider(settings)
+        assert provider.get_handoff_target() is None
+
+    def test_get_handoff_target_from_env(self) -> None:
+        env = {"CHATWOOT_HANDOFF_TEAM_ID": "5"}
+        with patch.dict(os.environ, env, clear=True):
+            settings = Settings()
+            provider = EnvConfigProvider(settings)
+            assert provider.get_handoff_target() == 5
+
+    def test_is_chatwoot_enabled_defaults_false(self) -> None:
+        settings = Settings()
+        provider = EnvConfigProvider(settings)
+        assert provider.is_chatwoot_enabled() is False
+
+    def test_is_chatwoot_enabled_true(self) -> None:
+        env = {"CHATWOOT_ENABLED": "true"}
+        with patch.dict(os.environ, env, clear=True):
+            settings = Settings()
+            provider = EnvConfigProvider(settings)
+            assert provider.is_chatwoot_enabled() is True
+
+
+class TestConfigProviderProtocol:
+    """EnvConfigProvider must satisfy the ConfigProvider protocol."""
+
+    def test_is_instance_of_protocol(self) -> None:
+        provider: ConfigProvider = EnvConfigProvider(Settings())
+        assert provider.is_chatwoot_enabled() is False

--- a/backend/tests/test_config_provider.py
+++ b/backend/tests/test_config_provider.py
@@ -7,10 +7,12 @@ provides sensible defaults for labels, channel profiles, and handoff.
 import os
 from unittest.mock import patch
 
-import pytest
-
 from backend.app.config import Settings
-from backend.app.config_provider import ChannelProfile, ConfigProvider, EnvConfigProvider
+from backend.app.config_provider import (
+    ChannelProfile,
+    ConfigProvider,
+    EnvConfigProvider,
+)
 
 
 class TestChannelProfile:

--- a/backend/tests/test_docker_compose.py
+++ b/backend/tests/test_docker_compose.py
@@ -1,0 +1,33 @@
+"""Tests for docker-compose infrastructure definitions.
+
+Validates that the redis service, volume, and healthcheck are present
+without requiring a running Docker daemon.
+"""
+
+import pathlib
+
+
+class TestDockerCompose:
+    """docker-compose.yml must contain the expected Redis configuration."""
+
+    def test_redis_service_present(self) -> None:
+        content = pathlib.Path("docker-compose.yml").read_text()
+        assert "  redis:" in content
+        assert "image: redis:7-alpine" in content
+        assert '"6379:6379"' in content
+        assert "redis_data:/data" in content
+
+    def test_redis_healthcheck_present(self) -> None:
+        content = pathlib.Path("docker-compose.yml").read_text()
+        assert '["CMD", "redis-cli", "ping"]' in content
+
+    def test_backend_depends_on_redis(self) -> None:
+        content = pathlib.Path("docker-compose.yml").read_text()
+        assert "depends_on:" in content
+        assert "redis:" in content
+        assert "condition: service_healthy" in content
+
+    def test_redis_volume_declared(self) -> None:
+        content = pathlib.Path("docker-compose.yml").read_text()
+        assert "volumes:" in content
+        assert "  redis_data:" in content

--- a/backend/tests/test_main_config_provider.py
+++ b/backend/tests/test_main_config_provider.py
@@ -1,0 +1,20 @@
+"""Tests for ConfigProvider dependency injection in backend/main.py.
+
+Validates that the ``get_config_provider`` dependency returns an
+``EnvConfigProvider`` wired to the application settings.
+"""
+
+from backend.app.config_provider import EnvConfigProvider
+from backend.main import get_config_provider
+
+
+class TestGetConfigProvider:
+    """``get_config_provider`` must expose the EnvConfigProvider singleton."""
+
+    def test_returns_env_config_provider(self) -> None:
+        provider = get_config_provider()
+        assert isinstance(provider, EnvConfigProvider)
+
+    def test_provider_reads_settings(self) -> None:
+        provider = get_config_provider()
+        assert provider.is_chatwoot_enabled() is False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,9 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
       - PORT=8000
+    depends_on:
+      redis:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s
@@ -40,3 +43,21 @@ services:
     depends_on:
       - backend
     restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    container_name: arte-chatbot-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+
+volumes:
+  redis_data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ requires-python = ">=3.11"
 dependencies = [
     "boto3>=1.42.75",
     "fastapi>=0.109.0",
-    "httpx>=0.26.0",
+    "httpx>=0.27",
     "ipywidgets>=8.1.8",
     "jsonschema>=4.21.0",
     "numpy>=2.4.4",
@@ -28,6 +28,7 @@ dependencies = [
     "pydantic>=2.5.0",
     "pydantic-settings>=2.1.0",
     "python-dotenv>=1.2.2",
+    "redis[hiredis]>=5.0",
     "requests>=2.32.5",
     "uvicorn>=0.27.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -52,6 +52,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
+    { name = "redis", extra = ["hiredis"] },
     { name = "requests" },
     { name = "uvicorn" },
 ]
@@ -73,7 +74,7 @@ typecheck = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.42.75" },
     { name = "fastapi", specifier = ">=0.109.0" },
-    { name = "httpx", specifier = ">=0.26.0" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "ipywidgets", specifier = ">=8.1.8" },
     { name = "jsonschema", specifier = ">=4.21.0" },
     { name = "numpy", specifier = ">=2.4.4" },
@@ -81,6 +82,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.5.0" },
     { name = "pydantic-settings", specifier = ">=2.1.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "redis", extras = ["hiredis"], specifier = ">=5.0" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "uvicorn", specifier = ">=0.27.0" },
 ]
@@ -101,6 +103,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
+]
+
+[[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
 ]
 
 [[package]]
@@ -318,6 +329,79 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hiredis"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/d6/9bef6dc3052c168c93fbf7e6c0f2b12c45f0f741a2d30fd919096774343a/hiredis-3.3.1.tar.gz", hash = "sha256:da6f0302360e99d32bc2869772692797ebadd536e1b826d0103c72ba49d38698", size = 89101, upload-time = "2026-03-16T15:21:08.092Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/71/b8e7da87ff0a270e086670da46732ff8e0af2fb4042afe1486846cf44ea7/hiredis-3.3.1-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:26f899cde0279e4b7d370716ff80320601c2bd93cdf3e774a42bdd44f65b41f8", size = 81823, upload-time = "2026-03-16T15:19:20.139Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e0/8bdafc6251aada93c670eb1893335bb248e10faa784f54de6b9384c7d2cb/hiredis-3.3.1-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:a2f049c3f3c83e886cd1f53958e2a1ebb369be626bef9e50d8b24d79864f1df6", size = 46043, upload-time = "2026-03-16T15:19:21.292Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/e8/48e5eee6dffb2d5659f437231341bfbf00c53d9fdb5d069ea629f1b2fa96/hiredis-3.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5f316cf2d0558f5027aab19dde7d7e4901c26c21fa95367bc37784e8f547bbf2", size = 41813, upload-time = "2026-03-16T15:19:22.404Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/e0/8dcd593db6d0e91cd797fafc565995cd28bd9d7ae85807c820b5e245ab82/hiredis-3.3.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:03baa381964b8df356d19ec4e3a6ae656044249a87b0def257fe1e08dbaf6094", size = 167570, upload-time = "2026-03-16T15:19:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e5/e2d75ecc15db51117ebd260fab4059b8a4cbbf74eb89c407c6d437bd6413/hiredis-3.3.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:304481241e081bc26f0778b2c2b99f9c43917e4e724a016dcc9439b7ab12c726", size = 179373, upload-time = "2026-03-16T15:19:24.739Z" },
+    { url = "https://files.pythonhosted.org/packages/86/9a/4fafde37b86f70125bcd01e8af5e9f448fc99f4116db6d0e9ad214fc688a/hiredis-3.3.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8597c35c9e82f65fd5897c4a2188c65d7daf10607b102960137b23d261cd957b", size = 177501, upload-time = "2026-03-16T15:19:25.982Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/73/413a17d6926c015683a608c148862f1dc7e8ad6f5c205b626607be9b9ddf/hiredis-3.3.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ad940dc2db545dc978cb41cb9a683e2ff328f3ef581230b9ca40ff6c3d01d542", size = 169446, upload-time = "2026-03-16T15:19:27.35Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/39/aa8e41d5f728dfa99f2236c1176a6b348c7577fd68ca9960d20d251d3b29/hiredis-3.3.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:156be6a0c736ee145cfe0fb155d0e96cec8d4872cf8b4f76ad6a2ee6ab391d0a", size = 164009, upload-time = "2026-03-16T15:19:28.426Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/37/85a609a2cf2b6354749bcef8f488c3298976358601cb4906bbaf2eb53944/hiredis-3.3.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:583de2f16528e66081cbdfe510d8488c2de73039dc00aada7d22bd49d73a4a94", size = 174623, upload-time = "2026-03-16T15:19:29.466Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/75e0a76e4c9021f9914cfa1de8d98cff4acd0a0eb3344d31f43c02ec9375/hiredis-3.3.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:c24c1460486b6b36083252c2db21a814becf8495ccd0e76b7286623e37239b63", size = 167649, upload-time = "2026-03-16T15:19:30.438Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/08/1212138ee61e9b72d3f561da60cf6dc15031c10117735938ac258613803f/hiredis-3.3.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a58a58cef0d911b1717154179a9ff47852249c536ea5966bde4370b6b20638ff", size = 165451, upload-time = "2026-03-16T15:19:31.404Z" },
+    { url = "https://files.pythonhosted.org/packages/46/36/cd776ef13b44afbb86c3d63c1a76b09d54cb1b545cce9e26fcd439d69606/hiredis-3.3.1-cp311-cp311-win32.whl", hash = "sha256:e0db44cf81e4d7b94f3776b9f89111f74ed6bbdbfd42a22bc4a5ce0644d3e060", size = 20399, upload-time = "2026-03-16T15:19:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/df/0e/5b2a73bea6d18e7ebda7ed73520854cdc176ba70a945bd541bdeeb3f8caa/hiredis-3.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:1f7bceb03a1b934872ffe3942eaeed7c7e09096e67b53f095b81f39c7a819113", size = 22336, upload-time = "2026-03-16T15:19:33.238Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1d/1a7d925d886211948ab9cca44221b1d9dd4d3481d015511e98794e37d369/hiredis-3.3.1-cp312-cp312-macosx_10_15_universal2.whl", hash = "sha256:60543f3b068b16a86e99ed96b7fdae71cdc1d8abdfe9b3f82032a555e52ece7e", size = 82023, upload-time = "2026-03-16T15:19:34.157Z" },
+    { url = "https://files.pythonhosted.org/packages/13/2f/a6017fe1db47cd63a4aefc0dd21dd4dcb0c4e857bfbcfaa27329745f24a3/hiredis-3.3.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:2611bfaaadc5e8d43fb7967f9bbf1110c8beaa83aee2f2d812c76f11cfb56c6a", size = 46215, upload-time = "2026-03-16T15:19:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4b/35a71d088c6934e162aa81c7e289fa3110a3aca84ab695d88dbd488c74a2/hiredis-3.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8e3754ce60e1b11b0afad9a053481ff184d2ee24bea47099107156d1b84a84aa", size = 41861, upload-time = "2026-03-16T15:19:36.32Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/54/904bc723a95926977764fefd6f0d46067579bac38fffc32b806f3f2c05c0/hiredis-3.3.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e89dabf436ee79b358fd970dcbed6333a36d91db73f27069ca24a02fb138a404", size = 170196, upload-time = "2026-03-16T15:19:37.274Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/4e840cd4cb53c28578234708b08fb9ec9e41c2880acc0e269a7264e1b3af/hiredis-3.3.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4f7e242eab698ad0be5a4b2ec616fa856569c57455cc67c625fd567726290e5f", size = 181808, upload-time = "2026-03-16T15:19:38.637Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0d/fc845f06f8203ab76c401d4d2b97f9fb768e644b053a40f441f7dcc71f2d/hiredis-3.3.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:53148a4e21057541b6d8e493b2ea1b500037ddf34433c391970036f3cbce00e3", size = 180577, upload-time = "2026-03-16T15:19:39.749Z" },
+    { url = "https://files.pythonhosted.org/packages/52/3a/859afe2620666bf6d58eb977870c47d98af4999d473b50528b323918f3f7/hiredis-3.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25132902d3eff38781e0d54f27a0942ec849e3c07dbdce83c4d92b7e43c8dce", size = 172507, upload-time = "2026-03-16T15:19:40.87Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a8/004349708ad8bf0d188d46049f846d3fe2d4a7a8d0d5a6a8ba024017d8b3/hiredis-3.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3fb6573efa15a29c12c0c0f7170b14e7c1347fe4bb39b6a15b779f46015cc929", size = 166339, upload-time = "2026-03-16T15:19:41.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/fb/bfc6df29381830c99bfd9e97ed3b6d75d9303866a28c23d51ab8c50f63e3/hiredis-3.3.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:487658e1db83c1ee9fbbac6a43039ea76957767a5987ffb16b590613f9e68297", size = 176766, upload-time = "2026-03-16T15:19:42.981Z" },
+    { url = "https://files.pythonhosted.org/packages/53/e7/f54aaad4559a413ec8b1043a89567a5a1f898426e4091b9af5e0f2120371/hiredis-3.3.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:a1d190790ee39b8b7adeeb10fc4090dc4859eb4e75ed27bd8108710eef18f358", size = 170313, upload-time = "2026-03-16T15:19:44.082Z" },
+    { url = "https://files.pythonhosted.org/packages/60/51/b80394db4c74d4cba342fa4208f690a2739c16f1125c2a62ba1701b8e2b7/hiredis-3.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a42c7becd4c9ec4ab5769c754eb61112777bdc6e1c1525e2077389e193b5f5aa", size = 167964, upload-time = "2026-03-16T15:19:45.237Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ef/5e438d1e058be57cdc1bafc1b1ec8ab43cc890c61447e88f8b878a0e32c3/hiredis-3.3.1-cp312-cp312-win32.whl", hash = "sha256:17ec8b524055a88b80d76c177dbbbe475a25c17c5bf4b67bdbdbd0629bcae838", size = 20532, upload-time = "2026-03-16T15:19:46.233Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/c6/39994b9c5646e7bf7d5e92170c07fd5f224ae9f34d95ff202f31845eb94b/hiredis-3.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:0fac4af8515e6cca74fc701169ae4dc9a71a90e9319c9d21006ec9454b43aa2f", size = 22381, upload-time = "2026-03-16T15:19:47.082Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/4b/c7f4d6d6643622f296395269e24b02c69d4ac72822f052b8cae16fa3af03/hiredis-3.3.1-cp313-cp313-macosx_10_15_universal2.whl", hash = "sha256:afe3c3863f16704fb5d7c2c6ff56aaf9e054f6d269f7b4c9074c5476178d1aba", size = 82027, upload-time = "2026-03-16T15:19:48.002Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/45/198be960a7443d6eb5045751e929480929c0defbca316ce1a47d15187330/hiredis-3.3.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:f19ee7dc1ef8a6497570d91fa4057ba910ad98297a50b8c44ff37589f7c89d17", size = 46220, upload-time = "2026-03-16T15:19:48.953Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/a4/6ab925177f289830008dbe1488a9858675e2e234f48c9c1653bd4d0eaddc/hiredis-3.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:09f5e510f637f2c72d2a79fb3ad05f7b6211e057e367ca5c4f97bb3d8c9d71f4", size = 41858, upload-time = "2026-03-16T15:19:49.939Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c8/a0ddbb9e9c27fcb0022f7b7e93abc75727cb634c6a5273ca5171033dac78/hiredis-3.3.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b46e96b50dad03495447860510daebd2c96fd44ed25ba8ccb03e9f89eaa9d34", size = 170095, upload-time = "2026-03-16T15:19:51.216Z" },
+    { url = "https://files.pythonhosted.org/packages/94/06/618d509cc454912028f71995f3dd6eb54606f0aa8163ff79c5b7ec1f2bda/hiredis-3.3.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b4fe7f38aa8956fcc1cea270e62601e0e11066aff78e384be70fd283d30293b6", size = 181745, upload-time = "2026-03-16T15:19:52.72Z" },
+    { url = "https://files.pythonhosted.org/packages/06/14/75b2deb62a61fc75a41ce1a6a781fe239133bbc88fef404d32a148ad152a/hiredis-3.3.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2b96da7e365d6488d2a75266a662cbe3cc14b28c23dd9b0c9aa04b5bc5c20192", size = 180465, upload-time = "2026-03-16T15:19:53.847Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8c/8e03dcbfde8e2ca3f880fce06ad0877b3f098ed5fdfb17cf3b821a32323a/hiredis-3.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:52d5641027d6731bc7b5e7d126a5158a99784a9f8c6de3d97ca89aca4969e9f8", size = 172419, upload-time = "2026-03-16T15:19:54.959Z" },
+    { url = "https://files.pythonhosted.org/packages/03/05/843005d68403a3805309075efc6638360a3ababa6cb4545163bf80c8e7f7/hiredis-3.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:eddeb9a153795cf6e615f9f3cef66a1d573ff3b6ee16df2b10d1d1c2f2baeaa8", size = 166398, upload-time = "2026-03-16T15:19:56.36Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/23/abe2476244fd792f5108009ec0ae666eaa5b2165ca19f2e86638d8324ac9/hiredis-3.3.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:011a9071c3df4885cac7f58a2623feac6c8e2ad30e6ba93c55195af05ce61ff5", size = 176844, upload-time = "2026-03-16T15:19:57.462Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/47/e1cdccc559b98e548bcff0868c3938d375663418c0adca465895ee1f72e7/hiredis-3.3.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:264ee7e9cb6c30dc78da4ecf71d74cf14ca122817c665d838eda8b4384bce1b0", size = 170366, upload-time = "2026-03-16T15:19:58.548Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/e1/fda8325f51d06877e8e92500b15d4aff3855b4c3c91dbd9636a82e4591f2/hiredis-3.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d1434d0bcc1b3ef048bae53f26456405c08aeed9827e65b24094f5f3a6793f1", size = 168023, upload-time = "2026-03-16T15:19:59.727Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/21/2839d1625095989c116470e2b6841bbe1a2a5509585e82a4f3f5cd47f511/hiredis-3.3.1-cp313-cp313-win32.whl", hash = "sha256:f915a34fb742e23d0d61573349aa45d6f74037fde9d58a9f340435eff8d62736", size = 20535, upload-time = "2026-03-16T15:20:00.938Z" },
+    { url = "https://files.pythonhosted.org/packages/84/f9/534c2a89b24445a9a9623beb4697fd72b8c8f16286f6f3bda012c7af004a/hiredis-3.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:d8e56e0d1fe607bfff422633f313aec9191c3859ab99d11ff097e3e6e068000c", size = 22383, upload-time = "2026-03-16T15:20:01.865Z" },
+    { url = "https://files.pythonhosted.org/packages/03/72/0450d6b449da58120c5497346eb707738f8f67b9e60c28a8ef90133fc81f/hiredis-3.3.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:439f9a5cc8f9519ce208a24cdebfa0440fef26aa682a40ba2c92acb10a53f5e0", size = 82112, upload-time = "2026-03-16T15:20:02.865Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c0/0be33a29bcd463e6cbb0282515dd4d0cdfe33c30c7afc6d4d8c460e23266/hiredis-3.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3724f0e58c6ff76fd683429945491de71324ab1bc0ad943a8d68cb0932d24075", size = 46238, upload-time = "2026-03-16T15:20:03.896Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/f999854bfaf3bcbee0f797f24706c182ecfaca825f6a582f6281a6aa97e0/hiredis-3.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:29fe35e3c6fe03204e75c86514f452591957a1e06b05d86e10d795455b71c355", size = 41891, upload-time = "2026-03-16T15:20:04.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c8/cd9ab90fec3a301d864d8ab6167aea387add8e2287969d89cbcd45d6b0e0/hiredis-3.3.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d42f3a13290f89191568fc113d95a3d2c8759cdd8c3672f021d8b7436f909e75", size = 170485, upload-time = "2026-03-16T15:20:06.284Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/9a/1ddf9ea236a292963146cbaf6722abeb9d503ca47d821267bb8b3b81c4f7/hiredis-3.3.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2afc675b831f7552da41116fffffca4340f387dc03f56d6ec0c7895ab0b59a10", size = 182030, upload-time = "2026-03-16T15:20:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/b8/e070a1dbf8a1bbb8814baa0b00836fbe3f10c7af8e11f942cc739c64e062/hiredis-3.3.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4106201cd052d9eabe3cb7b5a24b0fe37307792bda4fcb3cf6ddd72f697828e8", size = 180543, upload-time = "2026-03-16T15:20:09.096Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bb/b5f4f98e44626e2446cd8a52ce6cb1fc1c99786b6e2db3bf09cea97b90cd/hiredis-3.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8887bf0f31e4b550bd988c8863b527b6587d200653e9375cd91eea2b944b7424", size = 172356, upload-time = "2026-03-16T15:20:10.245Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/93/73a77b54ba94e82f76d02563c588d8a062513062675f483a033a43015f2c/hiredis-3.3.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1ac7697365dbe45109273b34227fee6826b276ead9a4a007e0877e1d3f0fcf21", size = 166433, upload-time = "2026-03-16T15:20:11.789Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c2/1b2dcbe5dc53a46a8cb05bed67d190a7e30bad2ad1f727ebe154dfeededd/hiredis-3.3.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2b6da6e07359107c653a809b3cff2d9ccaeedbafe33c6f16434aef6f53ce4a2b", size = 177220, upload-time = "2026-03-16T15:20:12.991Z" },
+    { url = "https://files.pythonhosted.org/packages/02/09/f4314cf096552568b5ea785ceb60c424771f4d35a76c410ad39d258f74bc/hiredis-3.3.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:ce334915f5d31048f76a42c607bf26687cf045eb1bc852b7340f09729c6a64fc", size = 170475, upload-time = "2026-03-16T15:20:14.519Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2e/3f56e438efc8fc27ed4a3dbad58c0280061466473ec35d8f86c90c841a84/hiredis-3.3.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ee11fd431f83d8a5b29d370b9d79a814d3218d30113bdcd44657e9bdf715fc92", size = 167913, upload-time = "2026-03-16T15:20:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/56/34/053e5ee91d6dc478faac661996d1fd4886c5acb7a1b5ac30e7d3c794bb51/hiredis-3.3.1-cp314-cp314-win32.whl", hash = "sha256:e0356561b4a97c83b9ee3de657a41b8d1a1781226853adaf47b550bb988fda6f", size = 21167, upload-time = "2026-03-16T15:20:17.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/33/06776c641d17881a9031e337e81b3b934c38c2adbb83c85062d6b5f83b72/hiredis-3.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:80aba5f85d6227faee628ae28d1c3b69c661806a0636548ac56c68782606454f", size = 23000, upload-time = "2026-03-16T15:20:17.966Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/5a/94f9a505b2ff5376d4a05fb279b69d89bafa7219dd33f6944026e3e56f80/hiredis-3.3.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:907f7b5501a534030738f0f27459a612d2266fd0507b007bb8f3e6de08167920", size = 83039, upload-time = "2026-03-16T15:20:19.316Z" },
+    { url = "https://files.pythonhosted.org/packages/93/ae/d3752a8f03a1fca43d402389d2a2d234d3db54c4d1f07f26c1041ca3c5de/hiredis-3.3.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:de94b409f49eb6a588ebdd5872e826caec417cd77c17af0fb94f2128427f1a2a", size = 46703, upload-time = "2026-03-16T15:20:20.401Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/76/e32c868a2fa23cd82bacaffd38649d938173244a0e717ec1c0c76874dbdd/hiredis-3.3.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:79cd03e7ff550c17758a7520bf437c156d3d4c8bb74214deeafa69cda49c85a4", size = 42379, upload-time = "2026-03-16T15:20:21.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f6/d687d36a74ce6cf448826cf2e8edfc1eb37cc965308f74eb696aa97c69df/hiredis-3.3.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6ffa7ba2e2da1f806f3181b9730b3e87ba9dbfec884806725d4584055ba3faa6", size = 180311, upload-time = "2026-03-16T15:20:23.037Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ac/f520dc0066a62a15aa920c7dd0a2028c213f4862d5f901409ae92ee5d785/hiredis-3.3.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ee37fe8cf081b72dea72f96a0ee604f492ec02252eb77dc26ff6eec3f997b580", size = 190488, upload-time = "2026-03-16T15:20:24.357Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f5/ae10fff82d0f291e90c41bf10a5d6543a96aae00cccede01bf2b6f7e178d/hiredis-3.3.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9bfdeff778d3f7ff449ca5922ab773899e7d31e26a576028b06a5e9cf0ed8c34", size = 189210, upload-time = "2026-03-16T15:20:25.51Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/8f/5be4344e542aa8d349a03d05486c59d9ca26f69c749d11e114bf34b84d50/hiredis-3.3.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:027ce4fabfeff5af5b9869d5524770877f9061d118bc36b85703ae3faf5aad8e", size = 180971, upload-time = "2026-03-16T15:20:26.631Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a2/29e230226ec2a31f13f8a832fbafe366e263f3b090553ebe49bb4581a7bd/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:dcea8c3f53674ae68e44b12e853b844a1d315250ca6677b11ec0c06aff85e86c", size = 175314, upload-time = "2026-03-16T15:20:27.848Z" },
+    { url = "https://files.pythonhosted.org/packages/89/2e/bf241707ad86b9f3ebfbc7ab89e19d5ec243ff92ca77644a383622e8740b/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0b5ff2f643f4b452b0597b7fe6aa35d398cb31d8806801acfafb1558610ea2aa", size = 185652, upload-time = "2026-03-16T15:20:29.364Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c1/b39170d8bcccd01febd45af4ac6b43ff38e134a868e2ec167a82a036fb35/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:3586c8a5f56d34b9dddaaa9e76905f31933cac267251006adf86ec0eef7d0400", size = 179033, upload-time = "2026-03-16T15:20:30.549Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/3a/4fe39a169115434f911abff08ff485b9b6201c168500e112b3f6a8110c0a/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a110d19881ca78a88583d3b07231e7c6864864f5f1f3491b638863ea45fa8708", size = 176126, upload-time = "2026-03-16T15:20:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/44/99/c1d0b0bc4f9e9150e24beb0dca2e186e32d5e749d0022e0d26453749ed51/hiredis-3.3.1-cp314-cp314t-win32.whl", hash = "sha256:98fd5b39410e9d69e10e90d0330e35650becaa5dd2548f509b9598f1f3c6124d", size = 22028, upload-time = "2026-03-16T15:20:33.33Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d6/191e6741addc97bcf5e755661f8c82f0fd0aa35f07ece56e858da689b57e/hiredis-3.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ab1f646ff531d70bfd25f01e60708dfa3d105eb458b7dedd9fe9a443039fd809", size = 23811, upload-time = "2026-03-16T15:20:34.292Z" },
 ]
 
 [[package]]
@@ -1078,6 +1162,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "redis"
+version = "7.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
+]
+
+[package.optional-dependencies]
+hiredis = [
+    { name = "hiredis" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
First slice (PR #1) of the Chatwoot integration feature branch chain. Establishes the foundation that all subsequent PRs depend on.

### What’s included
- **Dependencies**: `redis[hiredis]>=5.0` and `httpx>=0.27`
- **Docker**: Redis 7-alpine service with healthcheck and persistent volume; backend depends on Redis health
- **Env docs**: All new Chatwoot and Redis variables documented in `.env.example`
- **Settings**: 12 new Pydantic Settings fields + validator that warns when Chatwoot is enabled but misconfigured
- **Schemas**: Pydantic models for Chatwoot webhook payloads (`message_created`, `conversation_created`, `conversation_status_changed`)
- **ConfigProvider**: Protocol + `EnvConfigProvider` implementation for unified config access
- **DI wiring**: `get_config_provider()` dependency in `backend/main.py` (no behavior change to `/chat`)
- **Tests**: Full coverage for config, schemas, ConfigProvider, DI, and docker-compose validation

### TDD Evidence
All new code was written test-first (RED → GREEN → REFACTOR).

### Verification
- [x] `pytest` passes (45 new tests)
- [x] `docker compose config` validates
- [x] `ruff check` passes on new files
- [x] `ruff format` passes on new files
- [x] `.env.example` documents all new variables
- [x] Settings validator warns on misconfigured Chatwoot

### Scope boundaries
- Does NOT include `ChatwootHandler`, `ChatwootClient`, or `RedisCache` (PR #2)
- Does NOT modify `MessageBuffer` or `SessionManager` (PR #3)
- Does NOT add webhook endpoint (PR #4)