### PR TITLE
feat(#165,#164): wire Chatwoot webhook and health endpoints

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,3 +1,4 @@
+import hashlib
 import hmac
 from typing import Optional
 
@@ -38,3 +39,34 @@ def verify_api_key(api_key: str = Security(API_KEY_HEADER)) -> str:
             detail="Invalid API key",
         )
     return api_key
+
+
+def verify_chatwoot_signature(
+    payload: bytes,
+    signature: Optional[str],
+    secret: Optional[str],
+) -> bool:
+    """Verify a Chatwoot webhook HMAC-SHA256 signature.
+
+    Args:
+        payload: Raw request body bytes exactly as received.
+        signature: Signature header value. Supports raw hex and
+            ``sha256=<hex>`` values.
+        secret: Shared webhook secret configured in Chatwoot.
+
+    Returns:
+        ``True`` when the signature matches, otherwise ``False``.
+    """
+    if not payload or not signature or not secret:
+        return False
+
+    supplied_signature = signature.strip()
+    if supplied_signature.startswith("sha256="):
+        supplied_signature = supplied_signature.removeprefix("sha256=")
+
+    expected_signature = hmac.new(
+        secret.encode("utf-8"),
+        payload,
+        hashlib.sha256,
+    ).hexdigest()
+    return hmac.compare_digest(supplied_signature, expected_signature)

--- a/backend/app/redis_cache.py
+++ b/backend/app/redis_cache.py
@@ -5,7 +5,7 @@ unavailable so callers never need to catch connection errors.
 """
 
 import logging
-from typing import Optional
+from typing import Optional, Union
 
 import redis.asyncio
 from redis.exceptions import RedisError
@@ -21,7 +21,8 @@ class RedisCache:
         password: Optional Redis password.
         prefix: Key prefix for namespacing. Defaults to ``"chatwoot"``.
         account_id: Chatwoot account ID embedded in every key.
-            Defaults to ``1``.
+            Defaults to ``"unconfigured"`` to avoid collisions when Chatwoot is
+            disabled or not fully configured.
     """
 
     def __init__(
@@ -29,7 +30,7 @@ class RedisCache:
         redis_url: str,
         password: Optional[str] = None,
         prefix: str = "chatwoot",
-        account_id: int = 1,
+        account_id: Union[int, str] = "unconfigured",
     ) -> None:
         self._prefix = prefix
         self._account_id = account_id

--- a/backend/main.py
+++ b/backend/main.py
@@ -210,7 +210,7 @@ def get_config_provider() -> EnvConfigProvider:
 
 def get_redis_cache() -> RedisCache:
     """Dependency that provides a RedisCache instance for Chatwoot state."""
-    account_id = settings.chatwoot_account_id or 1
+    account_id = settings.chatwoot_account_id or "unconfigured"
     return RedisCache(
         redis_url=settings.redis_url,
         password=settings.redis_password,
@@ -458,9 +458,9 @@ async def chatwoot_webhook(
         raise HTTPException(status_code=401, detail="Invalid Chatwoot signature")
 
     payload = _parse_chatwoot_payload(raw_payload)
-    dependency = request.app.dependency_overrides.get(
-        get_chatwoot_handler,
-        get_chatwoot_handler,
+    dependency = (
+        request.app.dependency_overrides.get(get_chatwoot_handler)
+        or get_chatwoot_handler
     )
     handler = dependency()
     try:

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,40 +4,29 @@ FastAPI server with /health and /chat endpoints.
 """
 
 import asyncio
-import logging
-import time
-
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-)
-
 import json
+import logging
 import os
+import re
+import time
 import uuid
 from datetime import datetime, timezone
 from typing import Annotated, Any, Optional
 
-# Load environment variables from .env file
 from dotenv import load_dotenv
-
-load_dotenv()
-
-from backend.app.logging_config import setup_logging
-
-# Configure logging before anything else (reads LOG_LEVEL from centralized settings)
-setup_logging()
-
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import Depends, FastAPI, Header, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
-from backend.app.auth import verify_api_key
+from backend.app.auth import verify_api_key, verify_chatwoot_signature
 from backend.app.catalog import CatalogError, get_catalog
+from backend.app.chatwoot_client import ChatwootClient
+from backend.app.chatwoot_handler import ChatwootHandler
 from backend.app.config import settings
 from backend.app.config_provider import EnvConfigProvider
 from backend.app.conversation_logger import ConversationLogEntry, ConversationLogger
+from backend.app.escalation_handler import EscalationHandler
 from backend.app.file_inputs import FileInputsClient, FileUploadError
 from backend.app.greeting import maybe_prepend_greeting
 from backend.app.llm_client import (
@@ -47,7 +36,9 @@ from backend.app.llm_client import (
     LLMServiceError,
     expand_query_with_context,
 )
+from backend.app.logging_config import setup_logging
 from backend.app.message_buffer import (
+    RedisMessageBuffer,
     add_to_buffer,
     clear_pending_chat_response,
     clear_processing,
@@ -60,10 +51,17 @@ from backend.app.message_buffer import (
     set_pending_chat_response,
     set_processing,
 )
-
 from backend.app.message_splitter import process_split_messages
+from backend.app.redis_cache import RedisCache
 from backend.app.s3_client import S3Client, S3DownloadError
-from backend.app.schemas import LLMResponse, SourceDocument
+from backend.app.schemas import (
+    ChatwootWebhookPayload,
+    ConversationCreatedPayload,
+    ConversationStatusChangedPayload,
+    LLMResponse,
+    MessageCreatedPayload,
+    SourceDocument,
+)
 from backend.app.session import session_manager
 from backend.app.tools import get_tool_definitions, validate_s3_path
 from backend.app.user_profiler import PROFILE_INSTRUCTIONS, infer_user_profile
@@ -72,6 +70,16 @@ from rag import (
     DEFAULT_ESCALATION_MESSAGE,
     default_detector,
 )
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+
+load_dotenv()
+
+# Configure logging before anything else (reads LOG_LEVEL from centralized settings)
+setup_logging()
 
 logger = logging.getLogger(__name__)
 
@@ -91,8 +99,6 @@ OUT_OF_DOMAIN_MESSAGE = (
     "de productos y consultas generales sobre sistemas de energía solar. "
     "¿Hay algo relacionado con energía solar en lo que pueda ayudarte?"
 )
-
-import re
 
 INTENT_MARKER_RE = re.compile(r"\[INTENT:\s*(\w+)\]")
 
@@ -200,6 +206,54 @@ def get_file_inputs_client() -> FileInputsClient:
 def get_config_provider() -> EnvConfigProvider:
     """Dependency that provides a ConfigProvider instance."""
     return EnvConfigProvider()
+
+
+def get_redis_cache() -> RedisCache:
+    """Dependency that provides a RedisCache instance for Chatwoot state."""
+    account_id = settings.chatwoot_account_id or 1
+    return RedisCache(
+        redis_url=settings.redis_url,
+        password=settings.redis_password,
+        account_id=account_id,
+    )
+
+
+def get_chatwoot_client() -> ChatwootClient:
+    """Dependency that provides a configured Chatwoot API client."""
+    if (
+        not settings.chatwoot_api_url
+        or not settings.chatwoot_agent_bot_token
+        or settings.chatwoot_account_id is None
+    ):
+        raise RuntimeError("Chatwoot API client is not configured")
+
+    return ChatwootClient(
+        base_url=settings.chatwoot_api_url,
+        agent_bot_token=settings.chatwoot_agent_bot_token,
+        account_id=settings.chatwoot_account_id,
+        redis_cache=get_redis_cache(),
+    )
+
+
+def get_chatwoot_handler() -> ChatwootHandler:
+    """Dependency that wires Chatwoot webhook handling services."""
+    redis_cache = get_redis_cache()
+    config_provider = get_config_provider()
+    chatwoot_client = get_chatwoot_client()
+    message_buffer = RedisMessageBuffer(redis_cache, config_provider)
+    escalation_handler = EscalationHandler(
+        chatwoot_client=chatwoot_client,
+        config_provider=config_provider,
+        session_manager=session_manager,
+    )
+    return ChatwootHandler(
+        chatwoot_client=chatwoot_client,
+        redis_cache=redis_cache,
+        config_provider=config_provider,
+        message_buffer=message_buffer,
+        session_manager=session_manager,
+        escalation_handler=escalation_handler,
+    )
 
 
 # Lazy-load catalog to allow /health to work without AWS credentials in CI
@@ -351,6 +405,109 @@ async def health_check() -> JSONResponse:
             "status": "healthy",
             "service": "arte-chatbot-backend",
             "version": "1.0.0",
+        },
+    )
+
+
+def _parse_chatwoot_payload(raw_payload: bytes) -> ChatwootWebhookPayload:
+    """Parse a raw Chatwoot webhook body into the matching schema."""
+    try:
+        payload = json.loads(raw_payload)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=422, detail="Invalid Chatwoot payload") from exc
+
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=422, detail="Invalid Chatwoot payload")
+
+    event = payload.get("event")
+    schema_by_event = {
+        "message_created": MessageCreatedPayload,
+        "conversation_created": ConversationCreatedPayload,
+        "conversation_status_changed": ConversationStatusChangedPayload,
+    }
+    schema = schema_by_event.get(str(event))
+    if schema is None:
+        return ChatwootWebhookPayload.model_validate(payload)
+
+    try:
+        return schema.model_validate(payload)
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail=exc.errors()) from exc
+
+
+@app.post("/webhook/chatwoot")
+async def chatwoot_webhook(
+    request: Request,
+    x_chatwoot_signature: Annotated[Optional[str], Header()] = None,
+    x_hub_signature_256: Annotated[Optional[str], Header()] = None,
+) -> JSONResponse:
+    """Receive, verify, validate, and dispatch Chatwoot webhooks."""
+    if not settings.chatwoot_enabled:
+        return JSONResponse(
+            status_code=503,
+            content={"detail": "Chatwoot integration disabled"},
+        )
+
+    raw_payload = await request.body()
+    signature = x_chatwoot_signature or x_hub_signature_256
+    if not verify_chatwoot_signature(
+        raw_payload,
+        signature,
+        settings.chatwoot_webhook_secret,
+    ):
+        raise HTTPException(status_code=401, detail="Invalid Chatwoot signature")
+
+    payload = _parse_chatwoot_payload(raw_payload)
+    dependency = request.app.dependency_overrides.get(
+        get_chatwoot_handler,
+        get_chatwoot_handler,
+    )
+    handler = dependency()
+    try:
+        await handler.handle_event(payload)
+    except Exception as exc:
+        logger.exception("Chatwoot webhook handler failed: %s", exc)
+        raise HTTPException(status_code=500, detail="Chatwoot handler failed") from exc
+
+    return JSONResponse(status_code=200, content={"status": "accepted"})
+
+
+@app.get("/health/chatwoot")
+async def chatwoot_health(
+    redis_cache: Annotated[RedisCache, Depends(get_redis_cache)],
+) -> JSONResponse:
+    """Report Chatwoot integration health without external API calls."""
+    if not settings.chatwoot_enabled:
+        return JSONResponse(
+            status_code=200,
+            content={
+                "status": "disabled",
+                "chatwoot_enabled": False,
+                "redis": "not_configured",
+                "chatwoot_api": "not_configured",
+            },
+        )
+
+    has_chatwoot_config = bool(
+        settings.chatwoot_api_url
+        and settings.chatwoot_agent_bot_token
+        and settings.chatwoot_account_id is not None
+    )
+    redis_status = "healthy" if await redis_cache.health_check() else "unavailable"
+    chatwoot_api_status = "configured" if has_chatwoot_config else "not_configured"
+    status_value = (
+        "healthy"
+        if redis_status == "healthy" and chatwoot_api_status == "configured"
+        else "degraded"
+    )
+
+    return JSONResponse(
+        status_code=200,
+        content={
+            "status": status_value,
+            "chatwoot_enabled": True,
+            "redis": redis_status,
+            "chatwoot_api": chatwoot_api_status,
         },
     )
 
@@ -861,11 +1018,6 @@ async def _process_chat_message(
         session_id,
     )
 
-    system_message = {"role": "system", "content": system_prompt_with_profile}
-    conversation_history: list[dict[str, Any]] = [
-        system_message,
-        {"role": "user", "content": expanded_query},
-    ]
     source_docs: list[SourceDocument] = []
 
     try:
@@ -1508,34 +1660,6 @@ async def chat_endpoint(
             e,
         )
         raise HTTPException(status_code=500, detail="Internal server error")
-
-
-@app.get("/buffer-result/{session_id}", response_model=BufferResultResponse)
-async def get_buffer_result(session_id: str) -> BufferResultResponse:
-    """Poll for buffered message processing result.
-
-    After a 202 response from /chat, the client should poll this endpoint.
-    When the buffer window expires, the backend processes the joined message
-    with the chatbot and stores the response for pickup.
-    """
-    chat_response_json = pop_pending_chat_response(session_id)
-    if chat_response_json:
-        return BufferResultResponse(
-            status="ready",
-            session_id=session_id,
-            result=chat_response_json,
-        )
-
-    if is_buffering(session_id):
-        return BufferResultResponse(
-            status="pending",
-            session_id=session_id,
-        )
-
-    return BufferResultResponse(
-        status="not_found",
-        session_id=session_id,
-    )
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_chatwoot_auth.py
+++ b/backend/tests/test_chatwoot_auth.py
@@ -1,0 +1,40 @@
+"""Tests for Chatwoot webhook signature verification."""
+
+import hashlib
+import hmac
+
+from backend.app.auth import verify_chatwoot_signature
+
+
+def _signature(payload: bytes, secret: str) -> str:
+    """Return the HMAC-SHA256 hex digest for *payload*."""
+    return hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+
+
+def test_verify_chatwoot_signature_accepts_valid_raw_hex() -> None:
+    """Valid raw hex signatures should pass verification."""
+    payload = b'{"event":"message_created"}'
+    secret = "test-secret"
+
+    assert verify_chatwoot_signature(payload, _signature(payload, secret), secret)
+
+
+def test_verify_chatwoot_signature_rejects_invalid_signature() -> None:
+    """Invalid signatures should fail verification."""
+    payload = b'{"event":"message_created"}'
+
+    assert not verify_chatwoot_signature(payload, "invalid", "test-secret")
+
+
+def test_verify_chatwoot_signature_rejects_missing_signature() -> None:
+    """Missing signatures should fail verification."""
+    assert not verify_chatwoot_signature(b"{}", None, "test-secret")
+
+
+def test_verify_chatwoot_signature_accepts_sha256_prefix() -> None:
+    """Common sha256=<hex> prefixed signatures should pass verification."""
+    payload = b'{"event":"message_created"}'
+    secret = "test-secret"
+    signature = f"sha256={_signature(payload, secret)}"
+
+    assert verify_chatwoot_signature(payload, signature, secret)

--- a/backend/tests/test_chatwoot_endpoints.py
+++ b/backend/tests/test_chatwoot_endpoints.py
@@ -1,0 +1,269 @@
+"""Endpoint wiring tests for Chatwoot webhook and health routes."""
+
+import hashlib
+import hmac
+import json
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.app.config import settings
+
+
+def _signed_headers(payload: bytes, secret: str = "test-secret") -> dict[str, str]:
+    """Build Chatwoot signature headers for *payload*."""
+    digest = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+    return {"X-Chatwoot-Signature": digest}
+
+
+def _valid_payload() -> dict[str, Any]:
+    """Return a valid message_created webhook payload."""
+    return {
+        "event": "message_created",
+        "account": {"id": 1},
+        "conversation": {
+            "id": 42,
+            "status": "open",
+            "inbox_id": 7,
+            "contact_id": 9,
+        },
+        "sender": {"id": 11, "type": "contact", "name": "Cliente"},
+        "message": {
+            "id": 101,
+            "content": "Hola",
+            "content_type": "text",
+            "private": False,
+        },
+    }
+
+
+@pytest.fixture(autouse=True)
+def reset_settings() -> None:
+    """Reset lazy settings around endpoint tests."""
+    settings.reset()
+
+
+@pytest.fixture
+def main_module(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Import backend.main with baseline environment variables present."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai")
+    monkeypatch.setenv("CHAT_API_KEY", "test-chat")
+    monkeypatch.setenv("CHATWOOT_WEBHOOK_SECRET", "test-secret")
+    monkeypatch.setenv("CHATWOOT_API_URL", "https://chatwoot.test")
+    monkeypatch.setenv("CHATWOOT_AGENT_BOT_TOKEN", "test-token")
+    monkeypatch.setenv("CHATWOOT_ACCOUNT_ID", "1")
+    monkeypatch.setenv("CHATWOOT_INBOX_ID", "7")
+    settings.reset()
+
+    import backend.main as main
+
+    return main
+
+
+@pytest.fixture
+def client(main_module: Any) -> TestClient:
+    """Return a TestClient for the FastAPI app."""
+    return TestClient(main_module.app)
+
+
+def test_chatwoot_webhook_disabled_does_not_dispatch(
+    client: TestClient,
+    main_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Disabled integration should return 503 before parsing or dispatching."""
+    monkeypatch.setenv("CHATWOOT_ENABLED", "false")
+    settings.reset()
+    handler = AsyncMock()
+    main_module.app.dependency_overrides[main_module.get_chatwoot_handler] = lambda: (
+        handler
+    )
+
+    response = client.post("/webhook/chatwoot", content=b"not-json")
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Chatwoot integration disabled"}
+    handler.handle_event.assert_not_awaited()
+    main_module.app.dependency_overrides.clear()
+
+
+def test_chatwoot_webhook_valid_signature_dispatches_handler(
+    client: TestClient,
+    main_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Valid signed payloads should dispatch to ChatwootHandler."""
+    monkeypatch.setenv("CHATWOOT_ENABLED", "true")
+    settings.reset()
+    handler = AsyncMock()
+    main_module.app.dependency_overrides[main_module.get_chatwoot_handler] = lambda: (
+        handler
+    )
+    payload = _valid_payload()
+    body = json.dumps(payload).encode()
+
+    response = client.post(
+        "/webhook/chatwoot",
+        content=body,
+        headers=_signed_headers(body),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "accepted"}
+    handler.handle_event.assert_awaited_once()
+    main_module.app.dependency_overrides.clear()
+
+
+def test_chatwoot_webhook_invalid_signature_returns_401(
+    client: TestClient,
+    main_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalid HMAC signatures should be rejected."""
+    monkeypatch.setenv("CHATWOOT_ENABLED", "true")
+    settings.reset()
+    handler = AsyncMock()
+    main_module.app.dependency_overrides[main_module.get_chatwoot_handler] = lambda: (
+        handler
+    )
+
+    response = client.post(
+        "/webhook/chatwoot",
+        json=_valid_payload(),
+        headers={"X-Chatwoot-Signature": "bad"},
+    )
+
+    assert response.status_code == 401
+    handler.handle_event.assert_not_awaited()
+    main_module.app.dependency_overrides.clear()
+
+
+def test_chatwoot_webhook_invalid_payload_returns_422(
+    client: TestClient,
+    main_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Schema-invalid signed payloads should return 422."""
+    monkeypatch.setenv("CHATWOOT_ENABLED", "true")
+    settings.reset()
+    body = b'{"event":"message_created"}'
+
+    response = client.post(
+        "/webhook/chatwoot",
+        content=body,
+        headers=_signed_headers(body),
+    )
+
+    assert response.status_code == 422
+
+
+def test_chatwoot_webhook_handler_exception_returns_500(
+    client: TestClient,
+    main_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Handler failures should return 500 so Chatwoot retries."""
+    monkeypatch.setenv("CHATWOOT_ENABLED", "true")
+    settings.reset()
+    handler = AsyncMock()
+    handler.handle_event.side_effect = RuntimeError("boom")
+    main_module.app.dependency_overrides[main_module.get_chatwoot_handler] = lambda: (
+        handler
+    )
+    body = json.dumps(_valid_payload()).encode()
+
+    response = client.post(
+        "/webhook/chatwoot",
+        content=body,
+        headers=_signed_headers(body),
+    )
+
+    assert response.status_code == 500
+    main_module.app.dependency_overrides.clear()
+
+
+def test_chatwoot_health_disabled(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Disabled integration should report disabled status."""
+    monkeypatch.setenv("CHATWOOT_ENABLED", "false")
+    settings.reset()
+
+    response = client.get("/health/chatwoot")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "disabled"
+    assert response.json()["chatwoot_enabled"] is False
+
+
+def test_chatwoot_health_enabled_redis_healthy(
+    client: TestClient,
+    main_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Enabled integration with healthy Redis and config should be healthy."""
+    monkeypatch.setenv("CHATWOOT_ENABLED", "true")
+    settings.reset()
+    redis_cache = AsyncMock()
+    redis_cache.health_check.return_value = True
+    main_module.app.dependency_overrides[main_module.get_redis_cache] = lambda: (
+        redis_cache
+    )
+
+    response = client.get("/health/chatwoot")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "healthy",
+        "chatwoot_enabled": True,
+        "redis": "healthy",
+        "chatwoot_api": "configured",
+    }
+    main_module.app.dependency_overrides.clear()
+
+
+def test_chatwoot_health_enabled_redis_unavailable(
+    client: TestClient,
+    main_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Redis failures should degrade but not fail health."""
+    monkeypatch.setenv("CHATWOOT_ENABLED", "true")
+    settings.reset()
+    redis_cache = AsyncMock()
+    redis_cache.health_check.return_value = False
+    main_module.app.dependency_overrides[main_module.get_redis_cache] = lambda: (
+        redis_cache
+    )
+
+    response = client.get("/health/chatwoot")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "degraded"
+    assert response.json()["redis"] == "unavailable"
+    main_module.app.dependency_overrides.clear()
+
+
+def test_chatwoot_health_missing_chatwoot_config(
+    client: TestClient,
+    main_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing Chatwoot API config should report degraded/not_configured."""
+    monkeypatch.setenv("CHATWOOT_ENABLED", "true")
+    monkeypatch.delenv("CHATWOOT_API_URL", raising=False)
+    settings.reset()
+    redis_cache = AsyncMock()
+    redis_cache.health_check.return_value = True
+    main_module.app.dependency_overrides[main_module.get_redis_cache] = lambda: (
+        redis_cache
+    )
+
+    response = client.get("/health/chatwoot")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "degraded"
+    assert response.json()["chatwoot_api"] == "not_configured"
+    main_module.app.dependency_overrides.clear()

--- a/backend/tests/test_chatwoot_endpoints.py
+++ b/backend/tests/test_chatwoot_endpoints.py
@@ -267,3 +267,16 @@ def test_chatwoot_health_missing_chatwoot_config(
     assert response.json()["status"] == "degraded"
     assert response.json()["chatwoot_api"] == "not_configured"
     main_module.app.dependency_overrides.clear()
+
+
+def test_get_redis_cache_uses_unconfigured_namespace_when_account_missing(
+    main_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing Chatwoot account IDs must not share account 1 cache keys."""
+    monkeypatch.delenv("CHATWOOT_ACCOUNT_ID", raising=False)
+    settings.reset()
+
+    redis_cache = main_module.get_redis_cache()
+
+    assert redis_cache._build_key("scope", "id") == ("chatwoot:unconfigured:scope:id")

--- a/backend/tests/test_redis_cache.py
+++ b/backend/tests/test_redis_cache.py
@@ -20,9 +20,9 @@ def fake_redis() -> FakeAsyncRedis:
 
 @pytest.fixture
 def cache(fake_redis: FakeAsyncRedis) -> RedisCache:
-    with patch("backend.app.redis_cache.redis.asyncio.Redis") as MockRedis:
-        MockRedis.from_url.return_value = fake_redis
-        return RedisCache(redis_url="redis://localhost:6379/0")
+    with patch("backend.app.redis_cache.redis.asyncio.Redis.from_url") as from_url:
+        from_url.return_value = fake_redis
+        return RedisCache(redis_url="redis://localhost:6379/0", account_id=1)
 
 
 class TestKeyNaming:
@@ -38,10 +38,27 @@ class TestKeyNaming:
 
     def test_custom_prefix(self, fake_redis: FakeAsyncRedis) -> None:
         with patch(
-            "backend.app.redis_cache.redis.asyncio.Redis", return_value=fake_redis
+            "backend.app.redis_cache.redis.asyncio.Redis.from_url",
+            return_value=fake_redis,
         ):
-            custom = RedisCache(redis_url="redis://localhost", prefix="custom")
+            custom = RedisCache(
+                redis_url="redis://localhost", prefix="custom", account_id=1
+            )
         assert custom._build_key("scope", "id") == "custom:1:scope:id"
+
+    def test_default_account_namespace_is_unconfigured(
+        self, fake_redis: FakeAsyncRedis
+    ) -> None:
+        """Missing account IDs should not collide with real account 1 keys."""
+        with patch(
+            "backend.app.redis_cache.redis.asyncio.Redis.from_url",
+            return_value=fake_redis,
+        ):
+            default_cache = RedisCache(redis_url="redis://localhost")
+
+        assert default_cache._build_key("scope", "id") == (
+            "chatwoot:unconfigured:scope:id"
+        )
 
 
 class TestStringOperations:


### PR DESCRIPTION
## Summary
- Adds Chatwoot webhook HMAC verification and wires `POST /webhook/chatwoot` behind `CHATWOOT_ENABLED`.
- Adds lazy FastAPI factories for Chatwoot services and `GET /health/chatwoot` degraded/disabled reporting.
- Adds mocked endpoint/security tests using dummy secrets; no real Chatwoot or Redis service is required.

## Linked Issues
Refs #165
Refs #164

## Changes
| File | Change |
|------|--------|
| `backend/app/auth.py` | Added constant-time Chatwoot HMAC-SHA256 verification helper. |
| `backend/main.py` | Added Chatwoot DI factories, webhook endpoint, health endpoint, and removed duplicate buffer route/unreferenced local variables exposed by ruff. |
| `backend/tests/test_chatwoot_auth.py` | Added signature helper tests for valid, invalid, missing, and prefixed signatures. |
| `backend/tests/test_chatwoot_endpoints.py` | Added mocked webhook and health endpoint tests. |

## Test Plan
- [x] `uv run pytest backend/tests/test_chatwoot_auth.py backend/tests/test_chatwoot_endpoints.py`
- [x] `uv run pytest backend/tests/test_channel_profile.py backend/tests/test_config_provider.py backend/tests/test_redis_cache.py backend/tests/test_chatwoot_client.py backend/tests/test_message_buffer_redis.py backend/tests/test_session.py backend/tests/test_session_manager_hybrid.py backend/tests/test_escalation_handler.py backend/tests/test_chatwoot_handler.py backend/tests/test_user_profiler.py backend/tests/test_chatwoot_auth.py backend/tests/test_chatwoot_endpoints.py`
- [x] `uv run ruff check backend/app/auth.py backend/main.py backend/tests/test_chatwoot_auth.py backend/tests/test_chatwoot_endpoints.py`
- [x] `uv run ruff format --check backend/app/auth.py backend/main.py backend/tests/test_chatwoot_auth.py backend/tests/test_chatwoot_endpoints.py`

## Notes
- Health checks do not call the real Chatwoot API; they only report whether API configuration is present.
- Tests use dummy `test-secret`/`test-token` values and mocked dependencies.