### PR TITLE
feat(#166,#168,#165): evolve buffers, sessions, and escalation for Chatwoot

### DIFF
--- a/backend/app/chatwoot_handler.py
+++ b/backend/app/chatwoot_handler.py
@@ -5,9 +5,12 @@ idempotency via Redis, and logs all events with structured context.
 """
 
 import logging
+from typing import Any, Optional
 
 from backend.app.chatwoot_client import ChatwootClient
 from backend.app.config_provider import ConfigProvider
+from backend.app.escalation_handler import EscalationHandler
+from backend.app.message_buffer import RedisMessageBuffer
 from backend.app.redis_cache import RedisCache
 from backend.app.schemas import (
     ChatwootWebhookPayload,
@@ -35,10 +38,16 @@ class ChatwootHandler:
         chatwoot_client: ChatwootClient,
         redis_cache: RedisCache,
         config_provider: ConfigProvider,
+        message_buffer: Optional[RedisMessageBuffer] = None,
+        session_manager: Optional[Any] = None,
+        escalation_handler: Optional[EscalationHandler] = None,
     ) -> None:
         self._client = chatwoot_client
         self._redis = redis_cache
         self._config = config_provider
+        self._buffer = message_buffer
+        self._sessions = session_manager
+        self._escalation = escalation_handler
 
     async def handle_event(self, payload: ChatwootWebhookPayload) -> None:
         """Route a webhook payload to the correct handler.
@@ -90,14 +99,17 @@ class ChatwootHandler:
     async def _handle_message_created(self, payload: MessageCreatedPayload) -> None:
         """Handle a ``message_created`` webhook.
 
-        Currently a stub that logs the event. Full buffering and LLM
-        response flow will be implemented in PR #3.
+        Buffers contact messages for later LLM processing. Human-agent
+        messages flush/cancel pending buffers so the human response wins.
         """
         conversation_id = payload.conversation.id
+        conversation_key = str(conversation_id)
         sender_type = payload.sender.type
         content = payload.message.content or ""
 
         if sender_type == "user":
+            if self._buffer is not None:
+                await self._buffer.flush_and_cancel(conversation_key)
             logger.info(
                 "human agent message detected conversation_id=%s message_id=%s",
                 conversation_id,
@@ -109,6 +121,21 @@ class ChatwootHandler:
                 },
             )
         elif sender_type == "contact":
+            account_id = int(payload.account.get("id", 1))
+            if self._sessions is not None:
+                await self._sessions.get_or_create_session_for_conversation(
+                    conversation_key, account_id=account_id
+                )
+
+            profile = self._config.get_channel_profile(
+                str(payload.conversation.inbox_id)
+            )
+            window_seconds = int(getattr(profile, "buffer_window_seconds", 5))
+            if self._buffer is not None:
+                await self._buffer.add_message(
+                    conversation_key, content, window_seconds
+                )
+            await self._client.send_typing_indicator(conversation_id)
             logger.info(
                 "user message received conversation_id=%s message_id=%s",
                 conversation_id,

--- a/backend/app/escalation_handler.py
+++ b/backend/app/escalation_handler.py
@@ -5,6 +5,8 @@ when a conversation needs to be escalated to a human agent.
 """
 
 import logging
+from typing import Optional
+
 from backend.app.chatwoot_client import ChatwootClient
 from backend.app.config_provider import ConfigProvider
 from backend.app.session import SessionManager
@@ -36,11 +38,56 @@ class EscalationHandler:
         self,
         chatwoot_client: ChatwootClient,
         config_provider: ConfigProvider,
-        session_manager: SessionManager,
+        session_manager: Optional[SessionManager] = None,
     ) -> None:
         self._client = chatwoot_client
         self._config = config_provider
         self._session = session_manager
+
+    async def escalate_to_human(
+        self, conversation_id: int, reason: str, intent_type: str
+    ) -> bool:
+        """Escalate a Chatwoot conversation to a human agent.
+
+        Args:
+            conversation_id: Chatwoot conversation identifier.
+            reason: Human-readable escalation reason for logs/notes.
+            intent_type: Intent classifier label that triggered handoff.
+
+        Returns:
+            True when the critical handoff actions succeeded, False otherwise.
+        """
+        del reason
+        labels = [self._config.get_label("escalated")]
+        intent_label_name = _INTENT_LABEL_MAP.get(intent_type)
+        if intent_label_name is not None:
+            labels.append(self._config.get_label(intent_label_name))
+
+        for label in labels:
+            try:
+                await self._client.add_label(conversation_id, label)
+            except Exception as exc:
+                logger.warning(
+                    "Non-critical escalation label failed: conversation_id=%s, label=%s, error=%s",
+                    conversation_id,
+                    label,
+                    exc,
+                )
+
+        try:
+            await self._client.toggle_status(conversation_id, "open")
+            team_id = self._config.get_handoff_target()
+            if team_id is not None:
+                await self._client.assign_conversation(conversation_id, team_id=team_id)
+            await self._client.send_message(conversation_id, DEFAULT_ESCALATION_MESSAGE)
+            return True
+        except Exception as exc:
+            logger.error(
+                "Critical escalation action failed: conversation_id=%s, error=%s",
+                conversation_id,
+                exc,
+            )
+            return False
 
     async def handle_escalation(
         self,
@@ -88,9 +135,7 @@ class EscalationHandler:
 
         if team_id is not None:
             try:
-                await self._client.assign_conversation(
-                    conversation_id, team_id=team_id
-                )
+                await self._client.assign_conversation(conversation_id, team_id=team_id)
             except Exception as exc:
                 logger.error(
                     "Failed to assign conversation: conversation_id=%s, team_id=%s, error=%s",
@@ -100,9 +145,7 @@ class EscalationHandler:
                 )
 
         try:
-            await self._client.send_message(
-                conversation_id, DEFAULT_ESCALATION_MESSAGE
-            )
+            await self._client.send_message(conversation_id, DEFAULT_ESCALATION_MESSAGE)
         except Exception as exc:
             logger.error(
                 "Failed to send escalation message: conversation_id=%s, error=%s",
@@ -112,9 +155,8 @@ class EscalationHandler:
 
         # Store escalation reason in session for audit/debugging
         try:
-            await self._session.set_user_profile(
-                session_id, f"escalated:{reason}"
-            )
+            if self._session is not None:
+                self._session.set_user_profile(session_id, f"escalated:{reason}")
         except Exception as exc:
             logger.error(
                 "Failed to store escalation reason: session_id=%s, error=%s",

--- a/backend/app/escalation_handler.py
+++ b/backend/app/escalation_handler.py
@@ -1,0 +1,167 @@
+"""Escalation handler for human agent handoff via Chatwoot.
+
+Orchestrates labeling, status changes, assignment, and user notification
+when a conversation needs to be escalated to a human agent.
+"""
+
+import logging
+from backend.app.chatwoot_client import ChatwootClient
+from backend.app.config_provider import ConfigProvider
+from backend.app.session import SessionManager
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ESCALATION_MESSAGE = (
+    "Entiendo que necesitas asistencia personalizada. "
+    "Un agente de ventas te contactará pronto para ayudarte con tu consulta."
+)
+
+_INTENT_LABEL_MAP = {
+    "escalate_quote": "quote",
+    "escalate_technical": "technical",
+    "escalate_order": "order",
+}
+
+
+class EscalationHandler:
+    """Handles escalation workflows via the Chatwoot Application API.
+
+    Args:
+        chatwoot_client: Async client for Chatwoot HTTP operations.
+        config_provider: Runtime configuration provider.
+        session_manager: Session manager for storing escalation metadata.
+    """
+
+    def __init__(
+        self,
+        chatwoot_client: ChatwootClient,
+        config_provider: ConfigProvider,
+        session_manager: SessionManager,
+    ) -> None:
+        self._client = chatwoot_client
+        self._config = config_provider
+        self._session = session_manager
+
+    async def handle_escalation(
+        self,
+        session_id: str,
+        conversation_id: int,
+        reason: str,
+    ) -> None:
+        """Execute the full escalation handoff workflow.
+
+        Steps:
+            1. Add ``escalated`` label to the conversation.
+            2. Toggle conversation status to ``open``.
+            3. Assign conversation to the configured handoff team.
+            4. Send the default escalation message to the user.
+            5. Store the escalation reason in the session manager.
+
+        All Chatwoot API errors are logged but not re-raised so the bot
+        does not crash on transient failures.
+
+        Args:
+            session_id: Internal session identifier.
+            conversation_id: Chatwoot conversation ID.
+            reason: Human-readable escalation reason.
+        """
+        label = self._config.get_label("escalated")
+        team_id = self._config.get_handoff_target()
+
+        try:
+            await self._client.add_label(conversation_id, label)
+        except Exception as exc:
+            logger.error(
+                "Failed to add escalation label: conversation_id=%s, error=%s",
+                conversation_id,
+                exc,
+            )
+
+        try:
+            await self._client.toggle_status(conversation_id, "open")
+        except Exception as exc:
+            logger.error(
+                "Failed to toggle conversation status: conversation_id=%s, error=%s",
+                conversation_id,
+                exc,
+            )
+
+        if team_id is not None:
+            try:
+                await self._client.assign_conversation(
+                    conversation_id, team_id=team_id
+                )
+            except Exception as exc:
+                logger.error(
+                    "Failed to assign conversation: conversation_id=%s, team_id=%s, error=%s",
+                    conversation_id,
+                    team_id,
+                    exc,
+                )
+
+        try:
+            await self._client.send_message(
+                conversation_id, DEFAULT_ESCALATION_MESSAGE
+            )
+        except Exception as exc:
+            logger.error(
+                "Failed to send escalation message: conversation_id=%s, error=%s",
+                conversation_id,
+                exc,
+            )
+
+        # Store escalation reason in session for audit/debugging
+        try:
+            await self._session.set_user_profile(
+                session_id, f"escalated:{reason}"
+            )
+        except Exception as exc:
+            logger.error(
+                "Failed to store escalation reason: session_id=%s, error=%s",
+                session_id,
+                exc,
+            )
+
+    async def handle_escalation_by_intent(
+        self,
+        session_id: str,
+        conversation_id: int,
+        intent_type: str,
+    ) -> bool:
+        """Map an intent type to a label and trigger escalation.
+
+        Supported intents:
+            - ``escalate_quote`` → ``quote`` label
+            - ``escalate_technical`` → ``technical`` label
+            - ``escalate_order`` → ``order`` label
+
+        Args:
+            session_id: Internal session identifier.
+            conversation_id: Chatwoot conversation ID.
+            intent_type: Intent classification result.
+
+        Returns:
+            ``True`` if escalation was triggered, ``False`` for unknown intents.
+        """
+        label_name = _INTENT_LABEL_MAP.get(intent_type)
+        if label_name is None:
+            logger.warning(
+                "Unknown escalation intent: session_id=%s, intent_type=%s",
+                session_id,
+                intent_type,
+            )
+            return False
+
+        label = self._config.get_label(label_name)
+        try:
+            await self._client.add_label(conversation_id, label)
+        except Exception as exc:
+            logger.error(
+                "Failed to add intent label: conversation_id=%s, label=%s, error=%s",
+                conversation_id,
+                label,
+                exc,
+            )
+
+        await self.handle_escalation(session_id, conversation_id, intent_type)
+        return True

--- a/backend/app/message_buffer.py
+++ b/backend/app/message_buffer.py
@@ -32,6 +32,22 @@ class BufferResult(BaseModel):
     joined_message: Optional[str] = None
 
 
+class BufferState(BaseModel):
+    """Redis-serializable Chatwoot buffer state.
+
+    Attributes:
+        conversation_id: Chatwoot conversation identifier.
+        messages: Buffered user messages.
+        timer_deadline_epoch: Unix timestamp when the debounce window ends.
+        is_flushing: True while a human-agent race flush is in progress.
+    """
+
+    conversation_id: str
+    messages: list[str]
+    timer_deadline_epoch: Optional[float] = None
+    is_flushing: bool = False
+
+
 class MessageBuffer:
     """Redis-backed message buffer with in-memory fallback.
 
@@ -90,35 +106,95 @@ class MessageBuffer:
         try:
             raw = await self._redis.get(key)
             if raw:
-                state = json.loads(raw)
-                if state.get("is_flushing"):
+                state = BufferState.model_validate(
+                    self._normalise_state(session_id, raw)
+                )
+                if state.is_flushing:
                     return BufferResult(is_buffering=True)
-                state["messages"].append(message)
-                if (
-                    len(state["messages"]) >= self._max_messages()
-                    or time.time() >= state["deadline"]
+                state.messages.append(message)
+                if len(state.messages) >= self._max_messages() or time.time() >= (
+                    state.timer_deadline_epoch or 0
                 ):
-                    joined = "\n".join(state["messages"])
+                    joined = "\n".join(state.messages)
                     await self._redis.delete(key)
                     return BufferResult(is_buffering=False, joined_message=joined)
-                ok = await self._redis.set(key, json.dumps(state))
+                ok = await self._redis.set(
+                    key,
+                    state.model_dump_json(),
+                    ttl=self._window_seconds() + 60,
+                )
                 if not ok:
                     raise RuntimeError("Redis set returned False")
                 return BufferResult(is_buffering=True)
 
             # New buffer
-            state = {
-                "messages": [message],
-                "deadline": time.time() + self._window_seconds(),
-                "is_flushing": False,
-            }
-            ok = await self._redis.set(key, json.dumps(state))
+            state = BufferState(
+                conversation_id=session_id,
+                messages=[message],
+                timer_deadline_epoch=time.time() + self._window_seconds(),
+                is_flushing=False,
+            )
+            ok = await self._redis.set(
+                key,
+                state.model_dump_json(),
+                ttl=self._window_seconds() + 60,
+            )
             if not ok:
                 raise RuntimeError("Redis set returned False")
             return BufferResult(is_buffering=True)
         except Exception as exc:
             logger.warning("Redis buffer add failed, falling back to memory: %s", exc)
             return self._add_fallback(session_id, message)
+
+    async def add_message(
+        self, conversation_id: str, message: str, window_seconds: int
+    ) -> BufferState:
+        """Append a Chatwoot message and return persisted buffer state.
+
+        Args:
+            conversation_id: Chatwoot conversation identifier.
+            message: Message text to buffer.
+            window_seconds: Debounce window in seconds for this channel.
+
+        Returns:
+            The resulting buffer state.
+        """
+        key = self._buffer_key(conversation_id)
+        state = BufferState(
+            conversation_id=conversation_id,
+            messages=[],
+            timer_deadline_epoch=time.time() + window_seconds,
+            is_flushing=False,
+        )
+        try:
+            raw = await self._redis.get(key)
+            if raw:
+                state = BufferState.model_validate(
+                    self._normalise_state(conversation_id, raw)
+                )
+            if not state.is_flushing:
+                state.messages.append(message)
+                state.timer_deadline_epoch = time.time() + window_seconds
+                ok = await self._redis.set(
+                    key,
+                    state.model_dump_json(),
+                    ttl=window_seconds + 60,
+                )
+                if not ok:
+                    raise RuntimeError("Redis set returned False")
+            return state
+        except Exception as exc:
+            logger.warning("Redis add_message failed, falling back to memory: %s", exc)
+            if conversation_id not in self._fallback_buffer:
+                self._fallback_buffer[conversation_id] = []
+            self._fallback_buffer[conversation_id].append(message)
+            self._fallback_deadline[conversation_id] = time.time() + window_seconds
+            return BufferState(
+                conversation_id=conversation_id,
+                messages=list(self._fallback_buffer[conversation_id]),
+                timer_deadline_epoch=self._fallback_deadline[conversation_id],
+                is_flushing=self._fallback_flushing.get(conversation_id, False),
+            )
 
     def _add_fallback(self, session_id: str, message: str) -> BufferResult:
         """In-memory fallback for add when Redis is unavailable."""
@@ -155,12 +231,19 @@ class MessageBuffer:
             Messages joined with newline separator, or None if buffer empty.
         """
         key = self._buffer_key(session_id)
+        lock_key = self._lock_key(session_id)
         messages: list[str] = []
+        lock_acquired = False
         try:
+            lock_acquired = await self._redis.acquire_lock(lock_key, ttl_seconds=30)
+            if not lock_acquired:
+                return None
             raw = await self._redis.get(key)
             if raw:
-                state = json.loads(raw)
-                messages = state.get("messages", [])
+                state = BufferState.model_validate(
+                    self._normalise_state(session_id, raw)
+                )
+                messages = state.messages
                 await self._redis.delete(key)
             # Cancel any pending task
             task = self._tasks.pop(session_id, None)
@@ -172,6 +255,9 @@ class MessageBuffer:
             messages = self._fallback_buffer.pop(session_id, [])
             self._fallback_deadline.pop(session_id, None)
             self._fallback_flushing.pop(session_id, None)
+        finally:
+            if lock_acquired:
+                await self._redis.release_lock(lock_key)
 
         # Also check fallback if Redis returned empty but fallback has data
         if not messages and session_id in self._fallback_buffer:
@@ -208,10 +294,12 @@ class MessageBuffer:
                 key = self._buffer_key(session_id)
                 raw = await self._redis.get(key)
                 if raw:
-                    state = json.loads(raw)
-                    state["is_flushing"] = True
-                    await self._redis.set(key, json.dumps(state))
-                    messages = state.get("messages", [])
+                    state = BufferState.model_validate(
+                        self._normalise_state(session_id, raw)
+                    )
+                    state.is_flushing = True
+                    await self._redis.set(key, state.model_dump_json())
+                    messages = state.messages
                     await self._redis.delete(key)
                     if messages:
                         return "\n".join(messages)
@@ -247,8 +335,10 @@ class MessageBuffer:
         try:
             raw = await self._redis.get(key)
             if raw:
-                state = json.loads(raw)
-                return len(state.get("messages", [])) > 0
+                state = BufferState.model_validate(
+                    self._normalise_state(session_id, raw)
+                )
+                return len(state.messages) > 0
         except Exception as exc:
             logger.warning("Redis buffer is_buffering failed, using memory: %s", exc)
         # Fallback check
@@ -270,12 +360,29 @@ class MessageBuffer:
         try:
             raw = await self._redis.get(key)
             if raw:
-                state = json.loads(raw)
-                return len(state.get("messages", []))
+                state = BufferState.model_validate(
+                    self._normalise_state(session_id, raw)
+                )
+                return len(state.messages)
         except Exception as exc:
             logger.warning("Redis buffer get_count failed, using memory: %s", exc)
         # Fallback check
         return len(self._fallback_buffer.get(session_id, []))
+
+    def _normalise_state(self, conversation_id: str, raw: str) -> dict[str, Any]:
+        """Load legacy or spec buffer JSON into BufferState-compatible dict."""
+        data = json.loads(raw)
+        return {
+            "conversation_id": data.get("conversation_id", conversation_id),
+            "messages": data.get("messages", []),
+            "timer_deadline_epoch": data.get(
+                "timer_deadline_epoch", data.get("deadline")
+            ),
+            "is_flushing": data.get("is_flushing", False),
+        }
+
+
+RedisMessageBuffer = MessageBuffer
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/message_buffer.py
+++ b/backend/app/message_buffer.py
@@ -4,15 +4,284 @@ Accumulates incoming messages per session during a configurable window,
 then flushes them as a single joined message. Used to handle WhatsApp
 users who send multiple short messages in rapid succession.
 
-Design: module-level dicts for buffer state (NOT in SessionManager).
+Design: Redis-backed buffer state with in-memory fallback for resilience.
 """
 
 import asyncio
+import json
 import logging
+import time
+import warnings
 from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable, Optional
 
+from pydantic import BaseModel
+
 logger = logging.getLogger(__name__)
+
+
+class BufferResult(BaseModel):
+    """Result of adding a message to the buffer.
+
+    Attributes:
+        is_buffering: True if the buffer is still accumulating messages.
+        joined_message: The flushed message if auto-flush occurred, else None.
+    """
+
+    is_buffering: bool
+    joined_message: Optional[str] = None
+
+
+class MessageBuffer:
+    """Redis-backed message buffer with in-memory fallback.
+
+    Args:
+        redis_cache: Async Redis cache instance for persistent buffer state.
+        config_provider: Provider for runtime configuration (window_seconds).
+    """
+
+    def __init__(
+        self,
+        redis_cache: Any,
+        config_provider: Any,
+    ) -> None:
+        self._redis = redis_cache
+        self._config = config_provider
+        self._tasks: dict[str, asyncio.Task] = {}  # type: ignore[type-arg]
+        # In-memory fallback when Redis is unavailable
+        self._fallback_buffer: dict[str, list[str]] = {}
+        self._fallback_deadline: dict[str, float] = {}
+        self._fallback_flushing: dict[str, bool] = {}
+
+    def _buffer_key(self, session_id: str) -> str:
+        return self._redis._build_key("buffer", session_id)
+
+    def _lock_key(self, session_id: str) -> str:
+        return self._redis._build_key("buffer", session_id, "lock")
+
+    def _window_seconds(self) -> int:
+        value = self._config.get("buffer_window_seconds")
+        return int(value) if value is not None else 5
+
+    def _max_messages(self) -> int:
+        value = self._config.get("buffer_max_messages")
+        return int(value) if value is not None else 5
+
+    async def add(
+        self,
+        session_id: str,
+        message: str,
+        conversation_id: str = "",
+    ) -> BufferResult:
+        """Append a message to the session buffer.
+
+        Args:
+            session_id: The session identifier.
+            message: The message text to buffer.
+            conversation_id: Optional Chatwoot conversation ID.
+
+        Returns:
+            BufferResult with is_buffering=False and joined_message set if
+            the buffer auto-flushed (count limit or deadline expired).
+        """
+        key = self._buffer_key(session_id)
+
+        # Try Redis first
+        try:
+            raw = await self._redis.get(key)
+            if raw:
+                state = json.loads(raw)
+                if state.get("is_flushing"):
+                    return BufferResult(is_buffering=True)
+                state["messages"].append(message)
+                if (
+                    len(state["messages"]) >= self._max_messages()
+                    or time.time() >= state["deadline"]
+                ):
+                    joined = "\n".join(state["messages"])
+                    await self._redis.delete(key)
+                    return BufferResult(is_buffering=False, joined_message=joined)
+                ok = await self._redis.set(key, json.dumps(state))
+                if not ok:
+                    raise RuntimeError("Redis set returned False")
+                return BufferResult(is_buffering=True)
+
+            # New buffer
+            state = {
+                "messages": [message],
+                "deadline": time.time() + self._window_seconds(),
+                "is_flushing": False,
+            }
+            ok = await self._redis.set(key, json.dumps(state))
+            if not ok:
+                raise RuntimeError("Redis set returned False")
+            return BufferResult(is_buffering=True)
+        except Exception as exc:
+            logger.warning("Redis buffer add failed, falling back to memory: %s", exc)
+            return self._add_fallback(session_id, message)
+
+    def _add_fallback(self, session_id: str, message: str) -> BufferResult:
+        """In-memory fallback for add when Redis is unavailable."""
+        if (
+            session_id in self._fallback_flushing
+            and self._fallback_flushing[session_id]
+        ):
+            return BufferResult(is_buffering=True)
+
+        if session_id not in self._fallback_buffer:
+            self._fallback_buffer[session_id] = []
+            self._fallback_deadline[session_id] = time.time() + self._window_seconds()
+
+        self._fallback_buffer[session_id].append(message)
+
+        if (
+            len(self._fallback_buffer[session_id]) >= self._max_messages()
+            or time.time() >= self._fallback_deadline[session_id]
+        ):
+            joined = "\n".join(self._fallback_buffer.pop(session_id, []))
+            self._fallback_deadline.pop(session_id, None)
+            self._fallback_flushing.pop(session_id, None)
+            return BufferResult(is_buffering=False, joined_message=joined)
+
+        return BufferResult(is_buffering=True)
+
+    async def flush(self, session_id: str) -> Optional[str]:
+        """Flush buffer and return joined message. None if empty.
+
+        Args:
+            session_id: The session identifier.
+
+        Returns:
+            Messages joined with newline separator, or None if buffer empty.
+        """
+        key = self._buffer_key(session_id)
+        messages: list[str] = []
+        try:
+            raw = await self._redis.get(key)
+            if raw:
+                state = json.loads(raw)
+                messages = state.get("messages", [])
+                await self._redis.delete(key)
+            # Cancel any pending task
+            task = self._tasks.pop(session_id, None)
+            current_task = asyncio.current_task()
+            if task and task is not current_task and not task.done():
+                task.cancel()
+        except Exception as exc:
+            logger.warning("Redis buffer flush failed, falling back to memory: %s", exc)
+            messages = self._fallback_buffer.pop(session_id, [])
+            self._fallback_deadline.pop(session_id, None)
+            self._fallback_flushing.pop(session_id, None)
+
+        # Also check fallback if Redis returned empty but fallback has data
+        if not messages and session_id in self._fallback_buffer:
+            messages = self._fallback_buffer.pop(session_id, [])
+            self._fallback_deadline.pop(session_id, None)
+            self._fallback_flushing.pop(session_id, None)
+
+        if messages:
+            return "\n".join(messages)
+        return None
+
+    async def flush_and_cancel(self, session_id: str) -> Optional[str]:
+        """Flush buffer with distributed lock (race-condition guard).
+
+        Used when a human agent sends a message to prevent concurrent
+        bot responses.
+
+        Args:
+            session_id: The session identifier.
+
+        Returns:
+            Joined message or None if buffer was empty.
+        """
+        lock_key = self._lock_key(session_id)
+        try:
+            acquired = await self._redis.acquire_lock(lock_key, ttl_seconds=30)
+            if not acquired:
+                logger.warning(
+                    "flush_and_cancel could not acquire lock for session %s", session_id
+                )
+                return None
+
+            try:
+                key = self._buffer_key(session_id)
+                raw = await self._redis.get(key)
+                if raw:
+                    state = json.loads(raw)
+                    state["is_flushing"] = True
+                    await self._redis.set(key, json.dumps(state))
+                    messages = state.get("messages", [])
+                    await self._redis.delete(key)
+                    if messages:
+                        return "\n".join(messages)
+                # Cancel any pending task
+                task = self._tasks.pop(session_id, None)
+                current_task = asyncio.current_task()
+                if task and task is not current_task and not task.done():
+                    task.cancel()
+            finally:
+                await self._redis.release_lock(lock_key)
+        except Exception as exc:
+            logger.warning(
+                "Redis buffer flush_and_cancel failed, falling back to memory: %s", exc
+            )
+            # Fallback: just flush in-memory
+            messages = self._fallback_buffer.pop(session_id, [])
+            self._fallback_deadline.pop(session_id, None)
+            self._fallback_flushing.pop(session_id, None)
+            if messages:
+                return "\n".join(messages)
+        return None
+
+    async def is_buffering(self, session_id: str) -> bool:
+        """Check if session has buffered messages.
+
+        Args:
+            session_id: The session identifier.
+
+        Returns:
+            True if buffer has entries, False otherwise.
+        """
+        key = self._buffer_key(session_id)
+        try:
+            raw = await self._redis.get(key)
+            if raw:
+                state = json.loads(raw)
+                return len(state.get("messages", [])) > 0
+        except Exception as exc:
+            logger.warning("Redis buffer is_buffering failed, using memory: %s", exc)
+        # Fallback check
+        return (
+            session_id in self._fallback_buffer
+            and len(self._fallback_buffer[session_id]) > 0
+        )
+
+    async def get_count(self, session_id: str) -> int:
+        """Get number of buffered messages for a session.
+
+        Args:
+            session_id: The session identifier.
+
+        Returns:
+            Number of buffered messages.
+        """
+        key = self._buffer_key(session_id)
+        try:
+            raw = await self._redis.get(key)
+            if raw:
+                state = json.loads(raw)
+                return len(state.get("messages", []))
+        except Exception as exc:
+            logger.warning("Redis buffer get_count failed, using memory: %s", exc)
+        # Fallback check
+        return len(self._fallback_buffer.get(session_id, []))
+
+
+# ---------------------------------------------------------------------------
+# Module-level state for pending results and processing flags
+# (not migrated to Redis in this PR — kept for backward compatibility)
+# ---------------------------------------------------------------------------
 
 # Buffer state per session: session_id -> list of (message, timestamp)
 _buffer: dict[str, list[tuple[str, datetime]]] = {}
@@ -29,11 +298,32 @@ _pending_chat_responses: dict[str, tuple[str, datetime]] = {}
 # Sessions whose buffer was flushed and are being processed in background
 _processing_sessions: dict[str, datetime] = {}
 
+# Global MessageBuffer instance (initialized lazily so tests can swap it)
+_message_buffer: Optional[MessageBuffer] = None
+
+
+def _get_message_buffer() -> MessageBuffer:
+    """Return the module-level MessageBuffer instance.
+
+    Raises:
+        RuntimeError: If the global instance has not been set.
+    """
+    if _message_buffer is None:
+        raise RuntimeError(
+            "MessageBuffer has not been initialized. "
+            "Set backend.app.message_buffer._message_buffer before calling legacy wrappers."
+        )
+    return _message_buffer
+
 
 async def add_to_buffer(
     session_id: str, message: str, max_messages: int = 5
 ) -> Optional[str]:
     """Append message to session buffer.
+
+    .. deprecated::
+        Use ``MessageBuffer.add()`` directly. This wrapper is kept for
+        backward compatibility with existing callers.
 
     Args:
         session_id: The session identifier.
@@ -43,23 +333,28 @@ async def add_to_buffer(
     Returns:
         Joined text if overflow triggered, None if still buffering.
     """
+    warnings.warn(
+        "add_to_buffer is deprecated; use MessageBuffer.add()",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    if _message_buffer is not None:
+        result = await _message_buffer.add(session_id, message)
+        return result.joined_message
+    # Legacy fallback
     if session_id not in _buffer:
         _buffer[session_id] = []
     _buffer[session_id].append((message, datetime.now(timezone.utc)))
-
     if len(_buffer[session_id]) >= max_messages:
-        # Overflow: flush immediately
-        logger.info(
-            "Buffer overflow for session %s: %d messages, flushing",
-            session_id,
-            len(_buffer[session_id]),
-        )
         return await flush_buffer(session_id)
     return None
 
 
 async def flush_buffer(session_id: str) -> Optional[str]:
     """Flush buffer and return joined message. None if empty.
+
+    .. deprecated::
+        Use ``MessageBuffer.flush()`` directly.
 
     Also stores the result in _pending_results so callers can retrieve it
     after the async window expiration callback fires.
@@ -70,6 +365,14 @@ async def flush_buffer(session_id: str) -> Optional[str]:
     Returns:
         Messages joined with newline separator, or None if buffer empty.
     """
+    warnings.warn(
+        "flush_buffer is deprecated; use MessageBuffer.flush()",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    if _message_buffer is not None:
+        return await _message_buffer.flush(session_id)
+    # Legacy fallback
     messages = _buffer.pop(session_id, [])
     task = _buffer_tasks.pop(session_id, None)
     current_task = asyncio.current_task()
@@ -78,8 +381,6 @@ async def flush_buffer(session_id: str) -> Optional[str]:
     if not messages:
         return None
     joined = "\n".join(msg for msg, _ in messages)
-    # Clean up stale state from previous flushes to prevent memory leaks
-    # and avoid false "not_found" responses while background processing runs.
     _pending_results.pop(session_id, None)
     _pending_chat_responses.pop(session_id, None)
     _processing_sessions.pop(session_id, None)
@@ -95,6 +396,9 @@ def is_buffering(session_id: str) -> bool:
     Returns:
         True if buffer has entries, False otherwise.
     """
+    if _message_buffer is not None:
+        # We cannot await in a sync function; fall back to legacy dict
+        return session_id in _buffer and len(_buffer[session_id]) > 0
     return session_id in _buffer and len(_buffer[session_id]) > 0
 
 
@@ -232,7 +536,10 @@ def schedule_flush(
             await asyncio.sleep(window_seconds)
         except asyncio.CancelledError:
             return
-        message = await flush_buffer(session_id)
+        if _message_buffer is not None:
+            message = await _message_buffer.flush(session_id)
+        else:
+            message = await flush_buffer(session_id)
         if message:
             await callback(session_id, message)
 

--- a/backend/app/redis_cache.py
+++ b/backend/app/redis_cache.py
@@ -178,6 +178,24 @@ class RedisCache:
             logger.warning("Redis release_lock failed: %s", exc)
             return False
 
+    async def hdel(self, key: str, field: str) -> bool:
+        """Delete a hash field."""
+        try:
+            await self._redis.hdel(key, field)
+            return True
+        except RedisError as exc:
+            logger.warning("Redis hdel failed: %s", exc)
+            return False
+
+    async def expire(self, key: str, ttl: int) -> bool:
+        """Set TTL on an existing key."""
+        try:
+            await self._redis.expire(key, ttl)
+            return True
+        except RedisError as exc:
+            logger.warning("Redis expire failed: %s", exc)
+            return False
+
     async def health_check(self) -> bool:
         """Return ``True`` if Redis responds to ``PING``."""
         try:

--- a/backend/app/session.py
+++ b/backend/app/session.py
@@ -3,10 +3,16 @@ Servicio de gestión de sesiones para el chatbot.
 Almacena el historial de conversaciones por session_id.
 """
 
-from typing import Dict, List, Optional
-from datetime import datetime
-from pydantic import BaseModel
+import logging
 import threading
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+from backend.app.redis_cache import RedisCache
+
+logger = logging.getLogger(__name__)
 
 
 class ChatTurn(BaseModel):
@@ -33,16 +39,53 @@ class TokenTotals(BaseModel):
 
 
 class SessionManager:
-    """Gestiona las sesiones de conversación."""
+    """Gestiona las sesiones de conversación con almacenamiento híbrido Redis/memoria."""
 
-    def __init__(self, max_turns: int = 20):
-        self.sessions: Dict[str, List[ChatTurn]] = {}
-        self.profiles: Dict[str, str] = {}
-        self.token_totals: Dict[str, TokenTotals] = {}
+    _TTL_SECONDS = 86400  # 24 horas
+
+    def __init__(
+        self,
+        max_turns: int = 20,
+        redis_cache: Optional[RedisCache] = None,
+        chatwoot_client: Optional[Any] = None,
+    ):
         self.max_turns = max_turns
+        self._redis = redis_cache
+        self._chatwoot = chatwoot_client
         self._lock = threading.Lock()
+        # Fallback in-memory storage
+        self._sessions: Dict[str, List[ChatTurn]] = {}
+        self._profiles: Dict[str, str] = {}
+        self._token_totals: Dict[str, TokenTotals] = {}
+        self._conversation_map: Dict[str, str] = {}
+        self._reverse_map: Dict[str, str] = {}
 
-    def add_turn(
+    def _history_key(self, session_id: str) -> str:
+        if self._redis is None:
+            return f"history:{session_id}"
+        return self._redis._build_key("history", session_id)
+
+    def _profile_key(self, session_id: str) -> str:
+        if self._redis is None:
+            return f"profile:{session_id}"
+        return self._redis._build_key("profile", session_id)
+
+    def _tokens_key(self, session_id: str) -> str:
+        if self._redis is None:
+            return f"tokens:{session_id}"
+        return self._redis._build_key("tokens", session_id)
+
+    def _mapping_session_key(self) -> str:
+        if self._redis is None:
+            return "mapping:session"
+        return self._redis._build_key("mapping", "session")
+
+    def _mapping_conversation_key(self) -> str:
+        if self._redis is None:
+            return "mapping:conversation"
+        return self._redis._build_key("mapping", "conversation")
+
+    async def add_turn(
         self,
         session_id: str,
         question: str,
@@ -58,24 +101,33 @@ class SessionManager:
             answer: Respuesta del asistente
             source_documents: Lista de documentos fuente utilizados (opcional)
         """
+        turn = ChatTurn(
+            question=question,
+            answer=answer,
+            timestamp=datetime.now(),
+            source_documents=source_documents or [],
+        )
+
+        if self._redis is not None:
+            try:
+                key = self._history_key(session_id)
+                await self._redis.lpush(key, turn.model_dump_json())
+                await self._redis.ltrim(key, 0, self.max_turns - 1)
+                await self._redis.expire(key, self._TTL_SECONDS)
+                return
+            except Exception as exc:
+                logger.warning("Redis add_turn failed, falling back to memory: %s", exc)
+
         with self._lock:
-            if session_id not in self.sessions:
-                self.sessions[session_id] = []
+            if session_id not in self._sessions:
+                self._sessions[session_id] = []
+            self._sessions[session_id].append(turn)
+            if len(self._sessions[session_id]) > self.max_turns:
+                self._sessions[session_id] = self._sessions[session_id][
+                    -self.max_turns :
+                ]
 
-            turn = ChatTurn(
-                question=question,
-                answer=answer,
-                timestamp=datetime.now(),
-                source_documents=source_documents or [],
-            )
-
-            self.sessions[session_id].append(turn)
-
-            # Mantener solo los últimos max_turns turnos
-            if len(self.sessions[session_id]) > self.max_turns:
-                self.sessions[session_id] = self.sessions[session_id][-self.max_turns :]
-
-    def get_history(self, session_id: str) -> List[ChatTurn]:
+    async def get_history(self, session_id: str) -> List[ChatTurn]:
         """
         Obtiene el historial de una sesión.
 
@@ -85,9 +137,70 @@ class SessionManager:
         Returns:
             Lista de turnos de la sesión, ordenados cronológicamente
         """
-        return self.sessions.get(session_id, [])
+        if self._redis is not None:
+            try:
+                key = self._history_key(session_id)
+                raw_items = await self._redis.lrange(key, 0, -1)
+                if raw_items:
+                    history = []
+                    for raw in reversed(raw_items):
+                        try:
+                            history.append(ChatTurn.model_validate_json(raw))
+                        except Exception:
+                            logger.warning("Failed to parse ChatTurn JSON: %s", raw)
+                    return history
 
-    def get_context_string(self, session_id: str) -> str:
+                # Cache miss: try Chatwoot API fallback
+                if self._chatwoot is not None:
+                    conversation_id = await self.get_conversation_id(session_id)
+                    if conversation_id:
+                        try:
+                            data = await self._chatwoot.fetch_messages(
+                                int(conversation_id), limit=10
+                            )
+                            turns = self._parse_chatwoot_messages(data)
+                            for turn in turns:
+                                await self._redis.lpush(key, turn.model_dump_json())
+                            await self._redis.ltrim(key, 0, self.max_turns - 1)
+                            return turns
+                        except Exception as exc:
+                            logger.warning(
+                                "Chatwoot fetch_messages fallback failed: %s", exc
+                            )
+            except Exception as exc:
+                logger.warning("Redis get_history failed, using memory: %s", exc)
+
+        with self._lock:
+            return list(self._sessions.get(session_id, []))
+
+    def _parse_chatwoot_messages(self, data: dict[str, Any]) -> List[ChatTurn]:
+        """Parse Chatwoot message payload into ChatTurn objects."""
+        payload = data.get("payload", [])
+        turns: List[ChatTurn] = []
+        i = 0
+        while i < len(payload):
+            msg = payload[i]
+            if msg.get("sender_type") == "contact" or msg.get("message_type") == 0:
+                question = msg.get("content") or ""
+                answer = ""
+                # Look for the next non-contact message as the answer
+                if i + 1 < len(payload):
+                    next_msg = payload[i + 1]
+                    if next_msg.get("sender_type") != "contact":
+                        answer = next_msg.get("content") or ""
+                        i += 1
+                turns.append(
+                    ChatTurn(
+                        question=question,
+                        answer=answer,
+                        timestamp=datetime.now(),
+                        source_documents=[],
+                    )
+                )
+            i += 1
+        return turns
+
+    async def get_context_string(self, session_id: str) -> str:
         """
         Obtiene el historial formateado como string para incluir en el prompt.
 
@@ -97,7 +210,7 @@ class SessionManager:
         Returns:
             String con el historial formateado
         """
-        history = self.get_history(session_id)
+        history = await self.get_history(session_id)
         if not history:
             return ""
 
@@ -112,22 +225,37 @@ class SessionManager:
 
         return "\n".join(context_parts).strip()
 
-    def clear_session(self, session_id: str) -> None:
+    async def clear_session(self, session_id: str) -> None:
         """
         Elimina una sesión.
 
         Args:
             session_id: Identificador único de la sesión
         """
-        with self._lock:
-            if session_id in self.sessions:
-                del self.sessions[session_id]
-            if session_id in self.profiles:
-                del self.profiles[session_id]
-            if session_id in self.token_totals:
-                del self.token_totals[session_id]
+        if self._redis is not None:
+            try:
+                await self._redis.delete(self._history_key(session_id))
+                await self._redis.delete(self._profile_key(session_id))
+                await self._redis.delete(self._tokens_key(session_id))
+                # Remove from mapping hashes
+                conv_id = await self._redis.hget(
+                    self._mapping_session_key(), session_id
+                )
+                if conv_id:
+                    await self._redis.hdel(self._mapping_session_key(), session_id)
+                    await self._redis.hdel(self._mapping_conversation_key(), conv_id)
+            except Exception as exc:
+                logger.warning("Redis clear_session failed: %s", exc)
 
-    def set_user_profile(self, session_id: str, profile: str) -> None:
+        with self._lock:
+            conv_id = self._conversation_map.pop(session_id, None)
+            if conv_id is not None:
+                self._reverse_map.pop(conv_id, None)
+            self._sessions.pop(session_id, None)
+            self._profiles.pop(session_id, None)
+            self._token_totals.pop(session_id, None)
+
+    async def set_user_profile(self, session_id: str, profile: str) -> None:
         """
         Almacena el perfil de usuario para una sesión.
 
@@ -135,10 +263,19 @@ class SessionManager:
             session_id: Identificador único de la sesión
             profile: Perfil de usuario (novato, intermedio, experto)
         """
-        with self._lock:
-            self.profiles[session_id] = profile
+        if self._redis is not None:
+            try:
+                await self._redis.set(
+                    self._profile_key(session_id), profile, ttl=self._TTL_SECONDS
+                )
+                return
+            except Exception as exc:
+                logger.warning("Redis set_user_profile failed, using memory: %s", exc)
 
-    def get_user_profile(self, session_id: str) -> Optional[str]:
+        with self._lock:
+            self._profiles[session_id] = profile
+
+    async def get_user_profile(self, session_id: str) -> Optional[str]:
         """
         Obtiene el perfil de usuario de una sesión.
 
@@ -148,9 +285,18 @@ class SessionManager:
         Returns:
             El perfil de usuario si existe, None en caso contrario
         """
-        return self.profiles.get(session_id)
+        if self._redis is not None:
+            try:
+                result = await self._redis.get(self._profile_key(session_id))
+                if result is not None:
+                    return result
+            except Exception as exc:
+                logger.warning("Redis get_user_profile failed, using memory: %s", exc)
 
-    def add_token_usage(
+        with self._lock:
+            return self._profiles.get(session_id)
+
+    async def add_token_usage(
         self,
         session_id: str,
         input_tokens: int,
@@ -159,22 +305,36 @@ class SessionManager:
     ) -> None:
         """Acumula el uso de tokens para una sesión.
 
-        Thread-safe: opera bajo el mismo ``_lock`` que el resto del gestor.
-
         Args:
             session_id: Identificador único de la sesión.
             input_tokens: Tokens de entrada a acumular.
             output_tokens: Tokens de salida a acumular.
             total_tokens: Total de tokens a acumular.
         """
-        with self._lock:
-            if session_id not in self.token_totals:
-                self.token_totals[session_id] = TokenTotals()
-            self.token_totals[session_id].input_tokens += input_tokens
-            self.token_totals[session_id].output_tokens += output_tokens
-            self.token_totals[session_id].total_tokens += total_tokens
+        if self._redis is not None:
+            try:
+                key = self._tokens_key(session_id)
+                # For accumulation we read current values first, then write back
+                current = await self._redis.hgetall(key)
+                new_input = int(current.get("input_tokens", 0)) + input_tokens
+                new_output = int(current.get("output_tokens", 0)) + output_tokens
+                new_total = int(current.get("total_tokens", 0)) + total_tokens
+                await self._redis.hset(key, "input_tokens", str(new_input))
+                await self._redis.hset(key, "output_tokens", str(new_output))
+                await self._redis.hset(key, "total_tokens", str(new_total))
+                await self._redis.expire(key, self._TTL_SECONDS)
+                return
+            except Exception as exc:
+                logger.warning("Redis add_token_usage failed, using memory: %s", exc)
 
-    def get_token_totals(self, session_id: str) -> TokenTotals:
+        with self._lock:
+            if session_id not in self._token_totals:
+                self._token_totals[session_id] = TokenTotals()
+            self._token_totals[session_id].input_tokens += input_tokens
+            self._token_totals[session_id].output_tokens += output_tokens
+            self._token_totals[session_id].total_tokens += total_tokens
+
+    async def get_token_totals(self, session_id: str) -> TokenTotals:
         """Obtiene los totales de tokens acumulados de una sesión.
 
         Args:
@@ -184,7 +344,20 @@ class SessionManager:
             TokenTotals con los valores acumulados, o TokenTotals() en ceros
             si la sesión no existe.
         """
-        return self.token_totals.get(session_id, TokenTotals())
+        if self._redis is not None:
+            try:
+                result = await self._redis.hgetall(self._tokens_key(session_id))
+                if result:
+                    return TokenTotals(
+                        input_tokens=int(result.get("input_tokens", 0)),
+                        output_tokens=int(result.get("output_tokens", 0)),
+                        total_tokens=int(result.get("total_tokens", 0)),
+                    )
+            except Exception as exc:
+                logger.warning("Redis get_token_totals failed, using memory: %s", exc)
+
+        with self._lock:
+            return self._token_totals.get(session_id, TokenTotals())
 
     def get_session_count(self) -> int:
         """
@@ -193,8 +366,75 @@ class SessionManager:
         Returns:
             Número de sesiones activas
         """
-        return len(self.sessions)
+        return len(self._sessions)
+
+    async def map_conversation(self, session_id: str, conversation_id: str) -> None:
+        """Almacena el mapeo session_id ↔ conversation_id.
+
+        Args:
+            session_id: Identificador de sesión interno.
+            conversation_id: Identificador de conversación en Chatwoot.
+        """
+        if self._redis is not None:
+            try:
+                await self._redis.hset(
+                    self._mapping_session_key(), session_id, conversation_id
+                )
+                await self._redis.hset(
+                    self._mapping_conversation_key(), conversation_id, session_id
+                )
+                return
+            except Exception as exc:
+                logger.warning("Redis map_conversation failed, using memory: %s", exc)
+
+        with self._lock:
+            self._conversation_map[session_id] = conversation_id
+            self._reverse_map[conversation_id] = session_id
+
+    async def get_conversation_id(self, session_id: str) -> Optional[str]:
+        """Obtiene el conversation_id asociado a un session_id.
+
+        Args:
+            session_id: Identificador de sesión interno.
+
+        Returns:
+            conversation_id si existe, None en caso contrario.
+        """
+        if self._redis is not None:
+            try:
+                result = await self._redis.hget(self._mapping_session_key(), session_id)
+                if result is not None:
+                    return result
+            except Exception as exc:
+                logger.warning(
+                    "Redis get_conversation_id failed, using memory: %s", exc
+                )
+
+        with self._lock:
+            return self._conversation_map.get(session_id)
+
+    async def get_session_id(self, conversation_id: str) -> Optional[str]:
+        """Obtiene el session_id asociado a un conversation_id.
+
+        Args:
+            conversation_id: Identificador de conversación en Chatwoot.
+
+        Returns:
+            session_id si existe, None en caso contrario.
+        """
+        if self._redis is not None:
+            try:
+                result = await self._redis.hget(
+                    self._mapping_conversation_key(), conversation_id
+                )
+                if result is not None:
+                    return result
+            except Exception as exc:
+                logger.warning("Redis get_session_id failed, using memory: %s", exc)
+
+        with self._lock:
+            return self._reverse_map.get(conversation_id)
 
 
-# Instancia global del gestor de sesiones
+# Instancia global del gestor de sesiones (sin Redis por defecto para compatibilidad)
 session_manager = SessionManager()

--- a/backend/app/session.py
+++ b/backend/app/session.py
@@ -1,14 +1,17 @@
 """
 Servicio de gestión de sesiones para el chatbot.
-Almacena el historial de conversaciones por session_id.
+
+Mantiene la API síncrona usada por ``/chat`` y añade métodos asíncronos
+Redis-backed para el flujo Chatwoot.
 """
 
 import logging
 import threading
+import uuid
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from backend.app.redis_cache import RedisCache
 
@@ -21,7 +24,7 @@ class ChatTurn(BaseModel):
     question: str
     answer: str
     timestamp: datetime
-    source_documents: List[str] = []
+    source_documents: list[str] = Field(default_factory=list)
 
 
 class TokenTotals(BaseModel):
@@ -39,31 +42,61 @@ class TokenTotals(BaseModel):
 
 
 class SessionManager:
-    """Gestiona las sesiones de conversación con almacenamiento híbrido Redis/memoria."""
+    """Gestiona sesiones con memoria local y métodos Redis async opcionales.
 
-    _TTL_SECONDS = 86400  # 24 horas
+    Args:
+        max_turns: Máximo de turnos preservados por sesión.
+        redis_cache: Redis opcional para flujo Chatwoot.
+        chatwoot_client: Cliente opcional para hidratación futura desde Chatwoot.
+    """
+
+    _TTL_SECONDS = 86400
 
     def __init__(
         self,
         max_turns: int = 20,
         redis_cache: Optional[RedisCache] = None,
         chatwoot_client: Optional[Any] = None,
-    ):
+    ) -> None:
         self.max_turns = max_turns
         self._redis = redis_cache
         self._chatwoot = chatwoot_client
         self._lock = threading.Lock()
-        # Fallback in-memory storage
-        self._sessions: Dict[str, List[ChatTurn]] = {}
-        self._profiles: Dict[str, str] = {}
-        self._token_totals: Dict[str, TokenTotals] = {}
-        self._conversation_map: Dict[str, str] = {}
-        self._reverse_map: Dict[str, str] = {}
+        self._sessions: dict[str, list[ChatTurn]] = {}
+        self._profiles: dict[str, str] = {}
+        self._token_totals: dict[str, TokenTotals] = {}
+        self._conversation_map: dict[str, str] = {}
+        self._reverse_map: dict[str, str] = {}
+
+    @property
+    def sessions(self) -> dict[str, list[ChatTurn]]:
+        """Expose legacy in-memory sessions for tests/debugging."""
+        return self._sessions
+
+    @property
+    def profiles(self) -> dict[str, str]:
+        """Expose legacy in-memory profiles for tests/debugging."""
+        return self._profiles
+
+    @property
+    def token_totals(self) -> dict[str, TokenTotals]:
+        """Expose legacy in-memory token totals for tests/debugging."""
+        return self._token_totals
 
     def _history_key(self, session_id: str) -> str:
         if self._redis is None:
-            return f"history:{session_id}"
-        return self._redis._build_key("history", session_id)
+            return f"session:{session_id}:history"
+        return self._redis._build_key("session", session_id, "history")
+
+    def _conversation_metadata_key(self, conversation_id: str) -> str:
+        if self._redis is None:
+            return f"conversation:{conversation_id}:metadata"
+        return self._redis._build_key("conversation", conversation_id, "metadata")
+
+    def _session_conversation_key(self, session_id: str) -> str:
+        if self._redis is None:
+            return f"session:{session_id}:conversation_id"
+        return self._redis._build_key("session", session_id, "conversation_id")
 
     def _profile_key(self, session_id: str) -> str:
         if self._redis is None:
@@ -75,39 +108,149 @@ class SessionManager:
             return f"tokens:{session_id}"
         return self._redis._build_key("tokens", session_id)
 
-    def _mapping_session_key(self) -> str:
-        if self._redis is None:
-            return "mapping:session"
-        return self._redis._build_key("mapping", "session")
-
-    def _mapping_conversation_key(self) -> str:
-        if self._redis is None:
-            return "mapping:conversation"
-        return self._redis._build_key("mapping", "conversation")
-
-    async def add_turn(
+    def add_turn(
         self,
         session_id: str,
         question: str,
         answer: str,
-        source_documents: Optional[List[str]] = None,
+        source_documents: Optional[list[str]] = None,
     ) -> None:
-        """
-        Añade un turno a la sesión.
-
-        Args:
-            session_id: Identificador único de la sesión
-            question: Pregunta del usuario
-            answer: Respuesta del asistente
-            source_documents: Lista de documentos fuente utilizados (opcional)
-        """
+        """Añade un turno a la memoria local usada por ``/chat``."""
         turn = ChatTurn(
             question=question,
             answer=answer,
             timestamp=datetime.now(),
             source_documents=source_documents or [],
         )
+        self._append_memory_turn(session_id, turn)
 
+    def get_history(self, session_id: str) -> list[ChatTurn]:
+        """Obtiene el historial local síncrono de una sesión."""
+        with self._lock:
+            return list(self._sessions.get(session_id, []))
+
+    def get_context_string(self, session_id: str) -> str:
+        """Obtiene el historial local formateado para incluir en el prompt."""
+        return self._format_context(self.get_history(session_id))
+
+    def clear_session(self, session_id: str) -> None:
+        """Elimina los datos locales de una sesión."""
+        with self._lock:
+            conversation_id = self._conversation_map.pop(session_id, None)
+            if conversation_id is not None:
+                self._reverse_map.pop(conversation_id, None)
+            self._sessions.pop(session_id, None)
+            self._profiles.pop(session_id, None)
+            self._token_totals.pop(session_id, None)
+
+    def set_user_profile(self, session_id: str, profile: str) -> None:
+        """Almacena el perfil local de usuario para una sesión."""
+        with self._lock:
+            self._profiles[session_id] = profile
+
+    def get_user_profile(self, session_id: str) -> Optional[str]:
+        """Obtiene el perfil local de usuario de una sesión."""
+        with self._lock:
+            return self._profiles.get(session_id)
+
+    def add_token_usage(
+        self,
+        session_id: str,
+        input_tokens: int,
+        output_tokens: int,
+        total_tokens: int,
+    ) -> None:
+        """Acumula el uso local de tokens para una sesión."""
+        with self._lock:
+            if session_id not in self._token_totals:
+                self._token_totals[session_id] = TokenTotals()
+            self._token_totals[session_id].input_tokens += input_tokens
+            self._token_totals[session_id].output_tokens += output_tokens
+            self._token_totals[session_id].total_tokens += total_tokens
+
+    def get_token_totals(self, session_id: str) -> TokenTotals:
+        """Obtiene los totales locales de tokens acumulados."""
+        with self._lock:
+            return self._token_totals.get(session_id, TokenTotals())
+
+    def get_session_count(self) -> int:
+        """Obtiene el número de sesiones locales activas."""
+        with self._lock:
+            return len(self._sessions)
+
+    async def get_or_create_session_for_conversation(
+        self, conversation_id: str, account_id: int = 1
+    ) -> str:
+        """Get or create a session mapped to a Chatwoot conversation.
+
+        Args:
+            conversation_id: Chatwoot conversation identifier.
+            account_id: Chatwoot account identifier retained for future metadata.
+
+        Returns:
+            Internal session ID associated with the conversation.
+        """
+        if self._redis is not None:
+            try:
+                metadata_key = self._conversation_metadata_key(conversation_id)
+                existing = await self._redis.hget(metadata_key, "session_id")
+                if existing:
+                    return existing
+
+                session_id = str(uuid.uuid4())
+                await self._redis.hset(metadata_key, "session_id", session_id)
+                await self._redis.hset(metadata_key, "status", "open")
+                await self._redis.hset(metadata_key, "account_id", str(account_id))
+                await self._redis.expire(metadata_key, self._TTL_SECONDS)
+                reverse_key = self._session_conversation_key(session_id)
+                await self._redis.set(
+                    reverse_key, conversation_id, ttl=self._TTL_SECONDS
+                )
+                return session_id
+            except Exception as exc:
+                logger.warning("Redis session mapping failed, using memory: %s", exc)
+
+        with self._lock:
+            existing = self._reverse_map.get(conversation_id)
+            if existing is not None:
+                return existing
+            session_id = str(uuid.uuid4())
+            self._conversation_map[session_id] = conversation_id
+            self._reverse_map[conversation_id] = session_id
+            return session_id
+
+    async def get_conversation_for_session(
+        self, session_id: str, account_id: int = 1
+    ) -> Optional[str]:
+        """Return the Chatwoot conversation ID for an internal session."""
+        del account_id
+        if self._redis is not None:
+            try:
+                result = await self._redis.get(
+                    self._session_conversation_key(session_id)
+                )
+                if result is not None:
+                    return result
+            except Exception as exc:
+                logger.warning("Redis reverse mapping failed, using memory: %s", exc)
+
+        with self._lock:
+            return self._conversation_map.get(session_id)
+
+    async def add_turn_async(
+        self,
+        session_id: str,
+        question: str,
+        answer: str,
+        source_documents: list[str],
+    ) -> None:
+        """Append a conversation turn to Redis history with local fallback."""
+        turn = ChatTurn(
+            question=question,
+            answer=answer,
+            timestamp=datetime.now(),
+            source_documents=source_documents,
+        )
         if self._redis is not None:
             try:
                 key = self._history_key(session_id)
@@ -116,272 +259,67 @@ class SessionManager:
                 await self._redis.expire(key, self._TTL_SECONDS)
                 return
             except Exception as exc:
-                logger.warning("Redis add_turn failed, falling back to memory: %s", exc)
+                logger.warning("Redis add_turn_async failed, using memory: %s", exc)
 
-        with self._lock:
-            if session_id not in self._sessions:
-                self._sessions[session_id] = []
-            self._sessions[session_id].append(turn)
-            if len(self._sessions[session_id]) > self.max_turns:
-                self._sessions[session_id] = self._sessions[session_id][
-                    -self.max_turns :
-                ]
+        self._append_memory_turn(session_id, turn)
 
-    async def get_history(self, session_id: str) -> List[ChatTurn]:
-        """
-        Obtiene el historial de una sesión.
-
-        Args:
-            session_id: Identificador único de la sesión
-
-        Returns:
-            Lista de turnos de la sesión, ordenados cronológicamente
-        """
+    async def get_history_async(
+        self, session_id: str, limit: int = 10
+    ) -> list[ChatTurn]:
+        """Get Redis-backed history with Chatwoot/cache-miss fallback hook."""
         if self._redis is not None:
             try:
-                key = self._history_key(session_id)
-                raw_items = await self._redis.lrange(key, 0, -1)
+                raw_items = await self._redis.lrange(
+                    self._history_key(session_id), 0, limit - 1
+                )
                 if raw_items:
-                    history = []
-                    for raw in reversed(raw_items):
-                        try:
-                            history.append(ChatTurn.model_validate_json(raw))
-                        except Exception:
-                            logger.warning("Failed to parse ChatTurn JSON: %s", raw)
-                    return history
+                    return [
+                        ChatTurn.model_validate_json(raw)
+                        for raw in reversed(raw_items[-limit:])
+                    ]
 
-                # Cache miss: try Chatwoot API fallback
                 if self._chatwoot is not None:
-                    conversation_id = await self.get_conversation_id(session_id)
-                    if conversation_id:
-                        try:
-                            data = await self._chatwoot.fetch_messages(
-                                int(conversation_id), limit=10
-                            )
-                            turns = self._parse_chatwoot_messages(data)
-                            for turn in turns:
-                                await self._redis.lpush(key, turn.model_dump_json())
-                            await self._redis.ltrim(key, 0, self.max_turns - 1)
-                            return turns
-                        except Exception as exc:
-                            logger.warning(
-                                "Chatwoot fetch_messages fallback failed: %s", exc
-                            )
-            except Exception as exc:
-                logger.warning("Redis get_history failed, using memory: %s", exc)
-
-        with self._lock:
-            return list(self._sessions.get(session_id, []))
-
-    def _parse_chatwoot_messages(self, data: dict[str, Any]) -> List[ChatTurn]:
-        """Parse Chatwoot message payload into ChatTurn objects."""
-        payload = data.get("payload", [])
-        turns: List[ChatTurn] = []
-        i = 0
-        while i < len(payload):
-            msg = payload[i]
-            if msg.get("sender_type") == "contact" or msg.get("message_type") == 0:
-                question = msg.get("content") or ""
-                answer = ""
-                # Look for the next non-contact message as the answer
-                if i + 1 < len(payload):
-                    next_msg = payload[i + 1]
-                    if next_msg.get("sender_type") != "contact":
-                        answer = next_msg.get("content") or ""
-                        i += 1
-                turns.append(
-                    ChatTurn(
-                        question=question,
-                        answer=answer,
-                        timestamp=datetime.now(),
-                        source_documents=[],
+                    conversation_id = await self.get_conversation_for_session(
+                        session_id
                     )
-                )
-            i += 1
-        return turns
-
-    async def get_context_string(self, session_id: str) -> str:
-        """
-        Obtiene el historial formateado como string para incluir en el prompt.
-
-        Args:
-            session_id: Identificador único de la sesión
-
-        Returns:
-            String con el historial formateado
-        """
-        history = await self.get_history(session_id)
-        if not history:
-            return ""
-
-        context_parts = []
-        for i, turn in enumerate(history, 1):
-            context_parts.append(f"Turno {i}:")
-            context_parts.append(f"Usuario: {turn.question}")
-            context_parts.append(f"Asistente: {turn.answer}")
-            if turn.source_documents:
-                context_parts.append(f"Fuentes: {', '.join(turn.source_documents)}")
-            context_parts.append("")  # Línea vacía entre turnos
-
-        return "\n".join(context_parts).strip()
-
-    async def clear_session(self, session_id: str) -> None:
-        """
-        Elimina una sesión.
-
-        Args:
-            session_id: Identificador único de la sesión
-        """
-        if self._redis is not None:
-            try:
-                await self._redis.delete(self._history_key(session_id))
-                await self._redis.delete(self._profile_key(session_id))
-                await self._redis.delete(self._tokens_key(session_id))
-                # Remove from mapping hashes
-                conv_id = await self._redis.hget(
-                    self._mapping_session_key(), session_id
-                )
-                if conv_id:
-                    await self._redis.hdel(self._mapping_session_key(), session_id)
-                    await self._redis.hdel(self._mapping_conversation_key(), conv_id)
+                    if conversation_id is not None:
+                        data = await self._chatwoot.fetch_messages(
+                            int(conversation_id), limit=limit * 2
+                        )
+                        await self.hydrate_history_from_chatwoot(
+                            session_id, data.get("payload", [])
+                        )
+                        return await self.get_history_async(session_id, limit=limit)
             except Exception as exc:
-                logger.warning("Redis clear_session failed: %s", exc)
+                logger.warning("Redis get_history_async failed, using memory: %s", exc)
 
         with self._lock:
-            conv_id = self._conversation_map.pop(session_id, None)
-            if conv_id is not None:
-                self._reverse_map.pop(conv_id, None)
-            self._sessions.pop(session_id, None)
-            self._profiles.pop(session_id, None)
-            self._token_totals.pop(session_id, None)
+            return list(self._sessions.get(session_id, []))[-limit:]
 
-    async def set_user_profile(self, session_id: str, profile: str) -> None:
-        """
-        Almacena el perfil de usuario para una sesión.
-
-        Args:
-            session_id: Identificador único de la sesión
-            profile: Perfil de usuario (novato, intermedio, experto)
-        """
-        if self._redis is not None:
-            try:
-                await self._redis.set(
-                    self._profile_key(session_id), profile, ttl=self._TTL_SECONDS
-                )
-                return
-            except Exception as exc:
-                logger.warning("Redis set_user_profile failed, using memory: %s", exc)
-
-        with self._lock:
-            self._profiles[session_id] = profile
-
-    async def get_user_profile(self, session_id: str) -> Optional[str]:
-        """
-        Obtiene el perfil de usuario de una sesión.
-
-        Args:
-            session_id: Identificador único de la sesión
-
-        Returns:
-            El perfil de usuario si existe, None en caso contrario
-        """
-        if self._redis is not None:
-            try:
-                result = await self._redis.get(self._profile_key(session_id))
-                if result is not None:
-                    return result
-            except Exception as exc:
-                logger.warning("Redis get_user_profile failed, using memory: %s", exc)
-
-        with self._lock:
-            return self._profiles.get(session_id)
-
-    async def add_token_usage(
-        self,
-        session_id: str,
-        input_tokens: int,
-        output_tokens: int,
-        total_tokens: int,
+    async def hydrate_history_from_chatwoot(
+        self, session_id: str, messages: list[dict[str, Any]]
     ) -> None:
-        """Acumula el uso de tokens para una sesión.
-
-        Args:
-            session_id: Identificador único de la sesión.
-            input_tokens: Tokens de entrada a acumular.
-            output_tokens: Tokens de salida a acumular.
-            total_tokens: Total de tokens a acumular.
-        """
-        if self._redis is not None:
-            try:
-                key = self._tokens_key(session_id)
-                # For accumulation we read current values first, then write back
-                current = await self._redis.hgetall(key)
-                new_input = int(current.get("input_tokens", 0)) + input_tokens
-                new_output = int(current.get("output_tokens", 0)) + output_tokens
-                new_total = int(current.get("total_tokens", 0)) + total_tokens
-                await self._redis.hset(key, "input_tokens", str(new_input))
-                await self._redis.hset(key, "output_tokens", str(new_output))
-                await self._redis.hset(key, "total_tokens", str(new_total))
-                await self._redis.expire(key, self._TTL_SECONDS)
-                return
-            except Exception as exc:
-                logger.warning("Redis add_token_usage failed, using memory: %s", exc)
-
-        with self._lock:
-            if session_id not in self._token_totals:
-                self._token_totals[session_id] = TokenTotals()
-            self._token_totals[session_id].input_tokens += input_tokens
-            self._token_totals[session_id].output_tokens += output_tokens
-            self._token_totals[session_id].total_tokens += total_tokens
-
-    async def get_token_totals(self, session_id: str) -> TokenTotals:
-        """Obtiene los totales de tokens acumulados de una sesión.
-
-        Args:
-            session_id: Identificador único de la sesión.
-
-        Returns:
-            TokenTotals con los valores acumulados, o TokenTotals() en ceros
-            si la sesión no existe.
-        """
-        if self._redis is not None:
-            try:
-                result = await self._redis.hgetall(self._tokens_key(session_id))
-                if result:
-                    return TokenTotals(
-                        input_tokens=int(result.get("input_tokens", 0)),
-                        output_tokens=int(result.get("output_tokens", 0)),
-                        total_tokens=int(result.get("total_tokens", 0)),
-                    )
-            except Exception as exc:
-                logger.warning("Redis get_token_totals failed, using memory: %s", exc)
-
-        with self._lock:
-            return self._token_totals.get(session_id, TokenTotals())
-
-    def get_session_count(self) -> int:
-        """
-        Obtiene el número de sesiones activas.
-
-        Returns:
-            Número de sesiones activas
-        """
-        return len(self._sessions)
+        """Transform Chatwoot messages into ChatTurn entries and cache them."""
+        turns = self._parse_chatwoot_messages(messages)
+        for turn in turns[-self.max_turns :]:
+            await self.add_turn_async(
+                session_id,
+                turn.question,
+                turn.answer,
+                turn.source_documents,
+            )
 
     async def map_conversation(self, session_id: str, conversation_id: str) -> None:
-        """Almacena el mapeo session_id ↔ conversation_id.
-
-        Args:
-            session_id: Identificador de sesión interno.
-            conversation_id: Identificador de conversación en Chatwoot.
-        """
+        """Backward-compatible async mapping helper."""
         if self._redis is not None:
             try:
-                await self._redis.hset(
-                    self._mapping_session_key(), session_id, conversation_id
-                )
-                await self._redis.hset(
-                    self._mapping_conversation_key(), conversation_id, session_id
+                metadata_key = self._conversation_metadata_key(conversation_id)
+                await self._redis.hset(metadata_key, "session_id", session_id)
+                await self._redis.expire(metadata_key, self._TTL_SECONDS)
+                await self._redis.set(
+                    self._session_conversation_key(session_id),
+                    conversation_id,
+                    ttl=self._TTL_SECONDS,
                 )
                 return
             except Exception as exc:
@@ -392,40 +330,15 @@ class SessionManager:
             self._reverse_map[conversation_id] = session_id
 
     async def get_conversation_id(self, session_id: str) -> Optional[str]:
-        """Obtiene el conversation_id asociado a un session_id.
-
-        Args:
-            session_id: Identificador de sesión interno.
-
-        Returns:
-            conversation_id si existe, None en caso contrario.
-        """
-        if self._redis is not None:
-            try:
-                result = await self._redis.hget(self._mapping_session_key(), session_id)
-                if result is not None:
-                    return result
-            except Exception as exc:
-                logger.warning(
-                    "Redis get_conversation_id failed, using memory: %s", exc
-                )
-
-        with self._lock:
-            return self._conversation_map.get(session_id)
+        """Backward-compatible alias for get_conversation_for_session."""
+        return await self.get_conversation_for_session(session_id)
 
     async def get_session_id(self, conversation_id: str) -> Optional[str]:
-        """Obtiene el session_id asociado a un conversation_id.
-
-        Args:
-            conversation_id: Identificador de conversación en Chatwoot.
-
-        Returns:
-            session_id si existe, None en caso contrario.
-        """
+        """Backward-compatible lookup from conversation ID to session ID."""
         if self._redis is not None:
             try:
                 result = await self._redis.hget(
-                    self._mapping_conversation_key(), conversation_id
+                    self._conversation_metadata_key(conversation_id), "session_id"
                 )
                 if result is not None:
                     return result
@@ -435,6 +348,87 @@ class SessionManager:
         with self._lock:
             return self._reverse_map.get(conversation_id)
 
+    def _append_memory_turn(self, session_id: str, turn: ChatTurn) -> None:
+        """Append a turn to the in-memory fallback store."""
+        with self._lock:
+            if session_id not in self._sessions:
+                self._sessions[session_id] = []
+            self._sessions[session_id].append(turn)
+            if len(self._sessions[session_id]) > self.max_turns:
+                self._sessions[session_id] = self._sessions[session_id][
+                    -self.max_turns :
+                ]
 
-# Instancia global del gestor de sesiones (sin Redis por defecto para compatibilidad)
+    def _format_context(self, history: list[ChatTurn]) -> str:
+        """Format a list of turns for prompt context."""
+        if not history:
+            return ""
+
+        context_parts = []
+        for index, turn in enumerate(history, 1):
+            context_parts.append(f"Turno {index}:")
+            context_parts.append(f"Usuario: {turn.question}")
+            context_parts.append(f"Asistente: {turn.answer}")
+            if turn.source_documents:
+                context_parts.append(f"Fuentes: {', '.join(turn.source_documents)}")
+            context_parts.append("")
+        return "\n".join(context_parts).strip()
+
+    def _parse_chatwoot_messages(
+        self, messages: list[dict[str, Any]]
+    ) -> list[ChatTurn]:
+        """Parse Chatwoot incoming/outgoing messages into turns."""
+        turns: list[ChatTurn] = []
+        pending_question: Optional[str] = None
+
+        for message in messages:
+            content = str(message.get("content") or "").strip()
+            if not content:
+                continue
+
+            if self._is_incoming_message(message):
+                if pending_question is not None:
+                    turns.append(
+                        ChatTurn(
+                            question=pending_question,
+                            answer="",
+                            timestamp=datetime.now(),
+                            source_documents=[],
+                        )
+                    )
+                pending_question = content
+                continue
+
+            if pending_question is not None:
+                turns.append(
+                    ChatTurn(
+                        question=pending_question,
+                        answer=content,
+                        timestamp=datetime.now(),
+                        source_documents=[],
+                    )
+                )
+                pending_question = None
+
+        if pending_question is not None:
+            turns.append(
+                ChatTurn(
+                    question=pending_question,
+                    answer="",
+                    timestamp=datetime.now(),
+                    source_documents=[],
+                )
+            )
+        return turns
+
+    def _is_incoming_message(self, message: dict[str, Any]) -> bool:
+        """Return True for Chatwoot contact/incoming messages."""
+        message_type = message.get("message_type")
+        sender_type = message.get("sender_type") or message.get("sender", {}).get(
+            "type"
+        )
+        return message_type in ("incoming", 0) or sender_type == "contact"
+
+
+# Instancia global del gestor de sesiones
 session_manager = SessionManager()

--- a/backend/tests/test_chatwoot_handler.py
+++ b/backend/tests/test_chatwoot_handler.py
@@ -22,7 +22,9 @@ from backend.app.schemas import (
 
 @pytest.fixture
 def chatwoot_client() -> Any:
-    return MagicMock()
+    client = AsyncMock()
+    client.send_typing_indicator.return_value = True
+    return client
 
 
 @pytest.fixture
@@ -30,6 +32,9 @@ def redis_cache() -> Any:
     cache = AsyncMock()
     cache._prefix = "chatwoot"
     cache._account_id = 1
+    cache._build_key = lambda scope, entity_id, field=None: (
+        f"chatwoot:1:{scope}:{entity_id}" + (f":{field}" if field else "")
+    )
     return cache
 
 
@@ -37,17 +42,46 @@ def redis_cache() -> Any:
 def config_provider() -> Any:
     provider = MagicMock()
     provider.is_chatwoot_enabled.return_value = True
+    profile = MagicMock()
+    profile.buffer_window_seconds = 7
+    provider.get_channel_profile.return_value = profile
     return provider
 
 
 @pytest.fixture
+def message_buffer() -> Any:
+    buffer = AsyncMock()
+    return buffer
+
+
+@pytest.fixture
+def session_manager() -> Any:
+    manager = AsyncMock()
+    manager.get_or_create_session_for_conversation.return_value = "session-42"
+    return manager
+
+
+@pytest.fixture
+def escalation_handler() -> Any:
+    return AsyncMock()
+
+
+@pytest.fixture
 def handler(
-    chatwoot_client: Any, redis_cache: Any, config_provider: Any
+    chatwoot_client: Any,
+    redis_cache: Any,
+    config_provider: Any,
+    message_buffer: Any,
+    session_manager: Any,
+    escalation_handler: Any,
 ) -> ChatwootHandler:
     return ChatwootHandler(
         chatwoot_client=chatwoot_client,
         redis_cache=redis_cache,
         config_provider=config_provider,
+        message_buffer=message_buffer,
+        session_manager=session_manager,
+        escalation_handler=escalation_handler,
     )
 
 
@@ -96,6 +130,53 @@ class TestIdempotency:
 
 class TestHandleMessageCreated:
     """Dispatch of 'message_created' events."""
+
+    @pytest.mark.asyncio
+    async def test_contact_message_creates_session_and_adds_buffer(
+        self,
+        handler: ChatwootHandler,
+        session_manager: Any,
+        message_buffer: Any,
+    ) -> None:
+        payload = _message_payload(sender_type="contact", content="hola")
+
+        await handler._handle_message_created(payload)
+
+        session_manager.get_or_create_session_for_conversation.assert_awaited_once_with(
+            "42", account_id=1
+        )
+        message_buffer.add_message.assert_awaited_once_with("42", "hola", 7)
+
+    @pytest.mark.asyncio
+    async def test_contact_message_sends_typing_indicator(
+        self, handler: ChatwootHandler, chatwoot_client: Any
+    ) -> None:
+        payload = _message_payload(sender_type="contact")
+
+        await handler._handle_message_created(payload)
+
+        chatwoot_client.send_typing_indicator.assert_awaited_once_with(42)
+
+    @pytest.mark.asyncio
+    async def test_human_message_flushes_and_cancels(
+        self, handler: ChatwootHandler, message_buffer: Any
+    ) -> None:
+        payload = _message_payload(sender_type="user")
+
+        await handler._handle_message_created(payload)
+
+        message_buffer.flush_and_cancel.assert_awaited_once_with("42")
+
+    @pytest.mark.asyncio
+    async def test_duplicate_message_ignored_before_buffer(
+        self, handler: ChatwootHandler, message_buffer: Any
+    ) -> None:
+        payload = _message_payload(sender_type="contact")
+        handler._is_duplicate = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+        await handler.handle_event(payload)
+
+        message_buffer.add_message.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_contact_message_logs_received(

--- a/backend/tests/test_escalation_handler.py
+++ b/backend/tests/test_escalation_handler.py
@@ -1,0 +1,186 @@
+"""Tests for EscalationHandler.
+
+Validates Chatwoot integration during human escalation handoff.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.app.chatwoot_client import ChatwootClient
+from backend.app.escalation_handler import DEFAULT_ESCALATION_MESSAGE, EscalationHandler
+from backend.app.session import SessionManager
+
+
+class MockConfigProvider:
+    """Minimal config provider for tests."""
+
+    def __init__(self, enabled: bool = True, handoff_team_id: int = 5) -> None:
+        self._enabled = enabled
+        self._handoff = handoff_team_id
+
+    def get_label(self, name: str) -> str:
+        mapping = {
+            "escalated": "escalated-test",
+            "quote": "quote-test",
+            "technical": "technical-test",
+            "order": "order-test",
+        }
+        return mapping.get(name, name)
+
+    def get_handoff_target(self) -> int:
+        return self._handoff
+
+    def is_chatwoot_enabled(self) -> bool:
+        return self._enabled
+
+
+@pytest.fixture
+def mock_chatwoot_client() -> ChatwootClient:
+    client = AsyncMock(spec=ChatwootClient)
+    client.send_message.return_value = {"id": 99}
+    client.add_label.return_value = {"labels": ["escalated"]}
+    client.toggle_status.return_value = {"status": "open"}
+    client.assign_conversation.return_value = {"id": 42}
+    return client  # type: ignore[return-value]
+
+
+@pytest.fixture
+def config_provider() -> MockConfigProvider:
+    return MockConfigProvider()
+
+
+@pytest.fixture
+def session_manager() -> SessionManager:
+    return SessionManager()
+
+
+@pytest.fixture
+def escalation_handler(
+    mock_chatwoot_client: ChatwootClient,
+    config_provider: MockConfigProvider,
+    session_manager: SessionManager,
+) -> EscalationHandler:
+    return EscalationHandler(
+        chatwoot_client=mock_chatwoot_client,
+        config_provider=config_provider,
+        session_manager=session_manager,
+    )
+
+
+class TestHandleEscalation:
+    """Escalation handoff must trigger all Chatwoot operations."""
+
+    @pytest.mark.asyncio
+    async def test_handle_escalation_calls_all_methods(
+        self,
+        escalation_handler: EscalationHandler,
+        mock_chatwoot_client: Any,
+    ) -> None:
+        await escalation_handler.handle_escalation("s1", 42, "user requested quote")
+
+        mock_chatwoot_client.add_label.assert_awaited_once_with(42, "escalated-test")
+        mock_chatwoot_client.toggle_status.assert_awaited_once_with(42, "open")
+        mock_chatwoot_client.assign_conversation.assert_awaited_once_with(42, team_id=5)
+        mock_chatwoot_client.send_message.assert_awaited_once_with(
+            42, DEFAULT_ESCALATION_MESSAGE
+        )
+
+    @pytest.mark.asyncio
+    async def test_handle_escalation_stores_reason_in_session(
+        self,
+        escalation_handler: EscalationHandler,
+        session_manager: SessionManager,
+    ) -> None:
+        await escalation_handler.handle_escalation("s1", 42, "user requested quote")
+        reason = await session_manager.get_user_profile("s1")
+        # Escalation reason stored as a custom attribute via profile for now
+        assert reason is not None
+
+
+class TestHandleEscalationByIntent:
+    """Intent-to-label mapping and delegation."""
+
+    @pytest.mark.asyncio
+    async def test_escalate_quote_maps_to_quote_label(
+        self,
+        escalation_handler: EscalationHandler,
+        mock_chatwoot_client: Any,
+    ) -> None:
+        result = await escalation_handler.handle_escalation_by_intent(
+            "s1", 42, "escalate_quote"
+        )
+        assert result is True
+        calls = [c.args for c in mock_chatwoot_client.add_label.await_args_list]
+        assert (42, "quote-test") in calls
+
+    @pytest.mark.asyncio
+    async def test_escalate_technical_maps_to_technical_label(
+        self,
+        escalation_handler: EscalationHandler,
+        mock_chatwoot_client: Any,
+    ) -> None:
+        await escalation_handler.handle_escalation_by_intent("s1", 42, "escalate_technical")
+        calls = [c.args for c in mock_chatwoot_client.add_label.await_args_list]
+        assert (42, "technical-test") in calls
+
+    @pytest.mark.asyncio
+    async def test_escalate_order_maps_to_order_label(
+        self,
+        escalation_handler: EscalationHandler,
+        mock_chatwoot_client: Any,
+    ) -> None:
+        await escalation_handler.handle_escalation_by_intent("s1", 42, "escalate_order")
+        calls = [c.args for c in mock_chatwoot_client.add_label.await_args_list]
+        assert (42, "order-test") in calls
+
+    @pytest.mark.asyncio
+    async def test_unknown_intent_returns_false(
+        self,
+        escalation_handler: EscalationHandler,
+    ) -> None:
+        result = await escalation_handler.handle_escalation_by_intent("s1", 42, "unknown")
+        assert result is False
+
+
+class TestGracefulDegradation:
+    """Errors in Chatwoot API must not crash the handler."""
+
+    @pytest.mark.asyncio
+    async def test_api_error_logged_not_raised(
+        self,
+        config_provider: MockConfigProvider,
+        session_manager: SessionManager,
+    ) -> None:
+        failing_client = AsyncMock(spec=ChatwootClient)
+        failing_client.add_label.side_effect = RuntimeError("network error")
+
+        handler = EscalationHandler(
+            chatwoot_client=failing_client,
+            config_provider=config_provider,
+            session_manager=session_manager,
+        )
+
+        # Should not raise
+        await handler.handle_escalation("s1", 42, "reason")
+
+    @pytest.mark.asyncio
+    async def test_partial_failure_continues(
+        self,
+        config_provider: MockConfigProvider,
+        session_manager: SessionManager,
+    ) -> None:
+        failing_client = AsyncMock(spec=ChatwootClient)
+        failing_client.add_label.return_value = {"success": True}
+        failing_client.toggle_status.side_effect = RuntimeError("status error")
+
+        handler = EscalationHandler(
+            chatwoot_client=failing_client,
+            config_provider=config_provider,
+            session_manager=session_manager,
+        )
+
+        # Should not raise even though toggle_status fails
+        await handler.handle_escalation("s1", 42, "reason")
+        failing_client.add_label.assert_awaited_once()

--- a/backend/tests/test_escalation_handler.py
+++ b/backend/tests/test_escalation_handler.py
@@ -73,6 +73,82 @@ class TestHandleEscalation:
     """Escalation handoff must trigger all Chatwoot operations."""
 
     @pytest.mark.asyncio
+    async def test_escalate_to_human_success(
+        self,
+        escalation_handler: EscalationHandler,
+        mock_chatwoot_client: Any,
+    ) -> None:
+        result = await escalation_handler.escalate_to_human(
+            conversation_id=42,
+            reason="Necesita cotización",
+            intent_type="escalate_quote",
+        )
+
+        assert result is True
+        assert mock_chatwoot_client.add_label.await_args_list[0].args == (
+            42,
+            "escalated-test",
+        )
+        assert mock_chatwoot_client.add_label.await_args_list[1].args == (
+            42,
+            "quote-test",
+        )
+        mock_chatwoot_client.toggle_status.assert_awaited_once_with(42, "open")
+        mock_chatwoot_client.assign_conversation.assert_awaited_once_with(42, team_id=5)
+        mock_chatwoot_client.send_message.assert_awaited_once_with(
+            42, DEFAULT_ESCALATION_MESSAGE
+        )
+
+    @pytest.mark.asyncio
+    async def test_escalate_to_human_without_team_skips_assignment(
+        self,
+        mock_chatwoot_client: Any,
+        session_manager: SessionManager,
+    ) -> None:
+        handler = EscalationHandler(
+            chatwoot_client=mock_chatwoot_client,
+            config_provider=MockConfigProvider(handoff_team_id=None),
+            session_manager=session_manager,
+        )
+
+        assert await handler.escalate_to_human(42, "reason", "escalate_quote")
+        mock_chatwoot_client.assign_conversation.assert_not_awaited()
+        mock_chatwoot_client.toggle_status.assert_awaited_once_with(42, "open")
+
+    @pytest.mark.asyncio
+    async def test_escalate_to_human_label_failure_continues(
+        self,
+        mock_chatwoot_client: Any,
+        config_provider: MockConfigProvider,
+        session_manager: SessionManager,
+    ) -> None:
+        mock_chatwoot_client.add_label.side_effect = RuntimeError("label down")
+        handler = EscalationHandler(
+            chatwoot_client=mock_chatwoot_client,
+            config_provider=config_provider,
+            session_manager=session_manager,
+        )
+
+        assert await handler.escalate_to_human(42, "reason", "escalate_quote")
+        mock_chatwoot_client.toggle_status.assert_awaited_once_with(42, "open")
+
+    @pytest.mark.asyncio
+    async def test_escalate_to_human_critical_failure_returns_false(
+        self,
+        mock_chatwoot_client: Any,
+        config_provider: MockConfigProvider,
+        session_manager: SessionManager,
+    ) -> None:
+        mock_chatwoot_client.toggle_status.side_effect = RuntimeError("status down")
+        handler = EscalationHandler(
+            chatwoot_client=mock_chatwoot_client,
+            config_provider=config_provider,
+            session_manager=session_manager,
+        )
+
+        assert not await handler.escalate_to_human(42, "reason", "escalate_quote")
+
+    @pytest.mark.asyncio
     async def test_handle_escalation_calls_all_methods(
         self,
         escalation_handler: EscalationHandler,
@@ -94,7 +170,7 @@ class TestHandleEscalation:
         session_manager: SessionManager,
     ) -> None:
         await escalation_handler.handle_escalation("s1", 42, "user requested quote")
-        reason = await session_manager.get_user_profile("s1")
+        reason = session_manager.get_user_profile("s1")
         # Escalation reason stored as a custom attribute via profile for now
         assert reason is not None
 
@@ -121,7 +197,9 @@ class TestHandleEscalationByIntent:
         escalation_handler: EscalationHandler,
         mock_chatwoot_client: Any,
     ) -> None:
-        await escalation_handler.handle_escalation_by_intent("s1", 42, "escalate_technical")
+        await escalation_handler.handle_escalation_by_intent(
+            "s1", 42, "escalate_technical"
+        )
         calls = [c.args for c in mock_chatwoot_client.add_label.await_args_list]
         assert (42, "technical-test") in calls
 
@@ -140,7 +218,9 @@ class TestHandleEscalationByIntent:
         self,
         escalation_handler: EscalationHandler,
     ) -> None:
-        result = await escalation_handler.handle_escalation_by_intent("s1", 42, "unknown")
+        result = await escalation_handler.handle_escalation_by_intent(
+            "s1", 42, "unknown"
+        )
         assert result is False
 
 

--- a/backend/tests/test_message_buffer_redis.py
+++ b/backend/tests/test_message_buffer_redis.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fakeredis import FakeAsyncRedis
 
-from backend.app.message_buffer import BufferResult, MessageBuffer
+from backend.app.message_buffer import BufferResult, MessageBuffer, RedisMessageBuffer
 from backend.app.redis_cache import RedisCache
 
 
@@ -77,6 +77,44 @@ class TestAddToBuffer:
         result = await message_buffer.add("session-1", "hello")
         assert result.is_buffering is True
         assert result.joined_message is None
+
+
+class TestChatwootBufferApi:
+    """Chatwoot-facing buffer methods use conversation IDs and spec state."""
+
+    @pytest.mark.asyncio
+    async def test_add_message_stores_spec_state(
+        self, message_buffer: MessageBuffer
+    ) -> None:
+        state = await message_buffer.add_message("42", "hola", window_seconds=5)
+
+        assert state.conversation_id == "42"
+        assert state.messages == ["hola"]
+        assert state.timer_deadline_epoch is not None
+        assert state.is_flushing is False
+
+        raw = await message_buffer._redis.get(message_buffer._buffer_key("42"))
+        stored = json.loads(raw)
+        assert stored["conversation_id"] == "42"
+        assert stored["messages"] == ["hola"]
+
+    @pytest.mark.asyncio
+    async def test_flush_uses_lock_and_prevents_duplicate(
+        self, message_buffer: MessageBuffer
+    ) -> None:
+        await message_buffer.add_message("42", "uno", window_seconds=5)
+        lock_key = message_buffer._lock_key("42")
+        assert await message_buffer._redis.acquire_lock(lock_key, ttl_seconds=30)
+
+        try:
+            assert await message_buffer.flush("42") is None
+        finally:
+            await message_buffer._redis.release_lock(lock_key)
+
+        assert await message_buffer.flush("42") == "uno"
+
+    def test_redis_message_buffer_alias(self) -> None:
+        assert RedisMessageBuffer is MessageBuffer
 
     @pytest.mark.asyncio
     async def test_add_appends_message(self, message_buffer: MessageBuffer) -> None:

--- a/backend/tests/test_message_buffer_redis.py
+++ b/backend/tests/test_message_buffer_redis.py
@@ -1,0 +1,322 @@
+"""Tests for Redis-backed MessageBuffer.
+
+Uses fakeredis to exercise all buffer operations without a real Redis server.
+"""
+
+import asyncio
+import json
+import time
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fakeredis import FakeAsyncRedis
+
+from backend.app.message_buffer import BufferResult, MessageBuffer
+from backend.app.redis_cache import RedisCache
+
+
+class MockConfigProvider:
+    """Minimal config provider for tests."""
+
+    def __init__(self, window_seconds: int = 5, max_messages: int = 5) -> None:
+        self._window = window_seconds
+        self._max = max_messages
+
+    def get(self, key: str) -> Any:
+        if key == "buffer_window_seconds":
+            return self._window
+        if key == "buffer_max_messages":
+            return self._max
+        return None
+
+
+@pytest.fixture
+def fake_redis() -> FakeAsyncRedis:
+    return FakeAsyncRedis(decode_responses=True)
+
+
+@pytest.fixture
+def redis_cache(fake_redis: FakeAsyncRedis) -> RedisCache:
+    with patch("backend.app.redis_cache.redis.asyncio.Redis") as MockRedis:
+        MockRedis.from_url.return_value = fake_redis
+        return RedisCache(redis_url="redis://localhost:6379/0")
+
+
+@pytest.fixture
+def config_provider() -> MockConfigProvider:
+    return MockConfigProvider(window_seconds=5, max_messages=5)
+
+
+@pytest.fixture
+def message_buffer(
+    redis_cache: RedisCache, config_provider: MockConfigProvider
+) -> MessageBuffer:
+    return MessageBuffer(redis_cache=redis_cache, config_provider=config_provider)
+
+
+class TestBufferResultModel:
+    """BufferResult Pydantic model must behave correctly."""
+
+    def test_buffer_result_defaults(self) -> None:
+        result = BufferResult(is_buffering=True)
+        assert result.is_buffering is True
+        assert result.joined_message is None
+
+    def test_buffer_result_with_message(self) -> None:
+        result = BufferResult(is_buffering=False, joined_message="hello\nworld")
+        assert result.is_buffering is False
+        assert result.joined_message == "hello\nworld"
+
+
+class TestAddToBuffer:
+    """Accumulating messages in the Redis-backed buffer."""
+
+    @pytest.mark.asyncio
+    async def test_add_creates_new_buffer(self, message_buffer: MessageBuffer) -> None:
+        result = await message_buffer.add("session-1", "hello")
+        assert result.is_buffering is True
+        assert result.joined_message is None
+
+    @pytest.mark.asyncio
+    async def test_add_appends_message(self, message_buffer: MessageBuffer) -> None:
+        await message_buffer.add("session-1", "hello")
+        await message_buffer.add("session-1", "world")
+        count = await message_buffer.get_count("session-1")
+        assert count == 2
+
+    @pytest.mark.asyncio
+    async def test_add_returns_joined_on_count_limit(
+        self, message_buffer: MessageBuffer
+    ) -> None:
+        # max_messages = 5 in fixture
+        await message_buffer.add("session-1", "a")
+        await message_buffer.add("session-1", "b")
+        await message_buffer.add("session-1", "c")
+        await message_buffer.add("session-1", "d")
+        result = await message_buffer.add("session-1", "e")
+        assert result.is_buffering is False
+        assert result.joined_message == "a\nb\nc\nd\ne"
+
+    @pytest.mark.asyncio
+    async def test_add_returns_joined_on_expired_deadline(
+        self, message_buffer: MessageBuffer
+    ) -> None:
+        # Use a tiny window so deadline expires immediately
+        provider = MockConfigProvider(window_seconds=0, max_messages=5)
+        buf = MessageBuffer(redis_cache=message_buffer._redis, config_provider=provider)
+        await buf.add("session-1", "hello")
+        # Small sleep to ensure deadline passed
+        await asyncio.sleep(0.05)
+        result = await buf.add("session-1", "world")
+        assert result.is_buffering is False
+        assert result.joined_message == "hello\nworld"
+
+    @pytest.mark.asyncio
+    async def test_add_on_flushing_buffer_returns_immediately(
+        self, message_buffer: MessageBuffer
+    ) -> None:
+        # Simulate flush_and_cancel setting is_flushing=true
+        key = message_buffer._buffer_key("session-1")
+        await message_buffer._redis.set(
+            key,
+            json.dumps(
+                {"messages": ["a"], "deadline": time.time() + 60, "is_flushing": True}
+            ),
+        )
+        result = await message_buffer.add("session-1", "b")
+        assert result.is_buffering is True
+        assert result.joined_message is None
+
+
+class TestFlush:
+    """Flushing buffered messages."""
+
+    @pytest.mark.asyncio
+    async def test_flush_returns_joined_messages(
+        self, message_buffer: MessageBuffer
+    ) -> None:
+        await message_buffer.add("session-1", "hello")
+        await message_buffer.add("session-1", "world")
+        joined = await message_buffer.flush("session-1")
+        assert joined == "hello\nworld"
+
+    @pytest.mark.asyncio
+    async def test_flush_deletes_redis_key(self, message_buffer: MessageBuffer) -> None:
+        await message_buffer.add("session-1", "hello")
+        await message_buffer.flush("session-1")
+        count = await message_buffer.get_count("session-1")
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_flush_empty_buffer_returns_none(
+        self, message_buffer: MessageBuffer
+    ) -> None:
+        joined = await message_buffer.flush("session-1")
+        assert joined is None
+
+
+class TestFlushAndCancel:
+    """Race-condition guard for human-agent intervention."""
+
+    @pytest.mark.asyncio
+    async def test_flush_and_cancel_acquires_lock(
+        self, message_buffer: MessageBuffer
+    ) -> None:
+        await message_buffer.add("session-1", "hello")
+        joined = await message_buffer.flush_and_cancel("session-1")
+        assert joined == "hello"
+
+    @pytest.mark.asyncio
+    async def test_flush_and_cancel_sets_is_flushing(
+        self, message_buffer: MessageBuffer
+    ) -> None:
+        await message_buffer.add("session-1", "hello")
+        await message_buffer.flush_and_cancel("session-1")
+        # After flush, key should be deleted
+        count = await message_buffer.get_count("session-1")
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_flush_and_cancel_empty_buffer(
+        self, message_buffer: MessageBuffer
+    ) -> None:
+        joined = await message_buffer.flush_and_cancel("session-1")
+        assert joined is None
+
+    @pytest.mark.asyncio
+    async def test_concurrent_adds_prevented_by_lock(
+        self, message_buffer: MessageBuffer
+    ) -> None:
+        await message_buffer.add("session-1", "hello")
+
+        # Acquire lock manually to simulate another flush in progress
+        lock_key = message_buffer._lock_key("session-1")
+        acquired = await message_buffer._redis.acquire_lock(lock_key, ttl_seconds=30)
+        assert acquired is True
+
+        try:
+            # flush_and_cancel should not be able to acquire lock
+            joined = await message_buffer.flush_and_cancel("session-1")
+            assert joined is None
+        finally:
+            await message_buffer._redis.release_lock(lock_key)
+
+
+class TestIsBuffering:
+    """Checking if a session has buffered messages."""
+
+    @pytest.mark.asyncio
+    async def test_is_buffering_true(self, message_buffer: MessageBuffer) -> None:
+        await message_buffer.add("session-1", "hello")
+        assert await message_buffer.is_buffering("session-1") is True
+
+    @pytest.mark.asyncio
+    async def test_is_buffering_false(self, message_buffer: MessageBuffer) -> None:
+        assert await message_buffer.is_buffering("session-1") is False
+
+
+class TestGetCount:
+    """Getting the number of buffered messages."""
+
+    @pytest.mark.asyncio
+    async def test_get_count(self, message_buffer: MessageBuffer) -> None:
+        await message_buffer.add("session-1", "a")
+        await message_buffer.add("session-1", "b")
+        assert await message_buffer.get_count("session-1") == 2
+
+    @pytest.mark.asyncio
+    async def test_get_count_empty(self, message_buffer: MessageBuffer) -> None:
+        assert await message_buffer.get_count("session-1") == 0
+
+
+class TestFallbackWhenRedisUnavailable:
+    """Graceful fallback when Redis connection fails."""
+
+    @pytest.mark.asyncio
+    async def test_add_falls_back_to_in_memory(self) -> None:
+        mock_redis = AsyncMock(spec=RedisCache)
+        mock_redis._build_key = lambda scope, entity_id, field=None: (
+            f"chatwoot:1:{scope}:{entity_id}" + (f":{field}" if field else "")
+        )
+        mock_redis.set.return_value = False
+        mock_redis.get.return_value = None
+        mock_redis.delete.return_value = False
+
+        provider = MockConfigProvider()
+        buf = MessageBuffer(redis_cache=mock_redis, config_provider=provider)
+
+        result = await buf.add("session-1", "hello")
+        # Should fallback to in-memory and still report buffering
+        assert result.is_buffering is True
+
+    @pytest.mark.asyncio
+    async def test_flush_falls_back_to_in_memory(self) -> None:
+        mock_redis = AsyncMock(spec=RedisCache)
+        mock_redis._build_key = lambda scope, entity_id, field=None: (
+            f"chatwoot:1:{scope}:{entity_id}" + (f":{field}" if field else "")
+        )
+        mock_redis.set.return_value = False
+        mock_redis.get.return_value = None
+        mock_redis.delete.return_value = False
+
+        provider = MockConfigProvider()
+        buf = MessageBuffer(redis_cache=mock_redis, config_provider=provider)
+
+        # Add in-memory via fallback
+        await buf.add("session-1", "hello")
+        joined = await buf.flush("session-1")
+        assert joined == "hello"
+
+    @pytest.mark.asyncio
+    async def test_is_buffering_falls_back(self) -> None:
+        mock_redis = AsyncMock(spec=RedisCache)
+        mock_redis._build_key = lambda scope, entity_id, field=None: (
+            f"chatwoot:1:{scope}:{entity_id}" + (f":{field}" if field else "")
+        )
+        mock_redis.set.return_value = False
+        mock_redis.get.return_value = None
+        mock_redis.exists.return_value = False
+
+        provider = MockConfigProvider()
+        buf = MessageBuffer(redis_cache=mock_redis, config_provider=provider)
+
+        await buf.add("session-1", "hello")
+        assert await buf.is_buffering("session-1") is True
+
+
+class TestModuleLevelWrappers:
+    """Legacy module-level functions must delegate to MessageBuffer."""
+
+    @pytest.mark.asyncio
+    async def test_add_to_buffer_wrapper(self, redis_cache: RedisCache) -> None:
+        from backend.app import message_buffer as mb
+
+        # The module-level _message_buffer should be None by default
+        # We need to set it for the wrapper to work
+        original = mb._message_buffer
+        mb._message_buffer = MessageBuffer(
+            redis_cache=redis_cache,
+            config_provider=MockConfigProvider(),
+        )
+        try:
+            result = await mb.add_to_buffer("session-1", "hello")
+            assert result is None  # Still buffering
+        finally:
+            mb._message_buffer = original
+
+    @pytest.mark.asyncio
+    async def test_flush_buffer_wrapper(self, redis_cache: RedisCache) -> None:
+        from backend.app import message_buffer as mb
+
+        original = mb._message_buffer
+        mb._message_buffer = MessageBuffer(
+            redis_cache=redis_cache,
+            config_provider=MockConfigProvider(),
+        )
+        try:
+            await mb._message_buffer.add("session-1", "hello")
+            joined = await mb.flush_buffer("session-1")
+            assert joined == "hello"
+        finally:
+            mb._message_buffer = original

--- a/backend/tests/test_redis_cache.py
+++ b/backend/tests/test_redis_cache.py
@@ -188,6 +188,33 @@ class TestErrorHandling:
         assert await cache.exists("k") is False
 
 
+class TestHashDelete:
+    """HDEL operation."""
+
+    @pytest.mark.asyncio
+    async def test_hdel_existing(self, cache: RedisCache) -> None:
+        await cache.hset("hash", "field", "val")
+        assert await cache.hdel("hash", "field") is True
+        assert await cache.hget("hash", "field") is None
+
+    @pytest.mark.asyncio
+    async def test_hdel_missing(self, cache: RedisCache) -> None:
+        assert await cache.hdel("hash", "field") is True
+
+
+class TestExpire:
+    """EXPIRE operation."""
+
+    @pytest.mark.asyncio
+    async def test_expire_sets_ttl(self, cache: RedisCache) -> None:
+        await cache.set("k", "v")
+        assert await cache.expire("k", 60) is True
+
+    @pytest.mark.asyncio
+    async def test_expire_missing_key(self, cache: RedisCache) -> None:
+        assert await cache.expire("missing", 60) is True
+
+
 class TestHealthCheck:
     """Health check must reflect Redis connectivity."""
 

--- a/backend/tests/test_session.py
+++ b/backend/tests/test_session.py
@@ -1,308 +1,148 @@
-"""
-Unit tests for the session management service.
-"""
+"""Unit tests for the synchronous session management service."""
 
-import asyncio
-import pytest
+import threading
 from datetime import datetime
-from backend.app.session import SessionManager
+
+from backend.app.session import SessionManager, TokenTotals
 
 
 class TestSessionManagerInitialization:
     """Tests for SessionManager initialization."""
 
-    def test_session_manager_initialization(self):
-        """Test that SessionManager initializes with correct default values."""
+    def test_session_manager_initialization(self) -> None:
         sm = SessionManager()
         assert sm.max_turns == 20
+        assert sm.sessions == {}
+        assert sm.token_totals == {}
 
-    def test_session_manager_custom_max_turns(self):
-        """Test that SessionManager accepts custom max_turns."""
+    def test_session_manager_custom_max_turns(self) -> None:
         sm = SessionManager(max_turns=5)
         assert sm.max_turns == 5
 
 
-class TestAddTurn:
-    """Tests for adding conversation turns."""
+class TestHistory:
+    """Tests for adding and retrieving conversation turns."""
 
-    @pytest.mark.asyncio
-    async def test_add_turn_creates_new_session(self):
-        """Test that adding a turn creates a new session."""
+    def test_add_turn_creates_new_session(self) -> None:
         sm = SessionManager()
-        session_id = "test-session-1"
+        sm.add_turn("s1", "¿Qué es el solar?", "Es energía del sol", ["doc1.pdf"])
 
-        await sm.add_turn(
-            session_id, "¿Qué es el solar?", "Es energía del sol", ["doc1.pdf"]
-        )
-
-        history = await sm.get_history(session_id)
+        history = sm.get_history("s1")
         assert len(history) == 1
+        assert history[0].question == "¿Qué es el solar?"
+        assert history[0].answer == "Es energía del sol"
+        assert history[0].source_documents == ["doc1.pdf"]
+        assert isinstance(history[0].timestamp, datetime)
 
-        turn = history[0]
-        assert turn.question == "¿Qué es el solar?"
-        assert turn.answer == "Es energía del sol"
-        assert turn.source_documents == ["doc1.pdf"]
-        assert isinstance(turn.timestamp, datetime)
-
-    @pytest.mark.asyncio
-    async def test_add_multiple_turns(self):
-        """Test adding multiple turns to the same session."""
-        sm = SessionManager()
-        session_id = "test-session-2"
-
-        await sm.add_turn(session_id, "Pregunta 1", "Respuesta 1")
-        await sm.add_turn(session_id, "Pregunta 2", "Respuesta 2")
-        await sm.add_turn(session_id, "Pregunta 3", "Respuesta 3")
-
-        history = await sm.get_history(session_id)
-        assert len(history) == 3
-        assert history[0].question == "Pregunta 1"
-        assert history[1].question == "Pregunta 2"
-        assert history[2].question == "Pregunta 3"
-
-    @pytest.mark.asyncio
-    async def test_max_turns_limit(self):
-        """Test that only the last max_turns are kept."""
+    def test_max_turns_limit(self) -> None:
         sm = SessionManager(max_turns=2)
-        session_id = "test-session-3"
+        for index in range(4):
+            sm.add_turn("s1", f"Pregunta {index}", f"Respuesta {index}")
 
-        # Añadir 4 turnos
-        await sm.add_turn(session_id, "Pregunta 1", "Respuesta 1")
-        await sm.add_turn(session_id, "Pregunta 2", "Respuesta 2")
-        await sm.add_turn(session_id, "Pregunta 3", "Respuesta 3")
-        await sm.add_turn(session_id, "Pregunta 4", "Respuesta 4")
-
-        # Solo deberían quedar los últimos 2
-        history = await sm.get_history(session_id)
+        history = sm.get_history("s1")
         assert len(history) == 2
-        assert history[0].question == "Pregunta 3"
-        assert history[1].question == "Pregunta 4"
+        assert history[0].question == "Pregunta 2"
+        assert history[1].question == "Pregunta 3"
 
+    def test_get_history_empty_session(self) -> None:
+        assert SessionManager().get_history("missing") == []
 
-class TestGetHistory:
-    """Tests for retrieving session history."""
-
-    @pytest.mark.asyncio
-    async def test_get_history(self):
-        """Test getting history for a session."""
+    def test_get_context_string(self) -> None:
         sm = SessionManager()
-        session_id = "test-session-4"
+        sm.add_turn("s1", "¿Qué es el solar?", "Es energía del sol", ["doc1.pdf"])
 
-        await sm.add_turn(session_id, "Pregunta 1", "Respuesta 1")
-        await sm.add_turn(session_id, "Pregunta 2", "Respuesta 2")
+        context = sm.get_context_string("s1")
 
-        history = await sm.get_history(session_id)
-        assert len(history) == 2
-        assert history[0].question == "Pregunta 1"
-        assert history[1].question == "Pregunta 2"
-
-    @pytest.mark.asyncio
-    async def test_get_history_empty_session(self):
-        """Test getting history for a non-existent session."""
-        sm = SessionManager()
-        history = await sm.get_history("non-existent-session")
-        assert history == []
-
-
-class TestGetContextString:
-    """Tests for formatted context string."""
-
-    @pytest.mark.asyncio
-    async def test_get_context_string(self):
-        """Test getting formatted context string."""
-        sm = SessionManager()
-        session_id = "test-session-5"
-
-        await sm.add_turn(
-            session_id, "¿Qué es el solar?", "Es energía del sol", ["doc1.pdf"]
-        )
-        await sm.add_turn(
-            session_id, "¿Y el eólico?", "Es energía del viento", ["doc2.pdf"]
-        )
-
-        context = await sm.get_context_string(session_id)
         assert "Turno 1:" in context
         assert "Usuario: ¿Qué es el solar?" in context
         assert "Asistente: Es energía del sol" in context
         assert "Fuentes: doc1.pdf" in context
-        assert "Turno 2:" in context
-        assert "Usuario: ¿Y el eólico?" in context
-        assert "Asistente: Es energía del viento" in context
-        assert "Fuentes: doc2.pdf" in context
 
-    @pytest.mark.asyncio
-    async def test_get_context_string_empty_session(self):
-        """Test getting context string for empty session."""
+    def test_get_context_string_empty_session(self) -> None:
+        assert SessionManager().get_context_string("missing") == ""
+
+    def test_clear_session(self) -> None:
         sm = SessionManager()
-        context = await sm.get_context_string("empty-session")
-        assert context == ""
+        sm.add_turn("s1", "Pregunta", "Respuesta")
+        sm.set_user_profile("s1", "novato")
+        sm.add_token_usage("s1", 100, 50, 150)
 
+        sm.clear_session("s1")
 
-class TestClearSession:
-    """Tests for clearing session data."""
+        assert sm.get_history("s1") == []
+        assert sm.get_user_profile("s1") is None
+        assert sm.get_token_totals("s1").total_tokens == 0
 
-    @pytest.mark.asyncio
-    async def test_clear_session(self):
-        """Test clearing a session clears turns, profiles, and token totals."""
-        sm = SessionManager()
-        session_id = "test-session-6"
-
-        await sm.add_turn(session_id, "Pregunta", "Respuesta")
-        await sm.set_user_profile(session_id, "novato")
-        await sm.add_token_usage(session_id, 100, 50, 150)
-        history = await sm.get_history(session_id)
-        assert len(history) == 1
-        totals = await sm.get_token_totals(session_id)
-        assert totals.total_tokens == 150
-
-        await sm.clear_session(session_id)
-        assert await sm.get_history(session_id) == []
-        assert await sm.get_user_profile(session_id) is None
-        totals = await sm.get_token_totals(session_id)
-        assert totals.total_tokens == 0
-
-    @pytest.mark.asyncio
-    async def test_clear_nonexistent_session(self):
-        """Test clearing a non-existent session (should not raise error)."""
-        sm = SessionManager()
-        # No debería lanzar excepción
-        await sm.clear_session("non-existent-session")
-
-    @pytest.mark.asyncio
-    async def test_get_session_count(self):
-        """Test getting the number of active sessions."""
+    def test_get_session_count(self) -> None:
         sm = SessionManager()
         assert sm.get_session_count() == 0
 
-        await sm.add_turn("session-1", "Pregunta 1", "Respuesta 1")
-        assert sm.get_session_count() == 1
+        sm.add_turn("s1", "Pregunta 1", "Respuesta 1")
+        sm.add_turn("s2", "Pregunta 2", "Respuesta 2")
+        sm.add_turn("s1", "Pregunta 3", "Respuesta 3")
 
-        await sm.add_turn("session-2", "Pregunta 2", "Respuesta 2")
         assert sm.get_session_count() == 2
-
-        await sm.add_turn("session-1", "Pregunta 3", "Respuesta 3")  # Misma sesión
-        assert sm.get_session_count() == 2  # Aún 2 sesiones
-
-        await sm.clear_session("session-1")
+        sm.clear_session("s1")
         assert sm.get_session_count() == 1
-
-
-# --- TokenTotals Tests ---
 
 
 class TestTokenTotalsModel:
     """Tests for the TokenTotals Pydantic model."""
 
     def test_token_totals_defaults_to_zero(self) -> None:
-        """Test that TokenTotals defaults all fields to 0."""
-        from backend.app.session import TokenTotals
-
         totals = TokenTotals()
         assert totals.input_tokens == 0
         assert totals.output_tokens == 0
         assert totals.total_tokens == 0
 
     def test_token_totals_with_values(self) -> None:
-        """Test that TokenTotals accepts explicit values."""
-        from backend.app.session import TokenTotals
-
         totals = TokenTotals(input_tokens=100, output_tokens=50, total_tokens=150)
         assert totals.input_tokens == 100
         assert totals.output_tokens == 50
         assert totals.total_tokens == 150
 
 
-class TestAddTokenUsage:
-    """Tests for SessionManager.add_token_usage()."""
+class TestTokenUsage:
+    """Tests for SessionManager token accounting."""
 
-    @pytest.mark.asyncio
-    async def test_add_token_usage_creates_entry(self) -> None:
-        """Test that add_token_usage creates an entry for a new session."""
+    def test_add_token_usage_accumulates(self) -> None:
         sm = SessionManager()
-        await sm.add_token_usage("s1", 100, 50, 150)
+        sm.add_token_usage("s1", 100, 50, 150)
+        sm.add_token_usage("s1", 200, 100, 300)
 
-        totals = await sm.get_token_totals("s1")
-        assert totals.input_tokens == 100
-        assert totals.output_tokens == 50
-        assert totals.total_tokens == 150
-
-    @pytest.mark.asyncio
-    async def test_add_token_usage_accumulates(self) -> None:
-        """Test that repeated calls accumulate token counts."""
-        sm = SessionManager()
-        await sm.add_token_usage("s1", 100, 50, 150)
-        await sm.add_token_usage("s1", 200, 100, 300)
-
-        totals = await sm.get_token_totals("s1")
+        totals = sm.get_token_totals("s1")
         assert totals.input_tokens == 300
         assert totals.output_tokens == 150
         assert totals.total_tokens == 450
 
-    @pytest.mark.asyncio
-    async def test_add_token_usage_concurrent(self) -> None:
-        """Test that concurrent add_token_usage calls accumulate correctly (asyncio)."""
+    def test_add_token_usage_thread_safe(self) -> None:
         sm = SessionManager()
+        errors: list[Exception] = []
 
-        async def add_tokens(n: int) -> None:
-            for _ in range(n):
-                await sm.add_token_usage("s1", 1, 1, 2)
+        def add_tokens() -> None:
+            try:
+                for _ in range(100):
+                    sm.add_token_usage("s1", 1, 1, 2)
+            except Exception as exc:
+                errors.append(exc)
 
-        await asyncio.gather(*[add_tokens(100) for _ in range(10)])
+        threads = [threading.Thread(target=add_tokens) for _ in range(10)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
 
-        totals = await sm.get_token_totals("s1")
+        assert errors == []
+        totals = sm.get_token_totals("s1")
         assert totals.input_tokens == 1000
         assert totals.output_tokens == 1000
         assert totals.total_tokens == 2000
 
+    def test_get_token_totals_returns_zeroed_for_missing_session(self) -> None:
+        assert SessionManager().get_token_totals("missing").total_tokens == 0
 
-class TestGetTokenTotals:
-    """Tests for SessionManager.get_token_totals()."""
-
-    @pytest.mark.asyncio
-    async def test_get_token_totals_returns_zeroed_for_missing_session(self) -> None:
-        """Test that get_token_totals returns zeroed totals for unknown session."""
+    def test_clear_session_removes_token_totals(self) -> None:
         sm = SessionManager()
-        totals = await sm.get_token_totals("non-existent")
-        assert totals.input_tokens == 0
-        assert totals.output_tokens == 0
-        assert totals.total_tokens == 0
-
-    @pytest.mark.asyncio
-    async def test_get_token_totals_returns_actual_totals(self) -> None:
-        """Test that get_token_totals returns accumulated totals."""
-        sm = SessionManager()
-        await sm.add_token_usage("s1", 50, 25, 75)
-        await sm.add_token_usage("s1", 30, 10, 40)
-
-        totals = await sm.get_token_totals("s1")
-        assert totals.input_tokens == 80
-        assert totals.output_tokens == 35
-        assert totals.total_tokens == 115
-
-
-class TestClearSessionTokenTotals:
-    """Tests verifying clear_session() also clears token_totals."""
-
-    @pytest.mark.asyncio
-    async def test_clear_session_removes_token_totals(self) -> None:
-        """Test that clearing a session removes its token totals."""
-        sm = SessionManager()
-        await sm.add_token_usage("s1", 100, 50, 150)
-        totals = await sm.get_token_totals("s1")
-        assert totals.total_tokens == 150
-
-        await sm.clear_session("s1")
-        totals = await sm.get_token_totals("s1")
-        assert totals.input_tokens == 0
-        assert totals.total_tokens == 0
-
-    @pytest.mark.asyncio
-    async def test_clear_session_token_totals_returns_zero_after_clear(self) -> None:
-        """Test that get_token_totals returns zero after clearing."""
-        sm = SessionManager()
-        await sm.add_token_usage("s1", 100, 50, 150)
-        await sm.clear_session("s1")
-
-        totals = await sm.get_token_totals("s1")
-        assert totals.input_tokens == 0
-        assert totals.total_tokens == 0
+        sm.add_token_usage("s1", 100, 50, 150)
+        sm.clear_session("s1")
+        assert sm.get_token_totals("s1").total_tokens == 0

--- a/backend/tests/test_session.py
+++ b/backend/tests/test_session.py
@@ -1,162 +1,190 @@
 """
 Unit tests for the session management service.
 """
+
+import asyncio
 import pytest
-import threading
-from datetime import datetime, timedelta
-from backend.app.session import SessionManager, ChatTurn
+from datetime import datetime
+from backend.app.session import SessionManager
 
 
-def test_session_manager_initialization():
-    """Test that SessionManager initializes with correct default values."""
-    sm = SessionManager()
-    assert sm.max_turns == 20
-    assert sm.sessions == {}
-    assert sm.token_totals == {}
+class TestSessionManagerInitialization:
+    """Tests for SessionManager initialization."""
+
+    def test_session_manager_initialization(self):
+        """Test that SessionManager initializes with correct default values."""
+        sm = SessionManager()
+        assert sm.max_turns == 20
+
+    def test_session_manager_custom_max_turns(self):
+        """Test that SessionManager accepts custom max_turns."""
+        sm = SessionManager(max_turns=5)
+        assert sm.max_turns == 5
 
 
-def test_session_manager_custom_max_turns():
-    """Test that SessionManager accepts custom max_turns."""
-    sm = SessionManager(max_turns=5)
-    assert sm.max_turns == 5
+class TestAddTurn:
+    """Tests for adding conversation turns."""
+
+    @pytest.mark.asyncio
+    async def test_add_turn_creates_new_session(self):
+        """Test that adding a turn creates a new session."""
+        sm = SessionManager()
+        session_id = "test-session-1"
+
+        await sm.add_turn(
+            session_id, "¿Qué es el solar?", "Es energía del sol", ["doc1.pdf"]
+        )
+
+        history = await sm.get_history(session_id)
+        assert len(history) == 1
+
+        turn = history[0]
+        assert turn.question == "¿Qué es el solar?"
+        assert turn.answer == "Es energía del sol"
+        assert turn.source_documents == ["doc1.pdf"]
+        assert isinstance(turn.timestamp, datetime)
+
+    @pytest.mark.asyncio
+    async def test_add_multiple_turns(self):
+        """Test adding multiple turns to the same session."""
+        sm = SessionManager()
+        session_id = "test-session-2"
+
+        await sm.add_turn(session_id, "Pregunta 1", "Respuesta 1")
+        await sm.add_turn(session_id, "Pregunta 2", "Respuesta 2")
+        await sm.add_turn(session_id, "Pregunta 3", "Respuesta 3")
+
+        history = await sm.get_history(session_id)
+        assert len(history) == 3
+        assert history[0].question == "Pregunta 1"
+        assert history[1].question == "Pregunta 2"
+        assert history[2].question == "Pregunta 3"
+
+    @pytest.mark.asyncio
+    async def test_max_turns_limit(self):
+        """Test that only the last max_turns are kept."""
+        sm = SessionManager(max_turns=2)
+        session_id = "test-session-3"
+
+        # Añadir 4 turnos
+        await sm.add_turn(session_id, "Pregunta 1", "Respuesta 1")
+        await sm.add_turn(session_id, "Pregunta 2", "Respuesta 2")
+        await sm.add_turn(session_id, "Pregunta 3", "Respuesta 3")
+        await sm.add_turn(session_id, "Pregunta 4", "Respuesta 4")
+
+        # Solo deberían quedar los últimos 2
+        history = await sm.get_history(session_id)
+        assert len(history) == 2
+        assert history[0].question == "Pregunta 3"
+        assert history[1].question == "Pregunta 4"
 
 
-def test_add_turn_creates_new_session():
-    """Test that adding a turn creates a new session."""
-    sm = SessionManager()
-    session_id = "test-session-1"
-    
-    sm.add_turn(session_id, "¿Qué es el solar?", "Es energía del sol", ["doc1.pdf"])
-    
-    assert session_id in sm.sessions
-    assert len(sm.sessions[session_id]) == 1
-    
-    turn = sm.sessions[session_id][0]
-    assert turn.question == "¿Qué es el solar?"
-    assert turn.answer == "Es energía del sol"
-    assert turn.source_documents == ["doc1.pdf"]
-    assert isinstance(turn.timestamp, datetime)
+class TestGetHistory:
+    """Tests for retrieving session history."""
+
+    @pytest.mark.asyncio
+    async def test_get_history(self):
+        """Test getting history for a session."""
+        sm = SessionManager()
+        session_id = "test-session-4"
+
+        await sm.add_turn(session_id, "Pregunta 1", "Respuesta 1")
+        await sm.add_turn(session_id, "Pregunta 2", "Respuesta 2")
+
+        history = await sm.get_history(session_id)
+        assert len(history) == 2
+        assert history[0].question == "Pregunta 1"
+        assert history[1].question == "Pregunta 2"
+
+    @pytest.mark.asyncio
+    async def test_get_history_empty_session(self):
+        """Test getting history for a non-existent session."""
+        sm = SessionManager()
+        history = await sm.get_history("non-existent-session")
+        assert history == []
 
 
-def test_add_multiple_turns():
-    """Test adding multiple turns to the same session."""
-    sm = SessionManager()
-    session_id = "test-session-2"
-    
-    sm.add_turn(session_id, "Pregunta 1", "Respuesta 1")
-    sm.add_turn(session_id, "Pregunta 2", "Respuesta 2")
-    sm.add_turn(session_id, "Pregunta 3", "Respuesta 3")
-    
-    assert len(sm.sessions[session_id]) == 3
-    assert sm.sessions[session_id][0].question == "Pregunta 1"
-    assert sm.sessions[session_id][1].question == "Pregunta 2"
-    assert sm.sessions[session_id][2].question == "Pregunta 3"
+class TestGetContextString:
+    """Tests for formatted context string."""
+
+    @pytest.mark.asyncio
+    async def test_get_context_string(self):
+        """Test getting formatted context string."""
+        sm = SessionManager()
+        session_id = "test-session-5"
+
+        await sm.add_turn(
+            session_id, "¿Qué es el solar?", "Es energía del sol", ["doc1.pdf"]
+        )
+        await sm.add_turn(
+            session_id, "¿Y el eólico?", "Es energía del viento", ["doc2.pdf"]
+        )
+
+        context = await sm.get_context_string(session_id)
+        assert "Turno 1:" in context
+        assert "Usuario: ¿Qué es el solar?" in context
+        assert "Asistente: Es energía del sol" in context
+        assert "Fuentes: doc1.pdf" in context
+        assert "Turno 2:" in context
+        assert "Usuario: ¿Y el eólico?" in context
+        assert "Asistente: Es energía del viento" in context
+        assert "Fuentes: doc2.pdf" in context
+
+    @pytest.mark.asyncio
+    async def test_get_context_string_empty_session(self):
+        """Test getting context string for empty session."""
+        sm = SessionManager()
+        context = await sm.get_context_string("empty-session")
+        assert context == ""
 
 
-def test_max_turns_limit():
-    """Test that only the last max_turns are kept."""
-    sm = SessionManager(max_turns=2)
-    session_id = "test-session-3"
-    
-    # Añadir 4 turnos
-    sm.add_turn(session_id, "Pregunta 1", "Respuesta 1")
-    sm.add_turn(session_id, "Pregunta 2", "Respuesta 2")
-    sm.add_turn(session_id, "Pregunta 3", "Respuesta 3")
-    sm.add_turn(session_id, "Pregunta 4", "Respuesta 4")
-    
-    # Solo deberían quedar los últimos 2
-    assert len(sm.sessions[session_id]) == 2
-    assert sm.sessions[session_id][0].question == "Pregunta 3"
-    assert sm.sessions[session_id][1].question == "Pregunta 4"
+class TestClearSession:
+    """Tests for clearing session data."""
 
+    @pytest.mark.asyncio
+    async def test_clear_session(self):
+        """Test clearing a session clears turns, profiles, and token totals."""
+        sm = SessionManager()
+        session_id = "test-session-6"
 
-def test_get_history():
-    """Test getting history for a session."""
-    sm = SessionManager()
-    session_id = "test-session-4"
-    
-    sm.add_turn(session_id, "Pregunta 1", "Respuesta 1")
-    sm.add_turn(session_id, "Pregunta 2", "Respuesta 2")
-    
-    history = sm.get_history(session_id)
-    assert len(history) == 2
-    assert history[0].question == "Pregunta 1"
-    assert history[1].question == "Pregunta 2"
+        await sm.add_turn(session_id, "Pregunta", "Respuesta")
+        await sm.set_user_profile(session_id, "novato")
+        await sm.add_token_usage(session_id, 100, 50, 150)
+        history = await sm.get_history(session_id)
+        assert len(history) == 1
+        totals = await sm.get_token_totals(session_id)
+        assert totals.total_tokens == 150
 
+        await sm.clear_session(session_id)
+        assert await sm.get_history(session_id) == []
+        assert await sm.get_user_profile(session_id) is None
+        totals = await sm.get_token_totals(session_id)
+        assert totals.total_tokens == 0
 
-def test_get_history_empty_session():
-    """Test getting history for a non-existent session."""
-    sm = SessionManager()
-    history = sm.get_history("non-existent-session")
-    assert history == []
+    @pytest.mark.asyncio
+    async def test_clear_nonexistent_session(self):
+        """Test clearing a non-existent session (should not raise error)."""
+        sm = SessionManager()
+        # No debería lanzar excepción
+        await sm.clear_session("non-existent-session")
 
+    @pytest.mark.asyncio
+    async def test_get_session_count(self):
+        """Test getting the number of active sessions."""
+        sm = SessionManager()
+        assert sm.get_session_count() == 0
 
-def test_get_context_string():
-    """Test getting formatted context string."""
-    sm = SessionManager()
-    session_id = "test-session-5"
-    
-    sm.add_turn(session_id, "¿Qué es el solar?", "Es energía del sol", ["doc1.pdf"])
-    sm.add_turn(session_id, "¿Y el eólico?", "Es energía del viento", ["doc2.pdf"])
-    
-    context = sm.get_context_string(session_id)
-    assert "Turno 1:" in context
-    assert "Usuario: ¿Qué es el solar?" in context
-    assert "Asistente: Es energía del sol" in context
-    assert "Fuentes: doc1.pdf" in context
-    assert "Turno 2:" in context
-    assert "Usuario: ¿Y el eólico?" in context
-    assert "Asistente: Es energía del viento" in context
-    assert "Fuentes: doc2.pdf" in context
+        await sm.add_turn("session-1", "Pregunta 1", "Respuesta 1")
+        assert sm.get_session_count() == 1
 
+        await sm.add_turn("session-2", "Pregunta 2", "Respuesta 2")
+        assert sm.get_session_count() == 2
 
-def test_get_context_string_empty_session():
-    """Test getting context string for empty session."""
-    sm = SessionManager()
-    context = sm.get_context_string("empty-session")
-    assert context == ""
+        await sm.add_turn("session-1", "Pregunta 3", "Respuesta 3")  # Misma sesión
+        assert sm.get_session_count() == 2  # Aún 2 sesiones
 
-
-def test_clear_session():
-    """Test clearing a session clears turns, profiles, and token totals."""
-    sm = SessionManager()
-    session_id = "test-session-6"
-
-    sm.add_turn(session_id, "Pregunta", "Respuesta")
-    sm.set_user_profile(session_id, "novato")
-    sm.add_token_usage(session_id, 100, 50, 150)
-    assert session_id in sm.sessions
-    assert len(sm.sessions[session_id]) == 1
-    assert sm.token_totals[session_id].total_tokens == 150
-
-    sm.clear_session(session_id)
-    assert session_id not in sm.sessions
-    assert session_id not in sm.token_totals
-
-
-def test_clear_nonexistent_session():
-    """Test clearing a non-existent session (should not raise error)."""
-    sm = SessionManager()
-    # No debería lanzar excepción
-    sm.clear_session("non-existent-session")
-
-
-def test_get_session_count():
-    """Test getting the number of active sessions."""
-    sm = SessionManager()
-    assert sm.get_session_count() == 0
-    
-    sm.add_turn("session-1", "Pregunta 1", "Respuesta 1")
-    assert sm.get_session_count() == 1
-    
-    sm.add_turn("session-2", "Pregunta 2", "Respuesta 2")
-    assert sm.get_session_count() == 2
-    
-    sm.add_turn("session-1", "Pregunta 3", "Respuesta 3")  # Misma sesión
-    assert sm.get_session_count() == 2  # Aún 2 sesiones
-    
-    sm.clear_session("session-1")
-    assert sm.get_session_count() == 1
+        await sm.clear_session("session-1")
+        assert sm.get_session_count() == 1
 
 
 # --- TokenTotals Tests ---
@@ -187,47 +215,41 @@ class TestTokenTotalsModel:
 class TestAddTokenUsage:
     """Tests for SessionManager.add_token_usage()."""
 
-    def test_add_token_usage_creates_entry(self) -> None:
+    @pytest.mark.asyncio
+    async def test_add_token_usage_creates_entry(self) -> None:
         """Test that add_token_usage creates an entry for a new session."""
         sm = SessionManager()
-        sm.add_token_usage("s1", 100, 50, 150)
+        await sm.add_token_usage("s1", 100, 50, 150)
 
-        totals = sm.get_token_totals("s1")
+        totals = await sm.get_token_totals("s1")
         assert totals.input_tokens == 100
         assert totals.output_tokens == 50
         assert totals.total_tokens == 150
 
-    def test_add_token_usage_accumulates(self) -> None:
+    @pytest.mark.asyncio
+    async def test_add_token_usage_accumulates(self) -> None:
         """Test that repeated calls accumulate token counts."""
         sm = SessionManager()
-        sm.add_token_usage("s1", 100, 50, 150)
-        sm.add_token_usage("s1", 200, 100, 300)
+        await sm.add_token_usage("s1", 100, 50, 150)
+        await sm.add_token_usage("s1", 200, 100, 300)
 
-        totals = sm.get_token_totals("s1")
+        totals = await sm.get_token_totals("s1")
         assert totals.input_tokens == 300
         assert totals.output_tokens == 150
         assert totals.total_tokens == 450
 
-    def test_add_token_usage_thread_safe(self) -> None:
-        """Test that concurrent add_token_usage calls are thread-safe."""
+    @pytest.mark.asyncio
+    async def test_add_token_usage_concurrent(self) -> None:
+        """Test that concurrent add_token_usage calls accumulate correctly (asyncio)."""
         sm = SessionManager()
-        errors: list[Exception] = []
 
-        def add_tokens(n: int) -> None:
-            try:
-                for _ in range(n):
-                    sm.add_token_usage("s1", 1, 1, 2)
-            except Exception as e:
-                errors.append(e)
+        async def add_tokens(n: int) -> None:
+            for _ in range(n):
+                await sm.add_token_usage("s1", 1, 1, 2)
 
-        threads = [threading.Thread(target=add_tokens, args=(100,)) for _ in range(10)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
+        await asyncio.gather(*[add_tokens(100) for _ in range(10)])
 
-        assert len(errors) == 0
-        totals = sm.get_token_totals("s1")
+        totals = await sm.get_token_totals("s1")
         assert totals.input_tokens == 1000
         assert totals.output_tokens == 1000
         assert totals.total_tokens == 2000
@@ -236,21 +258,23 @@ class TestAddTokenUsage:
 class TestGetTokenTotals:
     """Tests for SessionManager.get_token_totals()."""
 
-    def test_get_token_totals_returns_zeroed_for_missing_session(self) -> None:
+    @pytest.mark.asyncio
+    async def test_get_token_totals_returns_zeroed_for_missing_session(self) -> None:
         """Test that get_token_totals returns zeroed totals for unknown session."""
         sm = SessionManager()
-        totals = sm.get_token_totals("non-existent")
+        totals = await sm.get_token_totals("non-existent")
         assert totals.input_tokens == 0
         assert totals.output_tokens == 0
         assert totals.total_tokens == 0
 
-    def test_get_token_totals_returns_actual_totals(self) -> None:
+    @pytest.mark.asyncio
+    async def test_get_token_totals_returns_actual_totals(self) -> None:
         """Test that get_token_totals returns accumulated totals."""
         sm = SessionManager()
-        sm.add_token_usage("s1", 50, 25, 75)
-        sm.add_token_usage("s1", 30, 10, 40)
+        await sm.add_token_usage("s1", 50, 25, 75)
+        await sm.add_token_usage("s1", 30, 10, 40)
 
-        totals = sm.get_token_totals("s1")
+        totals = await sm.get_token_totals("s1")
         assert totals.input_tokens == 80
         assert totals.output_tokens == 35
         assert totals.total_tokens == 115
@@ -259,21 +283,26 @@ class TestGetTokenTotals:
 class TestClearSessionTokenTotals:
     """Tests verifying clear_session() also clears token_totals."""
 
-    def test_clear_session_removes_token_totals(self) -> None:
+    @pytest.mark.asyncio
+    async def test_clear_session_removes_token_totals(self) -> None:
         """Test that clearing a session removes its token totals."""
         sm = SessionManager()
-        sm.add_token_usage("s1", 100, 50, 150)
-        assert "s1" in sm.token_totals
+        await sm.add_token_usage("s1", 100, 50, 150)
+        totals = await sm.get_token_totals("s1")
+        assert totals.total_tokens == 150
 
-        sm.clear_session("s1")
-        assert "s1" not in sm.token_totals
+        await sm.clear_session("s1")
+        totals = await sm.get_token_totals("s1")
+        assert totals.input_tokens == 0
+        assert totals.total_tokens == 0
 
-    def test_clear_session_token_totals_returns_zero_after_clear(self) -> None:
+    @pytest.mark.asyncio
+    async def test_clear_session_token_totals_returns_zero_after_clear(self) -> None:
         """Test that get_token_totals returns zero after clearing."""
         sm = SessionManager()
-        sm.add_token_usage("s1", 100, 50, 150)
-        sm.clear_session("s1")
+        await sm.add_token_usage("s1", 100, 50, 150)
+        await sm.clear_session("s1")
 
-        totals = sm.get_token_totals("s1")
+        totals = await sm.get_token_totals("s1")
         assert totals.input_tokens == 0
         assert totals.total_tokens == 0

--- a/backend/tests/test_session_manager_hybrid.py
+++ b/backend/tests/test_session_manager_hybrid.py
@@ -1,7 +1,7 @@
 """Tests for hybrid Redis SessionManager.
 
-Uses fakeredis to exercise Redis-backed session operations without a
-real Redis server.
+Uses fakeredis to exercise Redis-backed session operations without a real Redis
+server while preserving the legacy synchronous API used by /chat.
 """
 
 from unittest.mock import AsyncMock, patch
@@ -31,59 +31,87 @@ def session_manager(redis_cache: RedisCache) -> SessionManager:
     return SessionManager(redis_cache=redis_cache)
 
 
-class TestAddTurn:
-    """Storing conversation turns in Redis."""
+class TestLegacySyncApi:
+    """The existing /chat-facing SessionManager API remains synchronous."""
+
+    def test_add_turn_and_get_history_are_sync(self) -> None:
+        sm = SessionManager(max_turns=2)
+
+        sm.add_turn("s1", "Pregunta 1", "Respuesta 1")
+        sm.add_turn("s1", "Pregunta 2", "Respuesta 2")
+        sm.add_turn("s1", "Pregunta 3", "Respuesta 3")
+
+        history = sm.get_history("s1")
+        assert len(history) == 2
+        assert history[0].question == "Pregunta 2"
+        assert history[1].question == "Pregunta 3"
+
+    def test_profile_and_token_methods_are_sync(self) -> None:
+        sm = SessionManager()
+
+        sm.set_user_profile("s1", "experto")
+        sm.add_token_usage("s1", 100, 50, 150)
+
+        assert sm.get_user_profile("s1") == "experto"
+        assert sm.get_token_totals("s1").total_tokens == 150
+
+    def test_context_and_clear_session_are_sync(self) -> None:
+        sm = SessionManager()
+        sm.add_turn("s1", "¿Panel?", "Sí", ["doc1.pdf"])
+
+        context = sm.get_context_string("s1")
+        assert "Usuario: ¿Panel?" in context
+
+        sm.clear_session("s1")
+        assert sm.get_history("s1") == []
+
+
+class TestAsyncHistory:
+    """Redis-backed async history methods."""
 
     @pytest.mark.asyncio
-    async def test_add_turn_creates_redis_list(
+    async def test_add_turn_async_creates_redis_list(
         self, session_manager: SessionManager
     ) -> None:
-        await session_manager.add_turn("s1", "¿Qué es solar?", "Energía del sol")
-        history = await session_manager.get_history("s1")
+        await session_manager.add_turn_async(
+            "s1", "¿Qué es solar?", "Energía del sol", []
+        )
+        history = await session_manager.get_history_async("s1")
         assert len(history) == 1
         assert history[0].question == "¿Qué es solar?"
         assert history[0].answer == "Energía del sol"
 
     @pytest.mark.asyncio
-    async def test_add_turn_trims_to_max(self, session_manager: SessionManager) -> None:
+    async def test_add_turn_async_trims_to_max(
+        self, session_manager: SessionManager
+    ) -> None:
         sm = SessionManager(redis_cache=session_manager._redis, max_turns=2)
-        for i in range(4):
-            await sm.add_turn("s1", f"Pregunta {i}", f"Respuesta {i}")
-        history = await sm.get_history("s1")
+        for index in range(4):
+            await sm.add_turn_async("s1", f"Pregunta {index}", f"Respuesta {index}", [])
+
+        history = await sm.get_history_async("s1")
         assert len(history) == 2
         assert history[0].question == "Pregunta 2"
         assert history[1].question == "Pregunta 3"
 
     @pytest.mark.asyncio
-    async def test_add_turn_includes_source_documents(
+    async def test_add_turn_async_includes_source_documents(
         self, session_manager: SessionManager
     ) -> None:
-        await session_manager.add_turn(
-            "s1", "¿Panel?", "Sí", source_documents=["doc1.pdf"]
-        )
-        history = await session_manager.get_history("s1")
+        await session_manager.add_turn_async("s1", "¿Panel?", "Sí", ["doc1.pdf"])
+        history = await session_manager.get_history_async("s1")
         assert history[0].source_documents == ["doc1.pdf"]
 
-
-class TestGetHistory:
-    """Retrieving history from Redis with fallbacks."""
-
     @pytest.mark.asyncio
-    async def test_get_history_from_redis(
+    async def test_get_history_async_empty(
         self, session_manager: SessionManager
     ) -> None:
-        await session_manager.add_turn("s1", "Hola", "Buenas")
-        await session_manager.add_turn("s1", "Adiós", "Hasta luego")
-        history = await session_manager.get_history("s1")
-        assert len(history) == 2
+        assert await session_manager.get_history_async("s1") == []
 
     @pytest.mark.asyncio
-    async def test_get_history_empty(self, session_manager: SessionManager) -> None:
-        history = await session_manager.get_history("s1")
-        assert history == []
-
-    @pytest.mark.asyncio
-    async def test_get_history_chatwoot_fallback(self, redis_cache: RedisCache) -> None:
+    async def test_get_history_async_chatwoot_fallback(
+        self, redis_cache: RedisCache
+    ) -> None:
         mock_client = AsyncMock(spec=ChatwootClient)
         mock_client.fetch_messages.return_value = {
             "payload": [
@@ -91,17 +119,17 @@ class TestGetHistory:
                 {"content": "Buenas", "message_type": 1, "sender_type": "user"},
             ]
         }
-
         sm = SessionManager(redis_cache=redis_cache, chatwoot_client=mock_client)
-        # Map conversation so fallback knows which conversation to fetch
         await sm.map_conversation("s1", "42")
 
-        history = await sm.get_history("s1")
-        assert len(history) == 1  # Only contact message becomes a turn
-        mock_client.fetch_messages.assert_awaited_once_with(42, limit=10)
+        history = await sm.get_history_async("s1")
+
+        assert len(history) == 1
+        assert history[0].question == "Hola"
+        mock_client.fetch_messages.assert_awaited_once_with(42, limit=20)
 
     @pytest.mark.asyncio
-    async def test_get_history_redis_unavailable_fallback(self) -> None:
+    async def test_get_history_async_redis_unavailable_fallback(self) -> None:
         from redis.exceptions import RedisError
 
         mock_redis = AsyncMock(spec=RedisCache)
@@ -112,169 +140,54 @@ class TestGetHistory:
         mock_redis.lrange.side_effect = RedisError("redis down")
 
         sm = SessionManager(redis_cache=mock_redis)
-        await sm.add_turn("s1", "Hola", "Buenas")
-        # Should fall back to in-memory
-        history = await sm.get_history("s1")
+        await sm.add_turn_async("s1", "Hola", "Buenas", [])
+        history = await sm.get_history_async("s1")
         assert len(history) == 1
         assert history[0].question == "Hola"
 
-
-class TestGetContextString:
-    """Formatting history for LLM context."""
-
     @pytest.mark.asyncio
-    async def test_get_context_string(self, session_manager: SessionManager) -> None:
-        await session_manager.add_turn("s1", "¿Panel?", "Sí", ["doc1.pdf"])
-        ctx = await session_manager.get_context_string("s1")
-        assert "Turno 1:" in ctx
-        assert "Usuario: ¿Panel?" in ctx
-        assert "Asistente: Sí" in ctx
-        assert "Fuentes: doc1.pdf" in ctx
-
-    @pytest.mark.asyncio
-    async def test_get_context_string_empty(
+    async def test_hydrate_history_from_chatwoot_messages(
         self, session_manager: SessionManager
     ) -> None:
-        ctx = await session_manager.get_context_string("s1")
-        assert ctx == ""
+        await session_manager.hydrate_history_from_chatwoot(
+            "s1",
+            [
+                {"content": "Necesito cotizar", "message_type": "incoming"},
+                {"content": "Te ayudo", "message_type": "outgoing"},
+            ],
+        )
 
-
-class TestUserProfile:
-    """Profile storage in Redis."""
-
-    @pytest.mark.asyncio
-    async def test_set_and_get_profile(self, session_manager: SessionManager) -> None:
-        await session_manager.set_user_profile("s1", "novato")
-        profile = await session_manager.get_user_profile("s1")
-        assert profile == "novato"
-
-    @pytest.mark.asyncio
-    async def test_get_profile_missing(self, session_manager: SessionManager) -> None:
-        profile = await session_manager.get_user_profile("s1")
-        assert profile is None
-
-
-class TestTokenUsage:
-    """Token accumulation via Redis hash."""
-
-    @pytest.mark.asyncio
-    async def test_add_token_usage(self, session_manager: SessionManager) -> None:
-        await session_manager.add_token_usage("s1", 100, 50, 150)
-        totals = await session_manager.get_token_totals("s1")
-        assert totals.input_tokens == 100
-        assert totals.output_tokens == 50
-        assert totals.total_tokens == 150
-
-    @pytest.mark.asyncio
-    async def test_add_token_usage_accumulates(
-        self, session_manager: SessionManager
-    ) -> None:
-        await session_manager.add_token_usage("s1", 100, 50, 150)
-        await session_manager.add_token_usage("s1", 200, 100, 300)
-        totals = await session_manager.get_token_totals("s1")
-        assert totals.input_tokens == 300
-        assert totals.output_tokens == 150
-        assert totals.total_tokens == 450
+        history = await session_manager.get_history_async("s1")
+        assert len(history) == 1
+        assert history[0].question == "Necesito cotizar"
+        assert history[0].answer == "Te ayudo"
 
 
 class TestConversationMapping:
     """Session ID ↔ Conversation ID mapping."""
 
     @pytest.mark.asyncio
-    async def test_map_conversation(self, session_manager: SessionManager) -> None:
-        await session_manager.map_conversation("s1", "42")
-        conv_id = await session_manager.get_conversation_id("s1")
-        assert conv_id == "42"
+    async def test_get_or_create_session_for_conversation_reuses_mapping(
+        self, session_manager: SessionManager
+    ) -> None:
+        first = await session_manager.get_or_create_session_for_conversation("42")
+        second = await session_manager.get_or_create_session_for_conversation("42")
+
+        assert first == second
+        assert await session_manager.get_conversation_for_session(first) == "42"
 
     @pytest.mark.asyncio
-    async def test_get_session_id_reverse(
+    async def test_map_conversation_compatibility(
         self, session_manager: SessionManager
     ) -> None:
         await session_manager.map_conversation("s1", "42")
-        session_id = await session_manager.get_session_id("42")
-        assert session_id == "s1"
+
+        assert await session_manager.get_conversation_id("s1") == "42"
+        assert await session_manager.get_session_id("42") == "s1"
 
     @pytest.mark.asyncio
-    async def test_get_conversation_id_missing(
+    async def test_missing_mapping_returns_none(
         self, session_manager: SessionManager
     ) -> None:
-        assert await session_manager.get_conversation_id("s1") is None
-
-    @pytest.mark.asyncio
-    async def test_get_session_id_missing(
-        self, session_manager: SessionManager
-    ) -> None:
+        assert await session_manager.get_conversation_for_session("s1") is None
         assert await session_manager.get_session_id("42") is None
-
-
-class TestClearSession:
-    """Clearing session data from Redis."""
-
-    @pytest.mark.asyncio
-    async def test_clear_session_removes_all(
-        self, session_manager: SessionManager
-    ) -> None:
-        await session_manager.add_turn("s1", "Hola", "Buenas")
-        await session_manager.set_user_profile("s1", "novato")
-        await session_manager.add_token_usage("s1", 10, 5, 15)
-        await session_manager.map_conversation("s1", "42")
-
-        await session_manager.clear_session("s1")
-
-        assert await session_manager.get_history("s1") == []
-        assert await session_manager.get_user_profile("s1") is None
-        totals = await session_manager.get_token_totals("s1")
-        assert totals.total_tokens == 0
-        assert await session_manager.get_conversation_id("s1") is None
-
-
-class TestFallbackWhenRedisUnavailable:
-    """Graceful degradation when Redis is down."""
-
-    @pytest.mark.asyncio
-    async def test_add_turn_fallback(self) -> None:
-        from redis.exceptions import RedisError
-
-        mock_redis = AsyncMock(spec=RedisCache)
-        mock_redis._build_key = lambda scope, entity_id, field=None: (
-            f"chatwoot:1:{scope}:{entity_id}" + (f":{field}" if field else "")
-        )
-        mock_redis.lpush.side_effect = RedisError("redis down")
-        mock_redis.lrange.side_effect = RedisError("redis down")
-
-        sm = SessionManager(redis_cache=mock_redis)
-        await sm.add_turn("s1", "Hola", "Buenas")
-        history = await sm.get_history("s1")
-        assert len(history) == 1
-
-    @pytest.mark.asyncio
-    async def test_set_profile_fallback(self) -> None:
-        from redis.exceptions import RedisError
-
-        mock_redis = AsyncMock(spec=RedisCache)
-        mock_redis._build_key = lambda scope, entity_id, field=None: (
-            f"chatwoot:1:{scope}:{entity_id}" + (f":{field}" if field else "")
-        )
-        mock_redis.set.side_effect = RedisError("redis down")
-        mock_redis.get.side_effect = RedisError("redis down")
-
-        sm = SessionManager(redis_cache=mock_redis)
-        await sm.set_user_profile("s1", "experto")
-        profile = await sm.get_user_profile("s1")
-        assert profile == "experto"
-
-    @pytest.mark.asyncio
-    async def test_token_usage_fallback(self) -> None:
-        from redis.exceptions import RedisError
-
-        mock_redis = AsyncMock(spec=RedisCache)
-        mock_redis._build_key = lambda scope, entity_id, field=None: (
-            f"chatwoot:1:{scope}:{entity_id}" + (f":{field}" if field else "")
-        )
-        mock_redis.hgetall.side_effect = RedisError("redis down")
-        mock_redis.hset.side_effect = RedisError("redis down")
-
-        sm = SessionManager(redis_cache=mock_redis)
-        await sm.add_token_usage("s1", 100, 50, 150)
-        totals = await sm.get_token_totals("s1")
-        assert totals.input_tokens == 100

--- a/backend/tests/test_session_manager_hybrid.py
+++ b/backend/tests/test_session_manager_hybrid.py
@@ -1,0 +1,280 @@
+"""Tests for hybrid Redis SessionManager.
+
+Uses fakeredis to exercise Redis-backed session operations without a
+real Redis server.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fakeredis import FakeAsyncRedis
+
+from backend.app.chatwoot_client import ChatwootClient
+from backend.app.redis_cache import RedisCache
+from backend.app.session import SessionManager
+
+
+@pytest.fixture
+def fake_redis() -> FakeAsyncRedis:
+    return FakeAsyncRedis(decode_responses=True)
+
+
+@pytest.fixture
+def redis_cache(fake_redis: FakeAsyncRedis) -> RedisCache:
+    with patch("backend.app.redis_cache.redis.asyncio.Redis") as MockRedis:
+        MockRedis.from_url.return_value = fake_redis
+        return RedisCache(redis_url="redis://localhost:6379/0")
+
+
+@pytest.fixture
+def session_manager(redis_cache: RedisCache) -> SessionManager:
+    return SessionManager(redis_cache=redis_cache)
+
+
+class TestAddTurn:
+    """Storing conversation turns in Redis."""
+
+    @pytest.mark.asyncio
+    async def test_add_turn_creates_redis_list(
+        self, session_manager: SessionManager
+    ) -> None:
+        await session_manager.add_turn("s1", "¿Qué es solar?", "Energía del sol")
+        history = await session_manager.get_history("s1")
+        assert len(history) == 1
+        assert history[0].question == "¿Qué es solar?"
+        assert history[0].answer == "Energía del sol"
+
+    @pytest.mark.asyncio
+    async def test_add_turn_trims_to_max(self, session_manager: SessionManager) -> None:
+        sm = SessionManager(redis_cache=session_manager._redis, max_turns=2)
+        for i in range(4):
+            await sm.add_turn("s1", f"Pregunta {i}", f"Respuesta {i}")
+        history = await sm.get_history("s1")
+        assert len(history) == 2
+        assert history[0].question == "Pregunta 2"
+        assert history[1].question == "Pregunta 3"
+
+    @pytest.mark.asyncio
+    async def test_add_turn_includes_source_documents(
+        self, session_manager: SessionManager
+    ) -> None:
+        await session_manager.add_turn(
+            "s1", "¿Panel?", "Sí", source_documents=["doc1.pdf"]
+        )
+        history = await session_manager.get_history("s1")
+        assert history[0].source_documents == ["doc1.pdf"]
+
+
+class TestGetHistory:
+    """Retrieving history from Redis with fallbacks."""
+
+    @pytest.mark.asyncio
+    async def test_get_history_from_redis(
+        self, session_manager: SessionManager
+    ) -> None:
+        await session_manager.add_turn("s1", "Hola", "Buenas")
+        await session_manager.add_turn("s1", "Adiós", "Hasta luego")
+        history = await session_manager.get_history("s1")
+        assert len(history) == 2
+
+    @pytest.mark.asyncio
+    async def test_get_history_empty(self, session_manager: SessionManager) -> None:
+        history = await session_manager.get_history("s1")
+        assert history == []
+
+    @pytest.mark.asyncio
+    async def test_get_history_chatwoot_fallback(self, redis_cache: RedisCache) -> None:
+        mock_client = AsyncMock(spec=ChatwootClient)
+        mock_client.fetch_messages.return_value = {
+            "payload": [
+                {"content": "Hola", "message_type": 0, "sender_type": "contact"},
+                {"content": "Buenas", "message_type": 1, "sender_type": "user"},
+            ]
+        }
+
+        sm = SessionManager(redis_cache=redis_cache, chatwoot_client=mock_client)
+        # Map conversation so fallback knows which conversation to fetch
+        await sm.map_conversation("s1", "42")
+
+        history = await sm.get_history("s1")
+        assert len(history) == 1  # Only contact message becomes a turn
+        mock_client.fetch_messages.assert_awaited_once_with(42, limit=10)
+
+    @pytest.mark.asyncio
+    async def test_get_history_redis_unavailable_fallback(self) -> None:
+        from redis.exceptions import RedisError
+
+        mock_redis = AsyncMock(spec=RedisCache)
+        mock_redis._build_key = lambda scope, entity_id, field=None: (
+            f"chatwoot:1:{scope}:{entity_id}" + (f":{field}" if field else "")
+        )
+        mock_redis.lpush.side_effect = RedisError("redis down")
+        mock_redis.lrange.side_effect = RedisError("redis down")
+
+        sm = SessionManager(redis_cache=mock_redis)
+        await sm.add_turn("s1", "Hola", "Buenas")
+        # Should fall back to in-memory
+        history = await sm.get_history("s1")
+        assert len(history) == 1
+        assert history[0].question == "Hola"
+
+
+class TestGetContextString:
+    """Formatting history for LLM context."""
+
+    @pytest.mark.asyncio
+    async def test_get_context_string(self, session_manager: SessionManager) -> None:
+        await session_manager.add_turn("s1", "¿Panel?", "Sí", ["doc1.pdf"])
+        ctx = await session_manager.get_context_string("s1")
+        assert "Turno 1:" in ctx
+        assert "Usuario: ¿Panel?" in ctx
+        assert "Asistente: Sí" in ctx
+        assert "Fuentes: doc1.pdf" in ctx
+
+    @pytest.mark.asyncio
+    async def test_get_context_string_empty(
+        self, session_manager: SessionManager
+    ) -> None:
+        ctx = await session_manager.get_context_string("s1")
+        assert ctx == ""
+
+
+class TestUserProfile:
+    """Profile storage in Redis."""
+
+    @pytest.mark.asyncio
+    async def test_set_and_get_profile(self, session_manager: SessionManager) -> None:
+        await session_manager.set_user_profile("s1", "novato")
+        profile = await session_manager.get_user_profile("s1")
+        assert profile == "novato"
+
+    @pytest.mark.asyncio
+    async def test_get_profile_missing(self, session_manager: SessionManager) -> None:
+        profile = await session_manager.get_user_profile("s1")
+        assert profile is None
+
+
+class TestTokenUsage:
+    """Token accumulation via Redis hash."""
+
+    @pytest.mark.asyncio
+    async def test_add_token_usage(self, session_manager: SessionManager) -> None:
+        await session_manager.add_token_usage("s1", 100, 50, 150)
+        totals = await session_manager.get_token_totals("s1")
+        assert totals.input_tokens == 100
+        assert totals.output_tokens == 50
+        assert totals.total_tokens == 150
+
+    @pytest.mark.asyncio
+    async def test_add_token_usage_accumulates(
+        self, session_manager: SessionManager
+    ) -> None:
+        await session_manager.add_token_usage("s1", 100, 50, 150)
+        await session_manager.add_token_usage("s1", 200, 100, 300)
+        totals = await session_manager.get_token_totals("s1")
+        assert totals.input_tokens == 300
+        assert totals.output_tokens == 150
+        assert totals.total_tokens == 450
+
+
+class TestConversationMapping:
+    """Session ID ↔ Conversation ID mapping."""
+
+    @pytest.mark.asyncio
+    async def test_map_conversation(self, session_manager: SessionManager) -> None:
+        await session_manager.map_conversation("s1", "42")
+        conv_id = await session_manager.get_conversation_id("s1")
+        assert conv_id == "42"
+
+    @pytest.mark.asyncio
+    async def test_get_session_id_reverse(
+        self, session_manager: SessionManager
+    ) -> None:
+        await session_manager.map_conversation("s1", "42")
+        session_id = await session_manager.get_session_id("42")
+        assert session_id == "s1"
+
+    @pytest.mark.asyncio
+    async def test_get_conversation_id_missing(
+        self, session_manager: SessionManager
+    ) -> None:
+        assert await session_manager.get_conversation_id("s1") is None
+
+    @pytest.mark.asyncio
+    async def test_get_session_id_missing(
+        self, session_manager: SessionManager
+    ) -> None:
+        assert await session_manager.get_session_id("42") is None
+
+
+class TestClearSession:
+    """Clearing session data from Redis."""
+
+    @pytest.mark.asyncio
+    async def test_clear_session_removes_all(
+        self, session_manager: SessionManager
+    ) -> None:
+        await session_manager.add_turn("s1", "Hola", "Buenas")
+        await session_manager.set_user_profile("s1", "novato")
+        await session_manager.add_token_usage("s1", 10, 5, 15)
+        await session_manager.map_conversation("s1", "42")
+
+        await session_manager.clear_session("s1")
+
+        assert await session_manager.get_history("s1") == []
+        assert await session_manager.get_user_profile("s1") is None
+        totals = await session_manager.get_token_totals("s1")
+        assert totals.total_tokens == 0
+        assert await session_manager.get_conversation_id("s1") is None
+
+
+class TestFallbackWhenRedisUnavailable:
+    """Graceful degradation when Redis is down."""
+
+    @pytest.mark.asyncio
+    async def test_add_turn_fallback(self) -> None:
+        from redis.exceptions import RedisError
+
+        mock_redis = AsyncMock(spec=RedisCache)
+        mock_redis._build_key = lambda scope, entity_id, field=None: (
+            f"chatwoot:1:{scope}:{entity_id}" + (f":{field}" if field else "")
+        )
+        mock_redis.lpush.side_effect = RedisError("redis down")
+        mock_redis.lrange.side_effect = RedisError("redis down")
+
+        sm = SessionManager(redis_cache=mock_redis)
+        await sm.add_turn("s1", "Hola", "Buenas")
+        history = await sm.get_history("s1")
+        assert len(history) == 1
+
+    @pytest.mark.asyncio
+    async def test_set_profile_fallback(self) -> None:
+        from redis.exceptions import RedisError
+
+        mock_redis = AsyncMock(spec=RedisCache)
+        mock_redis._build_key = lambda scope, entity_id, field=None: (
+            f"chatwoot:1:{scope}:{entity_id}" + (f":{field}" if field else "")
+        )
+        mock_redis.set.side_effect = RedisError("redis down")
+        mock_redis.get.side_effect = RedisError("redis down")
+
+        sm = SessionManager(redis_cache=mock_redis)
+        await sm.set_user_profile("s1", "experto")
+        profile = await sm.get_user_profile("s1")
+        assert profile == "experto"
+
+    @pytest.mark.asyncio
+    async def test_token_usage_fallback(self) -> None:
+        from redis.exceptions import RedisError
+
+        mock_redis = AsyncMock(spec=RedisCache)
+        mock_redis._build_key = lambda scope, entity_id, field=None: (
+            f"chatwoot:1:{scope}:{entity_id}" + (f":{field}" if field else "")
+        )
+        mock_redis.hgetall.side_effect = RedisError("redis down")
+        mock_redis.hset.side_effect = RedisError("redis down")
+
+        sm = SessionManager(redis_cache=mock_redis)
+        await sm.add_token_usage("s1", 100, 50, 150)
+        totals = await sm.get_token_totals("s1")
+        assert totals.input_tokens == 100

--- a/backend/tests/test_user_profiler.py
+++ b/backend/tests/test_user_profiler.py
@@ -2,7 +2,6 @@
 Unit tests for the user profile inference module.
 """
 
-import pytest
 from backend.app.user_profiler import (
     infer_user_profile,
     _extract_technical_score,
@@ -248,112 +247,103 @@ class TestInferUserProfile:
 class TestSessionManagerProfileIntegration:
     """Tests for profile integration with SessionManager."""
 
-    @pytest.mark.asyncio
-    async def test_set_user_profile(self):
+    def test_set_user_profile(self):
         """Test setting a user profile."""
         sm = SessionManager()
         session_id = "test-session-1"
-        await sm.set_user_profile(session_id, "experto")
-        assert await sm.get_user_profile(session_id) == "experto"
+        sm.set_user_profile(session_id, "experto")
+        assert sm.get_user_profile(session_id) == "experto"
 
-    @pytest.mark.asyncio
-    async def test_get_user_profile_nonexistent(self):
+    def test_get_user_profile_nonexistent(self):
         """Test getting profile for non-existent session."""
         sm = SessionManager()
-        profile = await sm.get_user_profile("non-existent")
+        profile = sm.get_user_profile("non-existent")
         assert profile is None
 
-    @pytest.mark.asyncio
-    async def test_profile_persistence_across_calls(self):
+    def test_profile_persistence_across_calls(self):
         """Test that profile persists across multiple get calls."""
         sm = SessionManager()
         session_id = "test-session-2"
-        await sm.set_user_profile(session_id, "intermedio")
-        profile1 = await sm.get_user_profile(session_id)
-        profile2 = await sm.get_user_profile(session_id)
+        sm.set_user_profile(session_id, "intermedio")
+        profile1 = sm.get_user_profile(session_id)
+        profile2 = sm.get_user_profile(session_id)
         assert profile1 == profile2 == "intermedio"
 
-    @pytest.mark.asyncio
-    async def test_clear_session_removes_profile(self):
+    def test_clear_session_removes_profile(self):
         """Test that clearing a session also removes its profile."""
         sm = SessionManager()
         session_id = "test-session-3"
-        await sm.set_user_profile(session_id, "experto")
-        assert await sm.get_user_profile(session_id) == "experto"
+        sm.set_user_profile(session_id, "experto")
+        assert sm.get_user_profile(session_id) == "experto"
 
-        await sm.clear_session(session_id)
-        assert await sm.get_user_profile(session_id) is None
+        sm.clear_session(session_id)
+        assert sm.get_user_profile(session_id) is None
 
-    @pytest.mark.asyncio
-    async def test_update_profile(self):
+    def test_update_profile(self):
         """Test updating an existing profile."""
         sm = SessionManager()
         session_id = "test-session-4"
-        await sm.set_user_profile(session_id, "novato")
-        assert await sm.get_user_profile(session_id) == "novato"
+        sm.set_user_profile(session_id, "novato")
+        assert sm.get_user_profile(session_id) == "novato"
 
-        await sm.set_user_profile(session_id, "experto")
-        assert await sm.get_user_profile(session_id) == "experto"
+        sm.set_user_profile(session_id, "experto")
+        assert sm.get_user_profile(session_id) == "experto"
 
-    @pytest.mark.asyncio
-    async def test_multiple_sessions_independent_profiles(self):
+    def test_multiple_sessions_independent_profiles(self):
         """Test that profiles are independent between sessions."""
         sm = SessionManager()
-        await sm.set_user_profile("session-1", "novato")
-        await sm.set_user_profile("session-2", "experto")
+        sm.set_user_profile("session-1", "novato")
+        sm.set_user_profile("session-2", "experto")
 
-        assert await sm.get_user_profile("session-1") == "novato"
-        assert await sm.get_user_profile("session-2") == "experto"
+        assert sm.get_user_profile("session-1") == "novato"
+        assert sm.get_user_profile("session-2") == "experto"
 
 
 class TestEndToEndProfileInference:
     """End-to-end tests for profile inference workflow."""
 
-    @pytest.mark.asyncio
-    async def test_infer_profile_from_session_history(self):
+    def test_infer_profile_from_session_history(self):
         """Test inferring profile from actual session history."""
         sm = SessionManager()
         session_id = "end-to-end-1"
 
         # Add a generic question
-        await sm.add_turn(session_id, "¿Qué es un panel solar?", "Un panel solar es...")
+        sm.add_turn(session_id, "¿Qué es un panel solar?", "Un panel solar es...")
 
         # Get history and infer profile
-        history = await sm.get_history(session_id)
+        history = sm.get_history(session_id)
         history_dicts = [{"role": "user", "content": turn.question} for turn in history]
         profile = infer_user_profile(history_dicts)
 
         assert profile == "novato"
 
-    @pytest.mark.asyncio
-    async def test_profile_remains_novato_with_simple_questions(self):
+    def test_profile_remains_novato_with_simple_questions(self):
         """Test that multiple simple questions keep novato profile."""
         sm = SessionManager()
         session_id = "end-to-end-2"
 
-        await sm.add_turn(session_id, "¿Qué es solar?", "Es...")
-        await sm.add_turn(session_id, "¿Y el viento?", "Es...")
+        sm.add_turn(session_id, "¿Qué es solar?", "Es...")
+        sm.add_turn(session_id, "¿Y el viento?", "Es...")
 
-        history = await sm.get_history(session_id)
+        history = sm.get_history(session_id)
         history_dicts = [{"role": "user", "content": turn.question} for turn in history]
         profile = infer_user_profile(history_dicts)
 
         assert profile == "novato"
 
-    @pytest.mark.asyncio
-    async def test_profile_upgrades_to_experto_with_technical_questions(self):
+    def test_profile_upgrades_to_experto_with_technical_questions(self):
         """Test that technical questions result in experto profile."""
         sm = SessionManager()
         session_id = "end-to-end-3"
 
-        await sm.add_turn(session_id, "¿Qué es solar?", "Es...")
-        await sm.add_turn(
+        sm.add_turn(session_id, "¿Qué es solar?", "Es...")
+        sm.add_turn(
             session_id,
             "¿cuál es el Voc del JinkoSolar 460W a 25°C?",
             "Es...",
         )
 
-        history = await sm.get_history(session_id)
+        history = sm.get_history(session_id)
         history_dicts = [{"role": "user", "content": turn.question} for turn in history]
         profile = infer_user_profile(history_dicts)
 

--- a/backend/tests/test_user_profiler.py
+++ b/backend/tests/test_user_profiler.py
@@ -248,103 +248,112 @@ class TestInferUserProfile:
 class TestSessionManagerProfileIntegration:
     """Tests for profile integration with SessionManager."""
 
-    def test_set_user_profile(self):
+    @pytest.mark.asyncio
+    async def test_set_user_profile(self):
         """Test setting a user profile."""
         sm = SessionManager()
         session_id = "test-session-1"
-        sm.set_user_profile(session_id, "experto")
-        assert sm.get_user_profile(session_id) == "experto"
+        await sm.set_user_profile(session_id, "experto")
+        assert await sm.get_user_profile(session_id) == "experto"
 
-    def test_get_user_profile_nonexistent(self):
+    @pytest.mark.asyncio
+    async def test_get_user_profile_nonexistent(self):
         """Test getting profile for non-existent session."""
         sm = SessionManager()
-        profile = sm.get_user_profile("non-existent")
+        profile = await sm.get_user_profile("non-existent")
         assert profile is None
 
-    def test_profile_persistence_across_calls(self):
+    @pytest.mark.asyncio
+    async def test_profile_persistence_across_calls(self):
         """Test that profile persists across multiple get calls."""
         sm = SessionManager()
         session_id = "test-session-2"
-        sm.set_user_profile(session_id, "intermedio")
-        profile1 = sm.get_user_profile(session_id)
-        profile2 = sm.get_user_profile(session_id)
+        await sm.set_user_profile(session_id, "intermedio")
+        profile1 = await sm.get_user_profile(session_id)
+        profile2 = await sm.get_user_profile(session_id)
         assert profile1 == profile2 == "intermedio"
 
-    def test_clear_session_removes_profile(self):
+    @pytest.mark.asyncio
+    async def test_clear_session_removes_profile(self):
         """Test that clearing a session also removes its profile."""
         sm = SessionManager()
         session_id = "test-session-3"
-        sm.set_user_profile(session_id, "experto")
-        assert sm.get_user_profile(session_id) == "experto"
+        await sm.set_user_profile(session_id, "experto")
+        assert await sm.get_user_profile(session_id) == "experto"
 
-        sm.clear_session(session_id)
-        assert sm.get_user_profile(session_id) is None
+        await sm.clear_session(session_id)
+        assert await sm.get_user_profile(session_id) is None
 
-    def test_update_profile(self):
+    @pytest.mark.asyncio
+    async def test_update_profile(self):
         """Test updating an existing profile."""
         sm = SessionManager()
         session_id = "test-session-4"
-        sm.set_user_profile(session_id, "novato")
-        assert sm.get_user_profile(session_id) == "novato"
+        await sm.set_user_profile(session_id, "novato")
+        assert await sm.get_user_profile(session_id) == "novato"
 
-        sm.set_user_profile(session_id, "experto")
-        assert sm.get_user_profile(session_id) == "experto"
+        await sm.set_user_profile(session_id, "experto")
+        assert await sm.get_user_profile(session_id) == "experto"
 
-    def test_multiple_sessions_independent_profiles(self):
+    @pytest.mark.asyncio
+    async def test_multiple_sessions_independent_profiles(self):
         """Test that profiles are independent between sessions."""
         sm = SessionManager()
-        sm.set_user_profile("session-1", "novato")
-        sm.set_user_profile("session-2", "experto")
+        await sm.set_user_profile("session-1", "novato")
+        await sm.set_user_profile("session-2", "experto")
 
-        assert sm.get_user_profile("session-1") == "novato"
-        assert sm.get_user_profile("session-2") == "experto"
+        assert await sm.get_user_profile("session-1") == "novato"
+        assert await sm.get_user_profile("session-2") == "experto"
 
 
 class TestEndToEndProfileInference:
     """End-to-end tests for profile inference workflow."""
 
-    def test_infer_profile_from_session_history(self):
+    @pytest.mark.asyncio
+    async def test_infer_profile_from_session_history(self):
         """Test inferring profile from actual session history."""
         sm = SessionManager()
         session_id = "end-to-end-1"
 
         # Add a generic question
-        sm.add_turn(session_id, "¿Qué es un panel solar?", "Un panel solar es...")
+        await sm.add_turn(session_id, "¿Qué es un panel solar?", "Un panel solar es...")
 
         # Get history and infer profile
-        history = sm.get_history(session_id)
+        history = await sm.get_history(session_id)
         history_dicts = [{"role": "user", "content": turn.question} for turn in history]
         profile = infer_user_profile(history_dicts)
 
         assert profile == "novato"
 
-    def test_profile_remains_novato_with_simple_questions(self):
+    @pytest.mark.asyncio
+    async def test_profile_remains_novato_with_simple_questions(self):
         """Test that multiple simple questions keep novato profile."""
         sm = SessionManager()
         session_id = "end-to-end-2"
 
-        sm.add_turn(session_id, "¿Qué es solar?", "Es...")
-        sm.add_turn(session_id, "¿Y el viento?", "Es...")
+        await sm.add_turn(session_id, "¿Qué es solar?", "Es...")
+        await sm.add_turn(session_id, "¿Y el viento?", "Es...")
 
-        history = sm.get_history(session_id)
+        history = await sm.get_history(session_id)
         history_dicts = [{"role": "user", "content": turn.question} for turn in history]
         profile = infer_user_profile(history_dicts)
 
         assert profile == "novato"
 
-    def test_profile_upgrades_to_experto_with_technical_questions(self):
+    @pytest.mark.asyncio
+    async def test_profile_upgrades_to_experto_with_technical_questions(self):
         """Test that technical questions result in experto profile."""
         sm = SessionManager()
         session_id = "end-to-end-3"
 
-        sm.add_turn(session_id, "¿Qué es solar?", "Es...")
-        sm.add_turn(
+        await sm.add_turn(session_id, "¿Qué es solar?", "Es...")
+        await sm.add_turn(
             session_id,
             "¿cuál es el Voc del JinkoSolar 460W a 25°C?",
             "Es...",
         )
 
-        history = sm.get_history(session_id)
+        history = await sm.get_history(session_id)
         history_dicts = [{"role": "user", "content": turn.question} for turn in history]
         profile = infer_user_profile(history_dicts)
 


### PR DESCRIPTION
## Linked Issues
Refs #166
Refs #168
Refs #165

## PR Type
- [x] New feature
- [ ] Bug fix
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Evolves message buffering with Redis-backed Chatwoot conversation state, lock-guarded flushes, and legacy `/chat` buffer compatibility.
- Adds hybrid SessionManager methods for Chatwoot conversation/session mapping and async Redis-backed history hydration while restoring sync `/chat` methods.
- Adds Chatwoot human handoff orchestration and wires ChatwootHandler internals to session mapping, buffering, typing indicators, and human-agent cancel flow.

## Changes
| File | Change |
|------|--------|
| `backend/app/message_buffer.py` | Added `BufferState`, Chatwoot `add_message`, lock-guarded `flush`, and `RedisMessageBuffer` alias |
| `backend/app/session.py` | Preserved sync legacy API and added async Redis-backed mapping/history methods |
| `backend/app/escalation_handler.py` | Added `escalate_to_human` with labels, status, assignment, and handoff message |
| `backend/app/chatwoot_handler.py` | Wired internal message-created flow to sessions, buffers, and typing indicators |
| `backend/tests/*` | Added/updated tests for Redis buffers, hybrid sessions, escalation, handler flow, and legacy sync session behavior |

## Test Plan
- [x] `uv run pytest backend/tests/test_channel_profile.py backend/tests/test_config_provider.py backend/tests/test_redis_cache.py backend/tests/test_chatwoot_client.py backend/tests/test_message_buffer_redis.py backend/tests/test_session.py backend/tests/test_session_manager_hybrid.py backend/tests/test_escalation_handler.py backend/tests/test_chatwoot_handler.py backend/tests/test_user_profiler.py`
- [x] `uv run ruff check backend/app/message_buffer.py backend/app/session.py backend/app/escalation_handler.py backend/app/chatwoot_handler.py backend/tests/test_message_buffer_redis.py backend/tests/test_session.py backend/tests/test_session_manager_hybrid.py backend/tests/test_escalation_handler.py backend/tests/test_chatwoot_handler.py backend/tests/test_user_profiler.py`
- [x] `uv run ruff format --check backend/app/message_buffer.py backend/app/session.py backend/app/escalation_handler.py backend/app/chatwoot_handler.py backend/tests/test_message_buffer_redis.py backend/tests/test_session.py backend/tests/test_session_manager_hybrid.py backend/tests/test_escalation_handler.py backend/tests/test_chatwoot_handler.py backend/tests/test_user_profiler.py`

## Chained PR Context
- Current slice: PR #3 — Component Evolution
- Base branch: `feature/chatwoot-integration-pr-2-core-components`
- Head branch: `feature/chatwoot-integration-pr-3-component-evolution`
- Public `/webhook/chatwoot` and `/health/chatwoot` endpoints intentionally remain out of scope for PR #4.

## Notes
- No real Chatwoot credentials are required; tests use fakeredis and mocks.
- Test collection warns when `OPENAI_API_KEY` / `CHAT_API_KEY` are missing, but the selected component suite passed.