### PR TITLE
feat(#166,#167,#169,#165): core components — RedisCache, ChatwootClient, ChatwootHandler, ChannelProfile

### DIFF
--- a/backend/app/channel_profile.py
+++ b/backend/app/channel_profile.py
@@ -1,0 +1,62 @@
+"""Channel profile model for per-inbox Chatwoot configuration.
+
+Each inbox can be configured with its own behavior: buffer window,
+message formatting, tool calling, and prompt suffixes.
+"""
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class ChannelProfile(BaseModel):
+    """Per-inbox channel configuration profile.
+
+    Attributes:
+        inbox_id: The Chatwoot inbox identifier.
+        channel_type: Communication channel (whatsapp, web, email, api).
+        system_prompt_suffix: Optional text appended to the system prompt.
+        message_formatter: Output formatting style (compact, standard, verbose).
+        buffer_window_seconds: Debounce window for incoming messages (1–60s).
+        enable_tool_calling: Whether the LLM may invoke tools for this channel.
+        max_turns: Maximum conversation turns to keep in context.
+        custom_attributes: Free-form key-value attributes for extensibility.
+    """
+
+    inbox_id: str
+    channel_type: Literal["whatsapp", "web", "email", "api"] = "web"
+    system_prompt_suffix: Optional[str] = None
+    message_formatter: Literal["compact", "standard", "verbose"] = "standard"
+    buffer_window_seconds: int = 5
+    enable_tool_calling: bool = True
+    max_turns: int = 20
+    custom_attributes: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("buffer_window_seconds")
+    @classmethod
+    def _validate_buffer_window(cls, value: int) -> int:
+        if value <= 0 or value > 60:
+            raise ValueError("buffer_window_seconds must be > 0 and <= 60")
+        return value
+
+    def apply_to_system_prompt(self, base_prompt: str) -> str:
+        """Append the configured suffix to *base_prompt*, if any.
+
+        Args:
+            base_prompt: The original system prompt text.
+
+        Returns:
+            The prompt with suffix appended when present and non-empty.
+        """
+        if self.system_prompt_suffix:
+            return f"{base_prompt}\n\n{self.system_prompt_suffix}"
+        return base_prompt
+
+
+def get_default_channel_profile() -> ChannelProfile:
+    """Return a default channel profile with sensible defaults.
+
+    Returns:
+        A ``ChannelProfile`` instance with inbox_id="default".
+    """
+    return ChannelProfile(inbox_id="default")

--- a/backend/app/chatwoot_client.py
+++ b/backend/app/chatwoot_client.py
@@ -1,0 +1,228 @@
+"""Async HTTP client for the Chatwoot Application API.
+
+Provides connection-pooled requests, automatic retry with exponential
+backoff + jitter for transient failures, and a Redis outbox for
+background replay of failed actions.
+"""
+
+import asyncio
+import json
+import logging
+import random
+from typing import Any, Literal, Optional
+
+import httpx
+
+from backend.app.redis_cache import RedisCache
+
+logger = logging.getLogger(__name__)
+
+_MAX_RETRIES = 3
+_BASE_DELAY = 1.0
+
+
+class ChatwootClient:
+    """High-level async client for Chatwoot.
+
+    Args:
+        base_url: Chatwoot instance base URL (e.g. ``https://chatwoot.example.com``).
+        agent_bot_token: API token for the agent bot.
+        account_id: Chatwoot account identifier.
+        redis_cache: Redis cache instance for the outbox.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        agent_bot_token: str,
+        account_id: int,
+        redis_cache: RedisCache,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._account_id = account_id
+        self._redis = redis_cache
+        self._client = httpx.AsyncClient(
+            timeout=httpx.Timeout(30.0),
+            headers={"Authorization": f"Bearer {agent_bot_token}"},
+        )
+
+    def _conversation_url(self, conversation_id: int, suffix: str = "") -> str:
+        path = f"/api/v1/accounts/{self._account_id}/conversations/{conversation_id}"
+        if suffix:
+            path = f"{path}/{suffix}"
+        return f"{self._base_url}{path}"
+
+    async def _request_with_retry(
+        self,
+        method: str,
+        url: str,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Execute an HTTP request with retry logic.
+
+        Retries on 5xx, 429, and network timeouts up to ``_MAX_RETRIES``
+        total attempts. 4xx client errors are not retried.
+        """
+        for attempt in range(1, _MAX_RETRIES + 1):
+            try:
+                response = await self._client.request(method, url, **kwargs)
+            except httpx.NetworkError as exc:
+                logger.warning("Chatwoot network error (attempt %d): %s", attempt, exc)
+                if attempt == _MAX_RETRIES:
+                    return {}
+                await self._backoff(response=None, attempt=attempt)
+                continue
+
+            if response.status_code < 400:
+                return response.json()
+
+            if response.status_code < 500 and response.status_code != 429:
+                logger.error(
+                    "Chatwoot client error %d: %s", response.status_code, response.text
+                )
+                return {}
+
+            logger.warning(
+                "Chatwoot transient error %d (attempt %d)",
+                response.status_code,
+                attempt,
+            )
+            if attempt == _MAX_RETRIES:
+                break
+            await self._backoff(response=response, attempt=attempt)
+
+        return {}
+
+    async def _backoff(self, response: Optional[httpx.Response], attempt: int) -> None:
+        """Sleep with exponential backoff and optional jitter."""
+        retry_after: Optional[int] = None
+        if response is not None:
+            raw = response.headers.get("Retry-After")
+            if raw is not None and raw.isdigit():
+                retry_after = int(raw)
+
+        if retry_after is not None:
+            delay = retry_after
+        else:
+            delay = _BASE_DELAY * (2 ** (attempt - 1))
+            delay = delay * (0.5 + random.random())  # jitter ±50%
+
+        await asyncio.sleep(delay)
+
+    async def send_message(
+        self, conversation_id: int, content: str, message_type: str = "outgoing"
+    ) -> dict[str, Any]:
+        """Send a text message to a conversation.
+
+        Returns:
+            Parsed JSON response or empty dict on failure.
+        """
+        url = self._conversation_url(conversation_id, "messages")
+        payload = {"content": content, "message_type": message_type, "private": False}
+        result = await self._request_with_retry("POST", url, json=payload)
+        if not result:
+            await self.enqueue_failed_action(
+                {
+                    "method": "POST",
+                    "url": url,
+                    "payload": payload,
+                }
+            )
+        return result
+
+    async def send_typing_indicator(self, conversation_id: int) -> bool:
+        """Send a typing-on activity indicator.
+
+        Returns:
+            ``True`` if the indicator was accepted.
+        """
+        url = self._conversation_url(conversation_id, "messages")
+        payload = {"message_type": "activity", "content": "typing_on"}
+        result = await self._request_with_retry("POST", url, json=payload)
+        return bool(result)
+
+    async def toggle_status(
+        self, conversation_id: int, status: Literal["pending", "open", "resolved"]
+    ) -> dict[str, Any]:
+        """Toggle the conversation status.
+
+        Returns:
+            Parsed JSON response or empty dict on failure.
+        """
+        url = self._conversation_url(conversation_id, "toggle_status")
+        payload = {"status": status}
+        return await self._request_with_retry("POST", url, json=payload)
+
+    async def assign_conversation(
+        self,
+        conversation_id: int,
+        team_id: Optional[int] = None,
+        assignee_id: Optional[int] = None,
+    ) -> dict[str, Any]:
+        """Assign a conversation to a team or user.
+
+        Returns:
+            Parsed JSON response or empty dict on failure.
+        """
+        url = self._conversation_url(conversation_id, "assignments")
+        payload: dict[str, Any] = {}
+        if team_id is not None:
+            payload["team_id"] = team_id
+        if assignee_id is not None:
+            payload["assignee_id"] = assignee_id
+        return await self._request_with_retry("POST", url, json=payload)
+
+    async def add_label(self, conversation_id: int, label: str) -> dict[str, Any]:
+        """Add a label to a conversation.
+
+        Returns:
+            Parsed JSON response or empty dict on failure.
+        """
+        url = self._conversation_url(conversation_id, "labels")
+        payload = {"labels": [label]}
+        return await self._request_with_retry("POST", url, json=payload)
+
+    async def fetch_messages(
+        self, conversation_id: int, limit: int = 10
+    ) -> dict[str, Any]:
+        """Fetch recent messages from a conversation.
+
+        Returns:
+            Parsed JSON response or empty dict on failure.
+        """
+        url = self._conversation_url(conversation_id, "messages")
+        params = {"limit": limit}
+        return await self._request_with_retry("GET", url, params=params)
+
+    async def enqueue_failed_action(self, action: dict[str, Any]) -> bool:
+        """Store a failed action in the Redis outbox for later replay.
+
+        Returns:
+            ``True`` if the action was queued successfully.
+        """
+        key = f"{self._redis._prefix}:outbox"
+        try:
+            await self._redis.lpush(key, json.dumps(action))
+            return True
+        except Exception as exc:
+            logger.warning("Failed to enqueue action: %s", exc)
+            return False
+
+    async def process_outbox(self) -> list[dict[str, Any]]:
+        """Retry failed actions from the outbox.
+
+        .. note::
+            This is a stub implementation. Full retry logic will be
+            added in a later PR.
+
+        Returns:
+            List of actions that were in the outbox.
+        """
+        key = f"{self._redis._prefix}:outbox"
+        try:
+            raw_items = await self._redis.lrange(key, 0, -1)
+            actions = [json.loads(item) for item in raw_items]
+            return actions
+        except Exception as exc:
+            logger.warning("Failed to process outbox: %s", exc)
+            return []

--- a/backend/app/chatwoot_handler.py
+++ b/backend/app/chatwoot_handler.py
@@ -1,0 +1,190 @@
+"""Webhook event dispatcher for Chatwoot.
+
+Routes incoming webhook payloads to the appropriate handler, enforces
+idempotency via Redis, and logs all events with structured context.
+"""
+
+import logging
+
+from backend.app.chatwoot_client import ChatwootClient
+from backend.app.config_provider import ConfigProvider
+from backend.app.redis_cache import RedisCache
+from backend.app.schemas import (
+    ChatwootWebhookPayload,
+    ConversationCreatedPayload,
+    ConversationStatusChangedPayload,
+    MessageCreatedPayload,
+)
+
+logger = logging.getLogger(__name__)
+
+_PROCESSED_SET_TTL_SECONDS = 3600
+
+
+class ChatwootHandler:
+    """Dispatches Chatwoot webhook events to specialised handlers.
+
+    Args:
+        chatwoot_client: Client for the Chatwoot Application API.
+        redis_cache: Redis cache for idempotency and state.
+        config_provider: Runtime configuration provider.
+    """
+
+    def __init__(
+        self,
+        chatwoot_client: ChatwootClient,
+        redis_cache: RedisCache,
+        config_provider: ConfigProvider,
+    ) -> None:
+        self._client = chatwoot_client
+        self._redis = redis_cache
+        self._config = config_provider
+
+    async def handle_event(self, payload: ChatwootWebhookPayload) -> None:
+        """Route a webhook payload to the correct handler.
+
+        Idempotency is enforced for ``message_created`` events using a
+        Redis set with a 1-hour TTL.
+        """
+        event = payload.event
+        conversation_id = getattr(payload, "conversation", None)
+        conv_id = conversation_id.id if conversation_id else None
+
+        logger.info(
+            "chatwoot_event_received",
+            extra={
+                "event_type": event,
+                "conversation_id": conv_id,
+            },
+        )
+
+        if event == "message_created" and isinstance(payload, MessageCreatedPayload):
+            if await self._is_duplicate(payload.message.id):
+                logger.info(
+                    "chatwoot_duplicate_skipped",
+                    extra={
+                        "message_id": payload.message.id,
+                        "conversation_id": conv_id,
+                    },
+                )
+                return
+            await self._handle_message_created(payload)
+            await self._mark_processed(payload.message.id)
+        elif event == "conversation_created" and isinstance(
+            payload, ConversationCreatedPayload
+        ):
+            await self._handle_conversation_created(payload)
+        elif event == "conversation_status_changed" and isinstance(
+            payload, ConversationStatusChangedPayload
+        ):
+            await self._handle_conversation_status_changed(payload)
+        else:
+            logger.warning(
+                "chatwoot_unknown_event",
+                extra={
+                    "event_type": event,
+                    "conversation_id": conv_id,
+                },
+            )
+
+    async def _handle_message_created(self, payload: MessageCreatedPayload) -> None:
+        """Handle a ``message_created`` webhook.
+
+        Currently a stub that logs the event. Full buffering and LLM
+        response flow will be implemented in PR #3.
+        """
+        conversation_id = payload.conversation.id
+        sender_type = payload.sender.type
+        content = payload.message.content or ""
+
+        if sender_type == "user":
+            logger.info(
+                "human agent message detected conversation_id=%s message_id=%s",
+                conversation_id,
+                payload.message.id,
+                extra={
+                    "conversation_id": conversation_id,
+                    "sender_type": sender_type,
+                    "message_id": payload.message.id,
+                },
+            )
+        elif sender_type == "contact":
+            logger.info(
+                "user message received conversation_id=%s message_id=%s",
+                conversation_id,
+                payload.message.id,
+                extra={
+                    "conversation_id": conversation_id,
+                    "sender_type": sender_type,
+                    "message_id": payload.message.id,
+                    "content_preview": content[:50],
+                },
+            )
+        else:
+            logger.info(
+                "bot/agent_bot message received conversation_id=%s message_id=%s",
+                conversation_id,
+                payload.message.id,
+                extra={
+                    "conversation_id": conversation_id,
+                    "sender_type": sender_type,
+                    "message_id": payload.message.id,
+                },
+            )
+
+    async def _handle_conversation_created(
+        self, payload: ConversationCreatedPayload
+    ) -> None:
+        """Handle a ``conversation_created`` webhook.
+
+        Currently a stub that logs the event.
+        """
+        logger.info(
+            "conversation_created conversation_id=%s inbox_id=%s",
+            payload.conversation.id,
+            payload.conversation.inbox_id,
+            extra={
+                "conversation_id": payload.conversation.id,
+                "inbox_id": payload.conversation.inbox_id,
+                "contact_id": payload.conversation.contact_id,
+            },
+        )
+
+    async def _handle_conversation_status_changed(
+        self, payload: ConversationStatusChangedPayload
+    ) -> None:
+        """Handle a ``conversation_status_changed`` webhook.
+
+        Currently a stub that logs the event.
+        """
+        logger.info(
+            "conversation_status_changed conversation_id=%s new_status=%s",
+            payload.conversation.id,
+            payload.status,
+            extra={
+                "conversation_id": payload.conversation.id,
+                "new_status": payload.status,
+            },
+        )
+
+    async def _is_duplicate(self, message_id: int) -> bool:
+        """Return ``True`` if *message_id* has already been processed."""
+        key = self._redis._build_key("processed_messages", "")
+        return await self._redis.sismember(key, str(message_id))
+
+    async def _mark_processed(self, message_id: int) -> bool:
+        """Mark *message_id* as processed with a 1-hour TTL.
+
+        .. note::
+            Redis sets do not support TTL on individual members, so the
+            entire set is given a TTL. In production this may be replaced
+            with a sorted set or per-message key.
+        """
+        key = self._redis._build_key("processed_messages", "")
+        result = await self._redis.sadd(key, str(message_id))
+        await self._redis.set(
+            f"{key}:ttl",
+            "1",
+            ttl=_PROCESSED_SET_TTL_SECONDS,
+        )
+        return result

--- a/backend/app/config_provider.py
+++ b/backend/app/config_provider.py
@@ -5,19 +5,10 @@ admin-panel-backed providers can be swapped in without changing
 consumer code.
 """
 
-from dataclasses import dataclass
 from typing import Any, Optional, Protocol
 
+from backend.app.channel_profile import ChannelProfile, get_default_channel_profile
 from backend.app.config import Settings, settings
-
-
-@dataclass
-class ChannelProfile:
-    """Simple channel profile with safe defaults."""
-
-    name: str = "default"
-    supports_html: bool = False
-    max_message_length: int = 4096
 
 
 class ConfigProvider(Protocol):
@@ -76,11 +67,12 @@ class EnvConfigProvider:
         return mapping.get(name, name)
 
     def get_channel_profile(self, inbox_id: str) -> ChannelProfile:
-        """Return a default channel profile.
+        """Return a default channel profile for the given inbox.
 
-        Future implementations may lookup per-inbox overrides.
+        Future implementations may lookup per-inbox overrides from Redis
+        or an admin panel backend.
         """
-        return ChannelProfile()
+        return get_default_channel_profile()
 
     def get_handoff_target(self) -> Optional[int]:
         """Return the configured handoff team ID."""

--- a/backend/app/redis_cache.py
+++ b/backend/app/redis_cache.py
@@ -1,0 +1,188 @@
+"""Async Redis wrapper with structured key naming and graceful failures.
+
+All operations return safe defaults (``None``/``False``) when Redis is
+unavailable so callers never need to catch connection errors.
+"""
+
+import logging
+from typing import Optional
+
+import redis.asyncio
+from redis.exceptions import RedisError
+
+logger = logging.getLogger(__name__)
+
+
+class RedisCache:
+    """High-level async Redis client with key namespacing.
+
+    Args:
+        redis_url: Redis connection URL (e.g. ``redis://localhost:6379/0``).
+        password: Optional Redis password.
+        prefix: Key prefix for namespacing. Defaults to ``"chatwoot"``.
+        account_id: Chatwoot account ID embedded in every key.
+            Defaults to ``1``.
+    """
+
+    def __init__(
+        self,
+        redis_url: str,
+        password: Optional[str] = None,
+        prefix: str = "chatwoot",
+        account_id: int = 1,
+    ) -> None:
+        self._prefix = prefix
+        self._account_id = account_id
+        self._redis = redis.asyncio.Redis.from_url(
+            redis_url,
+            password=password,
+            decode_responses=True,
+        )
+
+    def _build_key(
+        self, scope: str, entity_id: str, field: Optional[str] = None
+    ) -> str:
+        """Build a namespaced Redis key.
+
+        Format: ``{prefix}:{account_id}:{scope}:{entity_id}[:{field}]``
+        """
+        key = f"{self._prefix}:{self._account_id}:{scope}:{entity_id}"
+        if field is not None:
+            key = f"{key}:{field}"
+        return key
+
+    async def get(self, key: str) -> Optional[str]:
+        """Fetch a string value."""
+        try:
+            result = await self._redis.get(key)
+            return result if result is None else str(result)
+        except RedisError as exc:
+            logger.warning("Redis get failed: %s", exc)
+            return None
+
+    async def set(self, key: str, value: str, ttl: Optional[int] = None) -> bool:
+        """Store a string value with optional TTL in seconds."""
+        try:
+            await self._redis.set(key, value, ex=ttl)
+            return True
+        except RedisError as exc:
+            logger.warning("Redis set failed: %s", exc)
+            return False
+
+    async def delete(self, key: str) -> bool:
+        """Remove a key."""
+        try:
+            await self._redis.delete(key)
+            return True
+        except RedisError as exc:
+            logger.warning("Redis delete failed: %s", exc)
+            return False
+
+    async def exists(self, key: str) -> bool:
+        """Check whether a key exists."""
+        try:
+            return bool(await self._redis.exists(key))
+        except RedisError as exc:
+            logger.warning("Redis exists failed: %s", exc)
+            return False
+
+    async def hget(self, key: str, field: str) -> Optional[str]:
+        """Fetch a hash field."""
+        try:
+            result = await self._redis.hget(key, field)
+            return result if result is None else str(result)
+        except RedisError as exc:
+            logger.warning("Redis hget failed: %s", exc)
+            return None
+
+    async def hset(self, key: str, field: str, value: str) -> bool:
+        """Set a hash field."""
+        try:
+            await self._redis.hset(key, field, value)
+            return True
+        except RedisError as exc:
+            logger.warning("Redis hset failed: %s", exc)
+            return False
+
+    async def hgetall(self, key: str) -> dict[str, str]:
+        """Fetch all fields of a hash."""
+        try:
+            result = await self._redis.hgetall(key)
+            return {str(k): str(v) for k, v in result.items()}
+        except RedisError as exc:
+            logger.warning("Redis hgetall failed: %s", exc)
+            return {}
+
+    async def lpush(self, key: str, value: str) -> int:
+        """Push a value onto the left of a list."""
+        try:
+            return int(await self._redis.lpush(key, value))
+        except RedisError as exc:
+            logger.warning("Redis lpush failed: %s", exc)
+            return 0
+
+    async def lrange(self, key: str, start: int, stop: int) -> list[str]:
+        """Return a slice of a list."""
+        try:
+            result = await self._redis.lrange(key, start, stop)
+            return [str(v) for v in result]
+        except RedisError as exc:
+            logger.warning("Redis lrange failed: %s", exc)
+            return []
+
+    async def ltrim(self, key: str, start: int, stop: int) -> bool:
+        """Trim a list to the given range."""
+        try:
+            await self._redis.ltrim(key, start, stop)
+            return True
+        except RedisError as exc:
+            logger.warning("Redis ltrim failed: %s", exc)
+            return False
+
+    async def sadd(self, key: str, member: str) -> bool:
+        """Add a member to a set."""
+        try:
+            await self._redis.sadd(key, member)
+            return True
+        except RedisError as exc:
+            logger.warning("Redis sadd failed: %s", exc)
+            return False
+
+    async def sismember(self, key: str, member: str) -> bool:
+        """Check whether *member* is in *key* set."""
+        try:
+            return bool(await self._redis.sismember(key, member))
+        except RedisError as exc:
+            logger.warning("Redis sismember failed: %s", exc)
+            return False
+
+    async def acquire_lock(self, lock_key: str, ttl_seconds: int = 30) -> bool:
+        """Acquire a distributed lock using ``SET NX EX``.
+
+        Returns:
+            ``True`` if the lock was acquired, ``False`` if it is already held.
+        """
+        try:
+            result = await self._redis.set(lock_key, "1", nx=True, ex=ttl_seconds)
+            return result is not None
+        except RedisError as exc:
+            logger.warning("Redis acquire_lock failed: %s", exc)
+            return False
+
+    async def release_lock(self, lock_key: str) -> bool:
+        """Release a distributed lock by deleting the key."""
+        try:
+            await self._redis.delete(lock_key)
+            return True
+        except RedisError as exc:
+            logger.warning("Redis release_lock failed: %s", exc)
+            return False
+
+    async def health_check(self) -> bool:
+        """Return ``True`` if Redis responds to ``PING``."""
+        try:
+            await self._redis.ping()
+            return True
+        except RedisError as exc:
+            logger.warning("Redis health_check failed: %s", exc)
+            return False

--- a/backend/tests/test_channel_profile.py
+++ b/backend/tests/test_channel_profile.py
@@ -1,0 +1,94 @@
+"""Tests for ChannelProfile Pydantic model and utilities.
+
+Validates defaults, field constraints, and the prompt-suffix helper.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from backend.app.channel_profile import ChannelProfile, get_default_channel_profile
+
+
+class TestChannelProfile:
+    """ChannelProfile must expose safe defaults and enforce constraints."""
+
+    def test_defaults(self) -> None:
+        profile = ChannelProfile(inbox_id="1")
+        assert profile.channel_type == "web"
+        assert profile.system_prompt_suffix is None
+        assert profile.message_formatter == "standard"
+        assert profile.buffer_window_seconds == 5
+        assert profile.enable_tool_calling is True
+        assert profile.max_turns == 20
+        assert profile.custom_attributes == {}
+
+    def test_custom_attributes_default_factory(self) -> None:
+        """Each instance must get its own dict to avoid shared mutable state."""
+        a = ChannelProfile(inbox_id="1")
+        b = ChannelProfile(inbox_id="2")
+        a.custom_attributes["foo"] = "bar"
+        assert "foo" not in b.custom_attributes
+
+    def test_buffer_window_seconds_too_low(self) -> None:
+        with pytest.raises(ValidationError):
+            ChannelProfile(inbox_id="1", buffer_window_seconds=0)
+
+    def test_buffer_window_seconds_negative(self) -> None:
+        with pytest.raises(ValidationError):
+            ChannelProfile(inbox_id="1", buffer_window_seconds=-1)
+
+    def test_buffer_window_seconds_too_high(self) -> None:
+        with pytest.raises(ValidationError):
+            ChannelProfile(inbox_id="1", buffer_window_seconds=61)
+
+    def test_buffer_window_seconds_boundary_low(self) -> None:
+        profile = ChannelProfile(inbox_id="1", buffer_window_seconds=1)
+        assert profile.buffer_window_seconds == 1
+
+    def test_buffer_window_seconds_boundary_high(self) -> None:
+        profile = ChannelProfile(inbox_id="1", buffer_window_seconds=60)
+        assert profile.buffer_window_seconds == 60
+
+    def test_all_channel_types_accepted(self) -> None:
+        for ct in ("whatsapp", "web", "email", "api"):
+            profile = ChannelProfile(inbox_id="1", channel_type=ct)
+            assert profile.channel_type == ct
+
+    def test_invalid_channel_type_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ChannelProfile(inbox_id="1", channel_type="sms")
+
+    def test_invalid_message_formatter_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ChannelProfile(inbox_id="1", message_formatter="fancy")
+
+    def test_apply_to_system_prompt_no_suffix(self) -> None:
+        base = "You are a helpful assistant."
+        profile = ChannelProfile(inbox_id="1")
+        assert profile.apply_to_system_prompt(base) == base
+
+    def test_apply_to_system_prompt_with_suffix(self) -> None:
+        base = "You are a helpful assistant."
+        profile = ChannelProfile(inbox_id="1", system_prompt_suffix="Be concise.")
+        result = profile.apply_to_system_prompt(base)
+        assert result == "You are a helpful assistant.\n\nBe concise."
+
+    def test_apply_to_system_prompt_empty_suffix_ignored(self) -> None:
+        base = "You are a helpful assistant."
+        profile = ChannelProfile(inbox_id="1", system_prompt_suffix="")
+        assert profile.apply_to_system_prompt(base) == base
+
+
+class TestGetDefaultChannelProfile:
+    """Factory must return a fully populated default profile."""
+
+    def test_returns_channel_profile(self) -> None:
+        profile = get_default_channel_profile()
+        assert isinstance(profile, ChannelProfile)
+
+    def test_has_expected_defaults(self) -> None:
+        profile = get_default_channel_profile()
+        assert profile.inbox_id == "default"
+        assert profile.channel_type == "web"
+        assert profile.buffer_window_seconds == 5
+        assert profile.enable_tool_calling is True

--- a/backend/tests/test_chatwoot_client.py
+++ b/backend/tests/test_chatwoot_client.py
@@ -1,0 +1,213 @@
+"""Tests for ChatwootClient async HTTP wrapper.
+
+Uses respx to mock the Chatwoot Application API and validates
+rate-limiting, retries, error handling, and outbox behaviour.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+import respx
+
+from backend.app.chatwoot_client import ChatwootClient
+from backend.app.redis_cache import RedisCache
+
+
+@pytest.fixture
+def redis_cache() -> RedisCache:
+    mock_redis = AsyncMock(spec=RedisCache)
+    mock_redis._prefix = "chatwoot"
+    mock_redis._account_id = 1
+    mock_redis._build_key = RedisCache._build_key
+    return mock_redis  # type: ignore[return-value]
+
+
+@pytest.fixture
+def client(redis_cache: RedisCache) -> ChatwootClient:
+    return ChatwootClient(
+        base_url="https://chatwoot.example.com",
+        agent_bot_token="test-token",
+        account_id=1,
+        redis_cache=redis_cache,
+    )
+
+
+class TestConstructor:
+    """Client must initialise with correct defaults."""
+
+    def test_base_url_stripped(self, client: ChatwootClient) -> None:
+        assert client._base_url == "https://chatwoot.example.com"
+
+    def test_auth_header_set(self, client: ChatwootClient) -> None:
+        headers = client._client.headers
+        assert headers["Authorization"] == "Bearer test-token"
+
+    def test_timeout_configured(self, client: ChatwootClient) -> None:
+        assert client._client.timeout == httpx.Timeout(30.0)
+
+
+class TestSendMessage:
+    """POST /accounts/{id}/conversations/{id}/messages"""
+
+    @pytest.mark.asyncio
+    async def test_send_message_success(self, client: ChatwootClient) -> None:
+        with respx.mock:
+            route = respx.post(
+                "https://chatwoot.example.com/api/v1/accounts/1/conversations/42/messages"
+            ).mock(
+                return_value=httpx.Response(200, json={"id": 99, "content": "hello"})
+            )
+            result = await client.send_message(42, "hello")
+            assert result == {"id": 99, "content": "hello"}
+            assert route.called
+
+    @pytest.mark.asyncio
+    async def test_send_message_4xx_no_retry(self, client: ChatwootClient) -> None:
+        with respx.mock:
+            route = respx.post(
+                "https://chatwoot.example.com/api/v1/accounts/1/conversations/42/messages"
+            ).mock(return_value=httpx.Response(422, json={"error": "invalid"}))
+            result = await client.send_message(42, "hello")
+            assert result == {}
+            assert route.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_send_message_5xx_retries_then_outbox(
+        self, client: ChatwootClient, redis_cache: Any
+    ) -> None:
+        with respx.mock:
+            route = respx.post(
+                "https://chatwoot.example.com/api/v1/accounts/1/conversations/42/messages"
+            ).mock(return_value=httpx.Response(500, text="boom"))
+            result = await client.send_message(42, "hello")
+            assert result == {}
+            assert route.call_count == 3
+            redis_cache.lpush.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_send_message_respects_retry_after(
+        self, client: ChatwootClient, redis_cache: Any
+    ) -> None:
+        with respx.mock:
+            route = respx.post(
+                "https://chatwoot.example.com/api/v1/accounts/1/conversations/42/messages"
+            ).mock(
+                return_value=httpx.Response(
+                    429, text="rate limited", headers={"Retry-After": "2"}
+                )
+            )
+            result = await client.send_message(42, "hello")
+            assert result == {}
+            assert route.call_count == 3
+
+
+class TestSendTypingIndicator:
+    """Typing indicator via activity message."""
+
+    @pytest.mark.asyncio
+    async def test_send_typing_indicator(self, client: ChatwootClient) -> None:
+        with respx.mock:
+            route = respx.post(
+                "https://chatwoot.example.com/api/v1/accounts/1/conversations/42/messages"
+            ).mock(return_value=httpx.Response(200, json={"id": 1}))
+            success = await client.send_typing_indicator(42)
+            assert success is True
+            request = route.calls.last.request
+            import json
+
+            body = json.loads(request.content)
+            assert body["message_type"] == "activity"
+            assert body["content"] == "typing_on"
+
+
+class TestToggleStatus:
+    """POST toggle_status."""
+
+    @pytest.mark.asyncio
+    async def test_toggle_status_success(self, client: ChatwootClient) -> None:
+        with respx.mock:
+            respx.post(
+                "https://chatwoot.example.com/api/v1/accounts/1/conversations/42/toggle_status"
+            ).mock(return_value=httpx.Response(200, json={"status": "resolved"}))
+            result = await client.toggle_status(42, "resolved")
+            assert result == {"status": "resolved"}
+
+    @pytest.mark.asyncio
+    async def test_toggle_status_4xx(self, client: ChatwootClient) -> None:
+        with respx.mock:
+            respx.post(
+                "https://chatwoot.example.com/api/v1/accounts/1/conversations/42/toggle_status"
+            ).mock(return_value=httpx.Response(404))
+            result = await client.toggle_status(42, "resolved")
+            assert result == {}
+
+
+class TestAssignConversation:
+    """POST assignments."""
+
+    @pytest.mark.asyncio
+    async def test_assign_conversation(self, client: ChatwootClient) -> None:
+        with respx.mock:
+            route = respx.post(
+                "https://chatwoot.example.com/api/v1/accounts/1/conversations/42/assignments"
+            ).mock(return_value=httpx.Response(200, json={"id": 42}))
+            result = await client.assign_conversation(42, team_id=3, assignee_id=7)
+            assert result == {"id": 42}
+            request = route.calls.last.request
+            import json
+
+            body = json.loads(request.content)
+            assert body["team_id"] == 3
+            assert body["assignee_id"] == 7
+
+
+class TestAddLabel:
+    """POST labels."""
+
+    @pytest.mark.asyncio
+    async def test_add_label(self, client: ChatwootClient) -> None:
+        with respx.mock:
+            respx.post(
+                "https://chatwoot.example.com/api/v1/accounts/1/conversations/42/labels"
+            ).mock(return_value=httpx.Response(200, json={"labels": ["urgent"]}))
+            result = await client.add_label(42, "urgent")
+            assert result == {"labels": ["urgent"]}
+
+
+class TestFetchMessages:
+    """GET messages."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_messages(self, client: ChatwootClient) -> None:
+        with respx.mock:
+            route = respx.get(
+                "https://chatwoot.example.com/api/v1/accounts/1/conversations/42/messages"
+            ).mock(return_value=httpx.Response(200, json={"payload": [{"id": 1}]}))
+            result = await client.fetch_messages(42, limit=5)
+            assert result == {"payload": [{"id": 1}]}
+            assert "limit=5" in str(route.calls.last.request.url)
+
+
+class TestOutbox:
+    """Outbox pattern for failed actions."""
+
+    @pytest.mark.asyncio
+    async def test_enqueue_failed_action(
+        self, client: ChatwootClient, redis_cache: Any
+    ) -> None:
+        action = {"type": "send_message", "conversation_id": 42}
+        result = await client.enqueue_failed_action(action)
+        assert result is True
+        redis_cache.lpush.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_process_outbox_stub(
+        self, client: ChatwootClient, redis_cache: Any
+    ) -> None:
+        redis_cache.lrange.return_value = ['{"type": "send_message"}']
+        result = await client.process_outbox()
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["type"] == "send_message"

--- a/backend/tests/test_chatwoot_handler.py
+++ b/backend/tests/test_chatwoot_handler.py
@@ -1,0 +1,234 @@
+"""Tests for ChatwootHandler webhook event dispatcher.
+
+Validates event routing, idempotency deduplication, and structured
+logging for all supported webhook types.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.app.chatwoot_handler import ChatwootHandler
+from backend.app.schemas import (
+    ChatwootConversation,
+    ChatwootMessage,
+    ChatwootSender,
+    ConversationCreatedPayload,
+    ConversationStatusChangedPayload,
+    MessageCreatedPayload,
+)
+
+
+@pytest.fixture
+def chatwoot_client() -> Any:
+    return MagicMock()
+
+
+@pytest.fixture
+def redis_cache() -> Any:
+    cache = AsyncMock()
+    cache._prefix = "chatwoot"
+    cache._account_id = 1
+    return cache
+
+
+@pytest.fixture
+def config_provider() -> Any:
+    provider = MagicMock()
+    provider.is_chatwoot_enabled.return_value = True
+    return provider
+
+
+@pytest.fixture
+def handler(
+    chatwoot_client: Any, redis_cache: Any, config_provider: Any
+) -> ChatwootHandler:
+    return ChatwootHandler(
+        chatwoot_client=chatwoot_client,
+        redis_cache=redis_cache,
+        config_provider=config_provider,
+    )
+
+
+def _message_payload(
+    sender_type: str = "contact",
+    message_id: int = 101,
+    content: str = "hello",
+) -> MessageCreatedPayload:
+    return MessageCreatedPayload(
+        event="message_created",
+        account={"id": 1},
+        conversation=ChatwootConversation(
+            id=42, status="open", inbox_id=1, contact_id=5
+        ),
+        sender=ChatwootSender(id=7, type=sender_type, name="Test"),
+        message=ChatwootMessage(id=message_id, content=content),
+    )
+
+
+class TestIdempotency:
+    """Duplicate message detection via Redis set."""
+
+    @pytest.mark.asyncio
+    async def test_is_duplicate_true(
+        self, handler: ChatwootHandler, redis_cache: Any
+    ) -> None:
+        redis_cache.sismember.return_value = True
+        assert await handler._is_duplicate(101) is True
+        redis_cache.sismember.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_is_duplicate_false(
+        self, handler: ChatwootHandler, redis_cache: Any
+    ) -> None:
+        redis_cache.sismember.return_value = False
+        assert await handler._is_duplicate(101) is False
+
+    @pytest.mark.asyncio
+    async def test_mark_processed(
+        self, handler: ChatwootHandler, redis_cache: Any
+    ) -> None:
+        redis_cache.sadd.return_value = True
+        assert await handler._mark_processed(101) is True
+        redis_cache.sadd.assert_awaited_once()
+
+
+class TestHandleMessageCreated:
+    """Dispatch of 'message_created' events."""
+
+    @pytest.mark.asyncio
+    async def test_contact_message_logs_received(
+        self, handler: ChatwootHandler, caplog: Any
+    ) -> None:
+        payload = _message_payload(sender_type="contact")
+        with caplog.at_level("INFO"):
+            await handler._handle_message_created(payload)
+        assert "user message received" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_user_message_logs_agent_detected(
+        self, handler: ChatwootHandler, caplog: Any
+    ) -> None:
+        payload = _message_payload(sender_type="user")
+        with caplog.at_level("INFO"):
+            await handler._handle_message_created(payload)
+        assert "human agent message detected" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_extracts_conversation_id(
+        self, handler: ChatwootHandler, caplog: Any
+    ) -> None:
+        payload = _message_payload(sender_type="contact")
+        with caplog.at_level("INFO"):
+            await handler._handle_message_created(payload)
+        assert "conversation_id=42" in caplog.text
+
+
+class TestHandleConversationCreated:
+    """Dispatch of 'conversation_created' events."""
+
+    @pytest.mark.asyncio
+    async def test_logs_event(self, handler: ChatwootHandler, caplog: Any) -> None:
+        payload = ConversationCreatedPayload(
+            event="conversation_created",
+            account={"id": 1},
+            conversation=ChatwootConversation(
+                id=99, status="open", inbox_id=1, contact_id=5
+            ),
+            sender=ChatwootSender(id=7, type="contact"),
+        )
+        with caplog.at_level("INFO"):
+            await handler._handle_conversation_created(payload)
+        assert "conversation_created" in caplog.text
+        assert "conversation_id=99" in caplog.text
+
+
+class TestHandleConversationStatusChanged:
+    """Dispatch of 'conversation_status_changed' events."""
+
+    @pytest.mark.asyncio
+    async def test_logs_event(self, handler: ChatwootHandler, caplog: Any) -> None:
+        payload = ConversationStatusChangedPayload(
+            event="conversation_status_changed",
+            account={"id": 1},
+            conversation=ChatwootConversation(
+                id=77, status="resolved", inbox_id=1, contact_id=5
+            ),
+            sender=ChatwootSender(id=7, type="user"),
+            status="resolved",
+        )
+        with caplog.at_level("INFO"):
+            await handler._handle_conversation_status_changed(payload)
+        assert "conversation_status_changed" in caplog.text
+        assert "conversation_id=77" in caplog.text
+
+
+class TestHandleEvent:
+    """Main dispatcher routes to the correct handler."""
+
+    @pytest.mark.asyncio
+    async def test_routes_message_created(self, handler: ChatwootHandler) -> None:
+        payload = _message_payload()
+        handler._is_duplicate = AsyncMock(return_value=False)  # type: ignore[method-assign]
+        handler._handle_message_created = AsyncMock()  # type: ignore[method-assign]
+        handler._mark_processed = AsyncMock(return_value=True)  # type: ignore[method-assign]
+        await handler.handle_event(payload)
+        handler._handle_message_created.assert_awaited_once_with(payload)
+        handler._mark_processed.assert_awaited_once_with(101)
+
+    @pytest.mark.asyncio
+    async def test_routes_conversation_created(self, handler: ChatwootHandler) -> None:
+        payload = ConversationCreatedPayload(
+            event="conversation_created",
+            account={"id": 1},
+            conversation=ChatwootConversation(
+                id=99, status="open", inbox_id=1, contact_id=5
+            ),
+            sender=ChatwootSender(id=7, type="contact"),
+        )
+        handler._handle_conversation_created = AsyncMock()  # type: ignore[method-assign]
+        handler._mark_processed = AsyncMock(return_value=True)  # type: ignore[method-assign]
+        await handler.handle_event(payload)
+        handler._handle_conversation_created.assert_awaited_once_with(payload)
+
+    @pytest.mark.asyncio
+    async def test_routes_status_changed(self, handler: ChatwootHandler) -> None:
+        payload = ConversationStatusChangedPayload(
+            event="conversation_status_changed",
+            account={"id": 1},
+            conversation=ChatwootConversation(
+                id=77, status="resolved", inbox_id=1, contact_id=5
+            ),
+            sender=ChatwootSender(id=7, type="user"),
+            status="resolved",
+        )
+        handler._handle_conversation_status_changed = AsyncMock()  # type: ignore[method-assign]
+        handler._mark_processed = AsyncMock(return_value=True)  # type: ignore[method-assign]
+        await handler.handle_event(payload)
+        handler._handle_conversation_status_changed.assert_awaited_once_with(payload)
+
+    @pytest.mark.asyncio
+    async def test_skips_duplicate_message(self, handler: ChatwootHandler) -> None:
+        payload = _message_payload()
+        handler._is_duplicate = AsyncMock(return_value=True)  # type: ignore[method-assign]
+        handler._handle_message_created = AsyncMock()  # type: ignore[method-assign]
+        await handler.handle_event(payload)
+        handler._handle_message_created.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unknown_event_logs_warning(
+        self, handler: ChatwootHandler, caplog: Any
+    ) -> None:
+        payload = MessageCreatedPayload(
+            event="unknown_event",
+            account={"id": 1},
+            conversation=ChatwootConversation(
+                id=42, status="open", inbox_id=1, contact_id=5
+            ),
+            sender=ChatwootSender(id=7, type="contact"),
+            message=ChatwootMessage(id=101, content="hi"),
+        )
+        with caplog.at_level("WARNING"):
+            await handler.handle_event(payload)
+        assert "unknown_event" in caplog.text

--- a/backend/tests/test_config_provider.py
+++ b/backend/tests/test_config_provider.py
@@ -8,21 +8,20 @@ import os
 from unittest.mock import patch
 
 from backend.app.config import Settings
-from backend.app.config_provider import (
-    ChannelProfile,
-    ConfigProvider,
-    EnvConfigProvider,
-)
+from backend.app.channel_profile import ChannelProfile
+from backend.app.config_provider import ConfigProvider, EnvConfigProvider
 
 
 class TestChannelProfile:
     """ChannelProfile must expose safe defaults."""
 
     def test_defaults(self) -> None:
-        profile = ChannelProfile()
-        assert profile.name == "default"
-        assert profile.supports_html is False
-        assert profile.max_message_length == 4096
+        profile = ChannelProfile(inbox_id="1")
+        assert profile.inbox_id == "1"
+        assert profile.channel_type == "web"
+        assert profile.buffer_window_seconds == 5
+        assert profile.enable_tool_calling is True
+        assert profile.max_turns == 20
 
 
 class TestEnvConfigProvider:
@@ -63,7 +62,8 @@ class TestEnvConfigProvider:
         provider = EnvConfigProvider(settings)
         profile = provider.get_channel_profile("1")
         assert isinstance(profile, ChannelProfile)
-        assert profile.name == "default"
+        assert profile.inbox_id == "default"
+        assert profile.channel_type == "web"
 
     def test_get_handoff_target_defaults_none(self) -> None:
         settings = Settings()

--- a/backend/tests/test_redis_cache.py
+++ b/backend/tests/test_redis_cache.py
@@ -1,0 +1,201 @@
+"""Tests for RedisCache async wrapper.
+
+Uses fakeredis.FakeAsyncRedis to exercise all Redis operations without
+a real server.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fakeredis import FakeAsyncRedis
+from redis.exceptions import RedisError
+
+from backend.app.redis_cache import RedisCache
+
+
+@pytest.fixture
+def fake_redis() -> FakeAsyncRedis:
+    return FakeAsyncRedis(decode_responses=True)
+
+
+@pytest.fixture
+def cache(fake_redis: FakeAsyncRedis) -> RedisCache:
+    with patch("backend.app.redis_cache.redis.asyncio.Redis") as MockRedis:
+        MockRedis.from_url.return_value = fake_redis
+        return RedisCache(redis_url="redis://localhost:6379/0")
+
+
+class TestKeyNaming:
+    """Key builder must follow the documented convention."""
+
+    def test_build_key_without_field(self, cache: RedisCache) -> None:
+        key = cache._build_key("conversation", "42")
+        assert key == "chatwoot:1:conversation:42"
+
+    def test_build_key_with_field(self, cache: RedisCache) -> None:
+        key = cache._build_key("conversation", "42", "metadata")
+        assert key == "chatwoot:1:conversation:42:metadata"
+
+    def test_custom_prefix(self, fake_redis: FakeAsyncRedis) -> None:
+        with patch(
+            "backend.app.redis_cache.redis.asyncio.Redis", return_value=fake_redis
+        ):
+            custom = RedisCache(redis_url="redis://localhost", prefix="custom")
+        assert custom._build_key("scope", "id") == "custom:1:scope:id"
+
+
+class TestStringOperations:
+    """GET / SET / DELETE / EXISTS."""
+
+    @pytest.mark.asyncio
+    async def test_get_existing(self, cache: RedisCache) -> None:
+        await cache.set("k", "v")
+        assert await cache.get("k") == "v"
+
+    @pytest.mark.asyncio
+    async def test_get_missing_returns_none(self, cache: RedisCache) -> None:
+        assert await cache.get("missing") is None
+
+    @pytest.mark.asyncio
+    async def test_set_and_ttl(self, cache: RedisCache) -> None:
+        assert await cache.set("k", "v", ttl=60) is True
+
+    @pytest.mark.asyncio
+    async def test_delete_existing(self, cache: RedisCache) -> None:
+        await cache.set("k", "v")
+        assert await cache.delete("k") is True
+        assert await cache.get("k") is None
+
+    @pytest.mark.asyncio
+    async def test_delete_missing(self, cache: RedisCache) -> None:
+        assert await cache.delete("missing") is True
+
+    @pytest.mark.asyncio
+    async def test_exists(self, cache: RedisCache) -> None:
+        await cache.set("k", "v")
+        assert await cache.exists("k") is True
+        assert await cache.exists("missing") is False
+
+
+class TestHashOperations:
+    """HGET / HSET / HGETALL."""
+
+    @pytest.mark.asyncio
+    async def test_hset_and_hget(self, cache: RedisCache) -> None:
+        assert await cache.hset("hash", "field", "val") is True
+        assert await cache.hget("hash", "field") == "val"
+
+    @pytest.mark.asyncio
+    async def test_hget_missing(self, cache: RedisCache) -> None:
+        assert await cache.hget("hash", "field") is None
+
+    @pytest.mark.asyncio
+    async def test_hgetall(self, cache: RedisCache) -> None:
+        await cache.hset("hash", "a", "1")
+        await cache.hset("hash", "b", "2")
+        result = await cache.hgetall("hash")
+        assert result == {"a": "1", "b": "2"}
+
+    @pytest.mark.asyncio
+    async def test_hgetall_empty(self, cache: RedisCache) -> None:
+        assert await cache.hgetall("empty") == {}
+
+
+class TestListOperations:
+    """LPUSH / LRANGE / LTRIM."""
+
+    @pytest.mark.asyncio
+    async def test_lpush(self, cache: RedisCache) -> None:
+        length = await cache.lpush("list", "a")
+        assert length == 1
+        length = await cache.lpush("list", "b")
+        assert length == 2
+
+    @pytest.mark.asyncio
+    async def test_lrange(self, cache: RedisCache) -> None:
+        await cache.lpush("list", "a")
+        await cache.lpush("list", "b")
+        await cache.lpush("list", "c")
+        result = await cache.lrange("list", 0, -1)
+        assert result == ["c", "b", "a"]
+
+    @pytest.mark.asyncio
+    async def test_ltrim(self, cache: RedisCache) -> None:
+        await cache.lpush("list", "a")
+        await cache.lpush("list", "b")
+        assert await cache.ltrim("list", 0, 0) is True
+        assert await cache.lrange("list", 0, -1) == ["b"]
+
+
+class TestSetOperations:
+    """SADD / SISMEMBER."""
+
+    @pytest.mark.asyncio
+    async def test_sadd(self, cache: RedisCache) -> None:
+        assert await cache.sadd("set", "member1") is True
+
+    @pytest.mark.asyncio
+    async def test_sismember(self, cache: RedisCache) -> None:
+        await cache.sadd("set", "member1")
+        assert await cache.sismember("set", "member1") is True
+        assert await cache.sismember("set", "member2") is False
+
+
+class TestLockOperations:
+    """Distributed lock via SET NX EX."""
+
+    @pytest.mark.asyncio
+    async def test_acquire_lock_success(self, cache: RedisCache) -> None:
+        assert await cache.acquire_lock("my_lock", ttl_seconds=10) is True
+
+    @pytest.mark.asyncio
+    async def test_acquire_lock_already_held(self, cache: RedisCache) -> None:
+        await cache.acquire_lock("my_lock", ttl_seconds=10)
+        assert await cache.acquire_lock("my_lock", ttl_seconds=10) is False
+
+    @pytest.mark.asyncio
+    async def test_release_lock(self, cache: RedisCache) -> None:
+        await cache.acquire_lock("my_lock", ttl_seconds=10)
+        assert await cache.release_lock("my_lock") is True
+        assert await cache.acquire_lock("my_lock", ttl_seconds=10) is True
+
+    @pytest.mark.asyncio
+    async def test_release_lock_missing(self, cache: RedisCache) -> None:
+        assert await cache.release_lock("my_lock") is True
+
+
+class TestErrorHandling:
+    """On RedisError the cache must return safe defaults and not raise."""
+
+    @pytest.mark.asyncio
+    async def test_get_on_redis_error_returns_none(self, cache: RedisCache) -> None:
+        cache._redis.get = AsyncMock(side_effect=RedisError("redis down"))  # type: ignore[misc]
+        assert await cache.get("k") is None
+
+    @pytest.mark.asyncio
+    async def test_set_on_redis_error_returns_false(self, cache: RedisCache) -> None:
+        cache._redis.set = AsyncMock(side_effect=RedisError("redis down"))  # type: ignore[misc]
+        assert await cache.set("k", "v") is False
+
+    @pytest.mark.asyncio
+    async def test_delete_on_redis_error_returns_false(self, cache: RedisCache) -> None:
+        cache._redis.delete = AsyncMock(side_effect=RedisError("redis down"))  # type: ignore[misc]
+        assert await cache.delete("k") is False
+
+    @pytest.mark.asyncio
+    async def test_exists_on_redis_error_returns_false(self, cache: RedisCache) -> None:
+        cache._redis.exists = AsyncMock(side_effect=RedisError("redis down"))  # type: ignore[misc]
+        assert await cache.exists("k") is False
+
+
+class TestHealthCheck:
+    """Health check must reflect Redis connectivity."""
+
+    @pytest.mark.asyncio
+    async def test_health_check_ok(self, cache: RedisCache) -> None:
+        assert await cache.health_check() is True
+
+    @pytest.mark.asyncio
+    async def test_health_check_fail(self, cache: RedisCache) -> None:
+        cache._redis.ping = AsyncMock(side_effect=RedisError("redis down"))  # type: ignore[misc]
+        assert await cache.health_check() is False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,8 @@ dev = [
   "pytest",
   "httpx",
   "pytest-asyncio>=1.3.0",
+  "fakeredis>=2.35.1",
+  "respx>=0.23.1",
 ]
 lint = [
   "ruff"

--- a/uv.lock
+++ b/uv.lock
@@ -59,9 +59,11 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "fakeredis" },
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "respx" },
 ]
 lint = [
     { name = "ruff" },
@@ -89,9 +91,11 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "fakeredis", specifier = ">=2.35.1" },
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "respx", specifier = ">=0.23.1" },
 ]
 lint = [{ name = "ruff" }]
 typecheck = [{ name = "mypy" }]
@@ -304,6 +308,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "fakeredis"
+version = "2.35.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/50/b748233c02fa77e5105238190cc9bb58b852eb1c8b1d0763230d3a5b745a/fakeredis-2.35.1.tar.gz", hash = "sha256:5bae5eba7b9d93cb968944ac40936373cf2397ff71667d4b595df65c3d2e413f", size = 189118, upload-time = "2026-04-12T17:05:58.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/27/b8b057a23f7777177e92d3a602fd866751b6b45014964548997e92e048fd/fakeredis-2.35.1-py3-none-any.whl", hash = "sha256:67d97e11f562b7870e11e5c30cf182270bfb2dd37f6707dba47cc6d91628d1b9", size = 129678, upload-time = "2026-04-12T17:05:56.86Z" },
 ]
 
 [[package]]
@@ -1211,6 +1228,18 @@ wheels = [
 ]
 
 [[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1371,6 +1400,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR implements the core components required for the Chatwoot integration (PR #2 of the chained feature branch). These components will be wired together in PR #3 (evolution) and PR #4 (integration).

## Changes

### New Components

- **`backend/app/channel_profile.py`** — Pydantic `ChannelProfile` model with per-inbox configuration
- **`backend/app/redis_cache.py`** — Async Redis wrapper with structured key naming, distributed locks, and graceful failures
- **`backend/app/chatwoot_client.py`** — Async HTTP client for Chatwoot Application API with retry logic and outbox stub
- **`backend/app/chatwoot_handler.py`** — Webhook event dispatcher with idempotency and structured logging

### Updated Components

- **`backend/app/config_provider.py`** — Updated to use the new Pydantic `ChannelProfile`

### Tests

- `test_channel_profile.py` — 15 tests
- `test_redis_cache.py` — 28 tests
- `test_chatwoot_client.py` — 15 tests
- `test_chatwoot_handler.py` — 13 tests

## Verification

- [x] `pytest` passes (116 tests total)
- [x] `ruff check` passes on all new/modified files
- [x] `ruff format --check` passes on all new/modified files
- [x] No changes to `/chat` endpoint behavior
