### PR TITLE
test(#164,#165): add Chatwoot integration test sweep and CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,8 @@ DATASET_PATH=evaluation/harness/dataset.json
 OUTPUT_DIR=evaluation/harness/output
 
 # --- Chatwoot Integration ---
+# Mocked CI tests use dummy values and do not require real Chatwoot secrets.
+# Never commit actual Chatwoot tokens or webhook secrets to this file.
 # Feature flag. Default: false (existing /chat endpoint remains active)
 CHATWOOT_ENABLED=false
 # URL of your self-hosted Chatwoot instance (no trailing slash)
@@ -75,7 +77,7 @@ CHATWOOT_ACCOUNT_ID=
 CHATWOOT_INBOX_ID=
 # Webhook secret for HMAC signature verification
 CHATWOOT_WEBHOOK_SECRET=
-# Team ID for human escalation handoff
+# Optional team ID for human escalation handoff. Leave empty if assignment is disabled.
 CHATWOOT_HANDOFF_TEAM_ID=
 # Labels (comma-separated) assigned by the bot
 CHATWOOT_BOT_LABEL=bot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
   evaluation:
     name: Run Evaluation Harness
     runs-on: ubuntu-latest
-    needs: [test-health, test-chatwoot-integration]
+    needs: test-health
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,10 +152,43 @@ jobs:
         if: failure()
         run: docker logs arte-chatbot-backend
 
+  test-chatwoot-integration:
+    name: Test Chatwoot Mocked Integration
+    runs-on: ubuntu-latest
+    needs: lint
+    env:
+      CHAT_API_KEY: test-chat-api-key
+      OPENAI_API_KEY: test-openai-key
+      CHATWOOT_ENABLED: "true"
+      CHATWOOT_API_URL: https://chatwoot.test
+      CHATWOOT_AGENT_BOT_TOKEN: test-token
+      CHATWOOT_ACCOUNT_ID: "1"
+      CHATWOOT_INBOX_ID: "7"
+      CHATWOOT_WEBHOOK_SECRET: test-secret
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Run mocked Chatwoot integration suite
+        run: |
+          uv run pytest \
+            backend/tests/test_chatwoot_auth.py \
+            backend/tests/test_chatwoot_endpoints.py \
+            backend/tests/test_chatwoot_scenarios.py \
+            backend/tests/test_chatwoot_redis_integration.py
+
   evaluation:
     name: Run Evaluation Harness
     runs-on: ubuntu-latest
-    needs: test-health
+    needs: [test-health, test-chatwoot-integration]
     permissions:
       id-token: write
       contents: read

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -42,7 +42,7 @@ def verify_api_key(api_key: str = Security(API_KEY_HEADER)) -> str:
 
 
 def verify_chatwoot_signature(
-    payload: bytes,
+    payload: Optional[bytes],
     signature: Optional[str],
     secret: Optional[str],
 ) -> bool:
@@ -57,7 +57,7 @@ def verify_chatwoot_signature(
     Returns:
         ``True`` when the signature matches, otherwise ``False``.
     """
-    if signature is None or not secret:
+    if payload is None or signature is None or not secret:
         return False
 
     supplied_signature = signature.strip()

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -57,7 +57,7 @@ def verify_chatwoot_signature(
     Returns:
         ``True`` when the signature matches, otherwise ``False``.
     """
-    if not payload or not signature or not secret:
+    if signature is None or not secret:
         return False
 
     supplied_signature = signature.strip()

--- a/backend/tests/test_chatwoot_auth.py
+++ b/backend/tests/test_chatwoot_auth.py
@@ -55,6 +55,14 @@ def test_verify_chatwoot_signature_accepts_empty_body_valid_signature() -> None:
     assert verify_chatwoot_signature(payload, _signature(payload, secret), secret)
 
 
+def test_verify_chatwoot_signature_rejects_none_payload() -> None:
+    """None payloads must fail closed instead of being treated as empty bodies."""
+    secret = "test-secret"
+    empty_body_signature = _signature(b"", secret)
+
+    assert not verify_chatwoot_signature(None, empty_body_signature, secret)
+
+
 def test_verify_chatwoot_signature_rejects_empty_body_invalid_signature() -> None:
     """Empty bodies with invalid signatures should fail verification."""
     assert not verify_chatwoot_signature(b"", "invalid", "test-secret")

--- a/backend/tests/test_chatwoot_auth.py
+++ b/backend/tests/test_chatwoot_auth.py
@@ -38,3 +38,31 @@ def test_verify_chatwoot_signature_accepts_sha256_prefix() -> None:
     signature = f"sha256={_signature(payload, secret)}"
 
     assert verify_chatwoot_signature(payload, signature, secret)
+
+
+def test_verify_chatwoot_signature_rejects_garbage_signature() -> None:
+    """Unsupported signature formats should fail closed."""
+    payload = b'{"event":"message_created"}'
+
+    assert not verify_chatwoot_signature(payload, "sha1=abc", "test-secret")
+
+
+def test_verify_chatwoot_signature_accepts_empty_body_valid_signature() -> None:
+    """Valid HMACs for empty bodies should pass signature verification."""
+    payload = b""
+    secret = "test-secret"
+
+    assert verify_chatwoot_signature(payload, _signature(payload, secret), secret)
+
+
+def test_verify_chatwoot_signature_rejects_empty_body_invalid_signature() -> None:
+    """Empty bodies with invalid signatures should fail verification."""
+    assert not verify_chatwoot_signature(b"", "invalid", "test-secret")
+
+
+def test_verify_chatwoot_signature_rejects_missing_secret() -> None:
+    """Enabled webhooks without a configured secret must fail closed."""
+    payload = b'{"event":"message_created"}'
+    signature = _signature(payload, "test-secret")
+
+    assert not verify_chatwoot_signature(payload, signature, None)

--- a/backend/tests/test_chatwoot_endpoints.py
+++ b/backend/tests/test_chatwoot_endpoints.py
@@ -140,6 +140,68 @@ def test_chatwoot_webhook_invalid_signature_returns_401(
     main_module.app.dependency_overrides.clear()
 
 
+def test_chatwoot_webhook_missing_secret_returns_401(
+    client: TestClient,
+    main_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Enabled webhooks without a secret should fail closed."""
+    monkeypatch.setenv("CHATWOOT_ENABLED", "true")
+    monkeypatch.delenv("CHATWOOT_WEBHOOK_SECRET", raising=False)
+    settings.reset()
+    handler = AsyncMock()
+    main_module.app.dependency_overrides[main_module.get_chatwoot_handler] = lambda: (
+        handler
+    )
+    body = json.dumps(_valid_payload()).encode()
+
+    response = client.post(
+        "/webhook/chatwoot",
+        content=body,
+        headers=_signed_headers(body),
+    )
+
+    assert response.status_code == 401
+    handler.handle_event.assert_not_awaited()
+    main_module.app.dependency_overrides.clear()
+
+
+def test_chatwoot_webhook_empty_body_valid_signature_returns_422(
+    client: TestClient,
+    main_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty signed bodies should pass auth and fail payload validation."""
+    monkeypatch.setenv("CHATWOOT_ENABLED", "true")
+    settings.reset()
+    body = b""
+
+    response = client.post(
+        "/webhook/chatwoot",
+        content=body,
+        headers=_signed_headers(body),
+    )
+
+    assert response.status_code == 422
+
+
+def test_chatwoot_webhook_empty_body_invalid_signature_returns_401(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty bodies with invalid signatures should fail auth."""
+    monkeypatch.setenv("CHATWOOT_ENABLED", "true")
+    settings.reset()
+
+    response = client.post(
+        "/webhook/chatwoot",
+        content=b"",
+        headers={"X-Chatwoot-Signature": "invalid"},
+    )
+
+    assert response.status_code == 401
+
+
 def test_chatwoot_webhook_invalid_payload_returns_422(
     client: TestClient,
     main_module: Any,

--- a/backend/tests/test_chatwoot_redis_integration.py
+++ b/backend/tests/test_chatwoot_redis_integration.py
@@ -1,0 +1,124 @@
+"""fakeredis integration tests for Chatwoot Redis-backed state."""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fakeredis import FakeAsyncRedis
+
+from backend.app.message_buffer import MessageBuffer
+from backend.app.redis_cache import RedisCache
+from backend.app.session import SessionManager
+
+
+class DummyConfigProvider:
+    """Minimal buffer config provider for Redis integration tests."""
+
+    def get(self, key: str) -> int | None:
+        """Return deterministic buffer settings."""
+        if key == "buffer_window_seconds":
+            return 5
+        if key == "buffer_max_messages":
+            return 5
+        return None
+
+
+@pytest.fixture
+def fake_redis() -> FakeAsyncRedis:
+    """Return a shared fake Redis instance."""
+    return FakeAsyncRedis(decode_responses=True)
+
+
+def _cache(fake_redis: FakeAsyncRedis, account_id: int | str) -> RedisCache:
+    """Build a RedisCache sharing the given fakeredis instance."""
+    with patch("backend.app.redis_cache.redis.asyncio.Redis") as mock_redis:
+        mock_redis.from_url.return_value = fake_redis
+        return RedisCache(
+            redis_url="redis://localhost:6379/0",
+            account_id=account_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_session_mapping_and_buffer_share_namespace_without_collisions(
+    fake_redis: FakeAsyncRedis,
+) -> None:
+    """Session metadata and buffers should coexist in one account namespace."""
+    redis_cache = _cache(fake_redis, account_id=1)
+    session_manager = SessionManager(redis_cache=redis_cache)
+    message_buffer = MessageBuffer(redis_cache, DummyConfigProvider())
+
+    session_id = await session_manager.get_or_create_session_for_conversation(
+        "42", account_id=1
+    )
+    await message_buffer.add_message("42", "Hola", window_seconds=5)
+
+    assert await session_manager.get_session_id("42") == session_id
+    assert await message_buffer.get_count("42") == 1
+    assert await fake_redis.exists("chatwoot:1:conversation:42:metadata") == 1
+    assert await fake_redis.exists("chatwoot:1:buffer:42") == 1
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_namespace_does_not_collide_with_account_one(
+    fake_redis: FakeAsyncRedis,
+) -> None:
+    """Disabled/unconfigured Chatwoot state must not share account 1 keys."""
+    account_cache = _cache(fake_redis, account_id=1)
+    unconfigured_cache = _cache(fake_redis, account_id="unconfigured")
+    account_buffer = MessageBuffer(account_cache, DummyConfigProvider())
+    unconfigured_buffer = MessageBuffer(unconfigured_cache, DummyConfigProvider())
+
+    await account_buffer.add_message("42", "Cuenta 1", window_seconds=5)
+    await unconfigured_buffer.add_message("42", "Sin configurar", window_seconds=5)
+
+    assert await account_buffer.flush("42") == "Cuenta 1"
+    assert await unconfigured_buffer.flush("42") == "Sin configurar"
+
+
+@pytest.mark.asyncio
+async def test_cache_miss_hydrates_history_from_chatwoot_source_of_truth(
+    fake_redis: FakeAsyncRedis,
+) -> None:
+    """History cache misses should fetch Chatwoot once and then use Redis."""
+    redis_cache = _cache(fake_redis, account_id=1)
+    chatwoot_client = AsyncMock()
+    chatwoot_client.fetch_messages.return_value = {
+        "payload": [
+            {"content": "Necesito paneles", "message_type": "incoming"},
+            {"content": "Te ayudo con paneles", "message_type": "outgoing"},
+        ]
+    }
+    session_manager = SessionManager(
+        redis_cache=redis_cache,
+        chatwoot_client=chatwoot_client,
+    )
+    await session_manager.map_conversation("session-1", "42")
+
+    first_history = await session_manager.get_history_async("session-1")
+    second_history = await session_manager.get_history_async("session-1")
+
+    assert first_history[0].question == "Necesito paneles"
+    assert second_history[0].answer == "Te ayudo con paneles"
+    chatwoot_client.fetch_messages.assert_awaited_once_with(42, limit=20)
+
+
+@pytest.mark.asyncio
+async def test_distributed_lock_prevents_double_flush(
+    fake_redis: FakeAsyncRedis,
+) -> None:
+    """Concurrent flush attempts should produce a single joined message."""
+    redis_cache = _cache(fake_redis, account_id=1)
+    message_buffer = MessageBuffer(redis_cache, DummyConfigProvider())
+    await message_buffer.add_message("42", "Uno", window_seconds=5)
+    await message_buffer.add_message("42", "Dos", window_seconds=5)
+
+    first, second = await asyncio.gather(
+        message_buffer.flush("42"),
+        message_buffer.flush("42"),
+    )
+
+    assert sorted([first, second], key=lambda value: value is not None) == [
+        None,
+        "Uno\nDos",
+    ]

--- a/backend/tests/test_chatwoot_scenarios.py
+++ b/backend/tests/test_chatwoot_scenarios.py
@@ -1,0 +1,363 @@
+"""Mocked scenario tests for Chatwoot webhook flows.
+
+These tests exercise the FastAPI endpoint plus real ``ChatwootHandler``
+dispatching with mocked collaborators. They intentionally avoid real Redis and
+Chatwoot network calls.
+"""
+
+import hashlib
+import hmac
+import json
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.app.chatwoot_handler import ChatwootHandler
+from backend.app.config import settings
+from backend.app.escalation_handler import EscalationHandler
+
+
+class InMemoryRedisCache:
+    """Small async RedisCache test double safe across TestClient event loops."""
+
+    def __init__(self) -> None:
+        self._sets: dict[str, set[str]] = {}
+        self._values: dict[str, str] = {}
+
+    def _build_key(self, scope: str, entity_id: str, field: str | None = None) -> str:
+        """Build keys using the production Chatwoot namespace shape."""
+        key = f"chatwoot:1:{scope}:{entity_id}"
+        if field is not None:
+            key = f"{key}:{field}"
+        return key
+
+    async def sismember(self, key: str, member: str) -> bool:
+        """Return whether a set member exists."""
+        return member in self._sets.get(key, set())
+
+    async def sadd(self, key: str, member: str) -> bool:
+        """Add a set member."""
+        self._sets.setdefault(key, set()).add(member)
+        return True
+
+    async def set(self, key: str, value: str, ttl: int | None = None) -> bool:
+        """Store a string value."""
+        del ttl
+        self._values[key] = value
+        return True
+
+
+class DummyProfile:
+    """Minimal channel profile used by handler scenario tests."""
+
+    buffer_window_seconds = 5
+
+
+class DummyConfigProvider:
+    """Config provider stub for scenario tests."""
+
+    def get(self, key: str) -> Any:
+        """Return unset config values."""
+        return None
+
+    def get_channel_profile(self, inbox_id: str) -> DummyProfile:
+        """Return the same deterministic profile for every inbox."""
+        del inbox_id
+        return DummyProfile()
+
+    def get_label(self, name: str) -> str:
+        """Resolve escalation labels deterministically."""
+        labels = {
+            "escalated": "escalated",
+            "quote": "quote",
+            "technical": "technical",
+            "order": "order",
+        }
+        return labels.get(name, name)
+
+    def get_handoff_target(self) -> int:
+        """Return a configured handoff team for scenario coverage."""
+        return 55
+
+    def is_chatwoot_enabled(self) -> bool:
+        """Return enabled for tests that construct this provider."""
+        return True
+
+
+def _signed_headers(payload: bytes, secret: str = "test-secret") -> dict[str, str]:
+    """Build Chatwoot signature headers for *payload*."""
+    digest = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+    return {"X-Chatwoot-Signature": digest}
+
+
+def _message_payload(
+    *, message_id: int = 101, sender_type: str = "contact"
+) -> dict[str, Any]:
+    """Return a valid Chatwoot ``message_created`` webhook payload."""
+    return {
+        "event": "message_created",
+        "account": {"id": 1},
+        "conversation": {
+            "id": 42,
+            "status": "open",
+            "inbox_id": 7,
+            "contact_id": 9,
+        },
+        "sender": {"id": 11, "type": sender_type, "name": "Cliente"},
+        "message": {
+            "id": message_id,
+            "content": "Hola",
+            "content_type": "text",
+            "private": False,
+        },
+    }
+
+
+@pytest.fixture(autouse=True)
+def reset_settings() -> None:
+    """Reset lazy settings around scenario tests."""
+    settings.reset()
+
+
+@pytest.fixture
+def main_module(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Import ``backend.main`` with deterministic test env vars."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai")
+    monkeypatch.setenv("CHAT_API_KEY", "test-chat")
+    monkeypatch.setenv("CHATWOOT_ENABLED", "true")
+    monkeypatch.setenv("CHATWOOT_WEBHOOK_SECRET", "test-secret")
+    monkeypatch.setenv("CHATWOOT_API_URL", "https://chatwoot.test")
+    monkeypatch.setenv("CHATWOOT_AGENT_BOT_TOKEN", "test-token")
+    monkeypatch.setenv("CHATWOOT_ACCOUNT_ID", "1")
+    monkeypatch.setenv("CHATWOOT_INBOX_ID", "7")
+    settings.reset()
+
+    import backend.main as main
+
+    return main
+
+
+@pytest.fixture
+def client(main_module: Any) -> TestClient:
+    """Return a TestClient for the FastAPI app."""
+    return TestClient(main_module.app)
+
+
+@pytest.fixture
+def redis_cache() -> InMemoryRedisCache:
+    """Return an in-memory RedisCache-compatible test double."""
+    return InMemoryRedisCache()
+
+
+@pytest.fixture
+def handler_dependencies() -> dict[str, Any]:
+    """Return mocked dependencies used to build a real handler."""
+    return {
+        "client": AsyncMock(),
+        "buffer": AsyncMock(),
+        "sessions": AsyncMock(),
+        "config": DummyConfigProvider(),
+    }
+
+
+def _override_handler(
+    main_module: Any,
+    redis_cache: InMemoryRedisCache,
+    dependencies: dict[str, Any],
+) -> ChatwootHandler:
+    """Install a FastAPI override returning a real ChatwootHandler."""
+    handler = ChatwootHandler(
+        chatwoot_client=dependencies["client"],
+        redis_cache=redis_cache,
+        config_provider=dependencies["config"],
+        message_buffer=dependencies["buffer"],
+        session_manager=dependencies["sessions"],
+    )
+    main_module.app.dependency_overrides[main_module.get_chatwoot_handler] = lambda: (
+        handler
+    )
+    return handler
+
+
+def test_valid_contact_message_dispatches_through_handler(
+    client: TestClient,
+    main_module: Any,
+    redis_cache: InMemoryRedisCache,
+    handler_dependencies: dict[str, Any],
+) -> None:
+    """Contact messages should traverse endpoint, handler, and dependencies."""
+    _override_handler(main_module, redis_cache, handler_dependencies)
+    body = json.dumps(_message_payload()).encode()
+
+    response = client.post(
+        "/webhook/chatwoot",
+        content=body,
+        headers=_signed_headers(body),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "accepted"}
+    handler_dependencies[
+        "sessions"
+    ].get_or_create_session_for_conversation.assert_awaited_once_with(
+        "42", account_id=1
+    )
+    handler_dependencies["buffer"].add_message.assert_awaited_once_with("42", "Hola", 5)
+    handler_dependencies["client"].send_typing_indicator.assert_awaited_once_with(42)
+    main_module.app.dependency_overrides.clear()
+
+
+def test_human_agent_message_cancels_buffer_without_bot_reply(
+    client: TestClient,
+    main_module: Any,
+    redis_cache: InMemoryRedisCache,
+    handler_dependencies: dict[str, Any],
+) -> None:
+    """Human-agent messages should cancel pending bot work and not reply."""
+    _override_handler(main_module, redis_cache, handler_dependencies)
+    body = json.dumps(_message_payload(message_id=102, sender_type="user")).encode()
+
+    response = client.post(
+        "/webhook/chatwoot",
+        content=body,
+        headers=_signed_headers(body),
+    )
+
+    assert response.status_code == 200
+    handler_dependencies["buffer"].flush_and_cancel.assert_awaited_once_with("42")
+    handler_dependencies["buffer"].add_message.assert_not_awaited()
+    handler_dependencies["client"].send_typing_indicator.assert_not_awaited()
+    main_module.app.dependency_overrides.clear()
+
+
+def test_duplicate_webhook_is_accepted_without_second_processing(
+    client: TestClient,
+    main_module: Any,
+    redis_cache: InMemoryRedisCache,
+    handler_dependencies: dict[str, Any],
+) -> None:
+    """Duplicate messages should return accepted and skip handler side effects."""
+    _override_handler(main_module, redis_cache, handler_dependencies)
+    body = json.dumps(_message_payload(message_id=103)).encode()
+    headers = _signed_headers(body)
+
+    first = client.post("/webhook/chatwoot", content=body, headers=headers)
+    second = client.post("/webhook/chatwoot", content=body, headers=headers)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    handler_dependencies["buffer"].add_message.assert_awaited_once()
+    handler_dependencies[
+        "sessions"
+    ].get_or_create_session_for_conversation.assert_awaited_once()
+    main_module.app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_escalation_calls_chatwoot_actions_in_expected_order() -> None:
+    """Escalation should label, open, assign, then notify the user."""
+    calls: list[str] = []
+
+    async def add_label(conversation_id: int, label: str) -> None:
+        calls.append(f"label:{conversation_id}:{label}")
+
+    async def toggle_status(conversation_id: int, status: str) -> None:
+        calls.append(f"status:{conversation_id}:{status}")
+
+    async def assign_conversation(conversation_id: int, team_id: int) -> None:
+        calls.append(f"assign:{conversation_id}:{team_id}")
+
+    async def send_message(conversation_id: int, message: str) -> None:
+        del message
+        calls.append(f"message:{conversation_id}")
+
+    chatwoot_client = AsyncMock()
+    chatwoot_client.add_label.side_effect = add_label
+    chatwoot_client.toggle_status.side_effect = toggle_status
+    chatwoot_client.assign_conversation.side_effect = assign_conversation
+    chatwoot_client.send_message.side_effect = send_message
+    handler = EscalationHandler(
+        chatwoot_client=chatwoot_client,
+        config_provider=DummyConfigProvider(),
+    )
+
+    result = await handler.escalate_to_human(
+        42,
+        reason="quote requested",
+        intent_type="escalate_quote",
+    )
+
+    assert result is True
+    assert calls == [
+        "label:42:escalated",
+        "label:42:quote",
+        "status:42:open",
+        "assign:42:55",
+        "message:42",
+    ]
+
+
+def test_invalid_signature_returns_401(
+    client: TestClient,
+    main_module: Any,
+) -> None:
+    """Invalid signatures should reject requests before dispatch."""
+    handler = AsyncMock()
+    main_module.app.dependency_overrides[main_module.get_chatwoot_handler] = lambda: (
+        handler
+    )
+
+    response = client.post(
+        "/webhook/chatwoot",
+        json=_message_payload(message_id=104),
+        headers={"X-Chatwoot-Signature": "garbage"},
+    )
+
+    assert response.status_code == 401
+    handler.handle_event.assert_not_awaited()
+    main_module.app.dependency_overrides.clear()
+
+
+def test_invalid_payload_returns_422_before_dispatch(
+    client: TestClient,
+    main_module: Any,
+) -> None:
+    """Schema-invalid signed payloads should return 422."""
+    handler = AsyncMock()
+    main_module.app.dependency_overrides[main_module.get_chatwoot_handler] = lambda: (
+        handler
+    )
+    body = b'{"event":"message_created"}'
+
+    response = client.post(
+        "/webhook/chatwoot",
+        content=body,
+        headers=_signed_headers(body),
+    )
+
+    assert response.status_code == 422
+    handler.handle_event.assert_not_awaited()
+    main_module.app.dependency_overrides.clear()
+
+
+def test_disabled_chatwoot_returns_503_before_parsing_or_dispatch(
+    client: TestClient,
+    main_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Disabled integration should reject even malformed bodies early."""
+    monkeypatch.setenv("CHATWOOT_ENABLED", "false")
+    settings.reset()
+    handler = AsyncMock()
+    main_module.app.dependency_overrides[main_module.get_chatwoot_handler] = lambda: (
+        handler
+    )
+
+    response = client.post("/webhook/chatwoot", content=b"not-json")
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Chatwoot integration disabled"}
+    handler.handle_event.assert_not_awaited()
+    main_module.app.dependency_overrides.clear()

--- a/docs/guides/chatwoot_testing_ci.md
+++ b/docs/guides/chatwoot_testing_ci.md
@@ -1,0 +1,77 @@
+# Chatwoot mocked testing and CI
+
+This project runs Chatwoot coverage with mocked dependencies by default. The
+mocked suite validates webhook security, endpoint dispatch, Redis-backed state,
+and escalation orchestration without connecting to a real Chatwoot instance.
+
+## Quick path
+
+```bash
+# Mocked Chatwoot endpoint, scenario, security, and Redis integration suite
+uv run pytest \
+  backend/tests/test_chatwoot_auth.py \
+  backend/tests/test_chatwoot_endpoints.py \
+  backend/tests/test_chatwoot_scenarios.py \
+  backend/tests/test_chatwoot_redis_integration.py
+
+# Affected component suite around the Chatwoot integration
+uv run pytest \
+  backend/tests/test_channel_profile.py \
+  backend/tests/test_config_provider.py \
+  backend/tests/test_redis_cache.py \
+  backend/tests/test_chatwoot_client.py \
+  backend/tests/test_message_buffer_redis.py \
+  backend/tests/test_session_manager_hybrid.py \
+  backend/tests/test_escalation_handler.py \
+  backend/tests/test_chatwoot_handler.py \
+  backend/tests/test_chatwoot_auth.py \
+  backend/tests/test_chatwoot_endpoints.py \
+  backend/tests/test_chatwoot_scenarios.py \
+  backend/tests/test_chatwoot_redis_integration.py
+```
+
+## CI-equivalent mocked command
+
+The `test-chatwoot-integration` job in `.github/workflows/ci.yml` uses dummy
+values only:
+
+```bash
+CHAT_API_KEY=test-chat-api-key \
+OPENAI_API_KEY=test-openai-key \
+CHATWOOT_ENABLED=true \
+CHATWOOT_API_URL=https://chatwoot.test \
+CHATWOOT_AGENT_BOT_TOKEN=test-token \
+CHATWOOT_ACCOUNT_ID=1 \
+CHATWOOT_INBOX_ID=7 \
+CHATWOOT_WEBHOOK_SECRET=test-secret \
+uv run pytest \
+  backend/tests/test_chatwoot_auth.py \
+  backend/tests/test_chatwoot_endpoints.py \
+  backend/tests/test_chatwoot_scenarios.py \
+  backend/tests/test_chatwoot_redis_integration.py
+```
+
+Mocked CI tests MUST NOT use real Chatwoot tokens, webhook secrets, or a real
+Chatwoot API URL.
+
+## GitHub secrets and variables
+
+| Name | Required for mocked CI? | Required for real staging/e2e? | Notes |
+|------|--------------------------|--------------------------------|-------|
+| `CHAT_API_KEY` | No, dummy value is set by CI | Yes | Existing API auth secret. |
+| `OPENAI_API_KEY` | No, dummy value is set by CI | Yes | Existing LLM secret. |
+| `AWS_ROLE_ARN` | No | Yes | Existing GitHub OIDC role for evaluation/S3 workflows. |
+| `AWS_BUCKET_NAME` | No | Yes | Existing S3 bucket name for evaluation/data workflows. |
+| `CHATWOOT_API_URL` | No, dummy value is set by CI | Yes | Base URL for the real Chatwoot instance. |
+| `CHATWOOT_AGENT_BOT_TOKEN` | No, dummy value is set by CI | Yes | AgentBot token. Never commit it. |
+| `CHATWOOT_ACCOUNT_ID` | No, dummy value is set by CI | Yes | Numeric Chatwoot account ID. |
+| `CHATWOOT_INBOX_ID` | No, dummy value is set by CI | Yes | Numeric inbox ID for the WhatsApp channel. |
+| `CHATWOOT_WEBHOOK_SECRET` | No, dummy value is set by CI | Yes | HMAC shared secret. Never commit it. |
+| `CHATWOOT_HANDOFF_TEAM_ID` | No | Optional | Required only when escalation assignment is enabled. |
+
+## Real Chatwoot staging/e2e guardrail
+
+Before enabling any workflow that calls a real Chatwoot API, configure a
+protected GitHub Environment such as `staging`. Store the real Chatwoot secrets
+there, require approval, and keep the mocked deterministic suite as the default
+PR gate.


### PR DESCRIPTION
Closes #164
Refs #165, #166, #167, #168, #169, #170

## PR Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [x] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds mocked end-to-end Chatwoot webhook scenario tests through FastAPI and `ChatwootHandler` with deterministic mocks.
- Adds fakeredis integration coverage for session mapping, buffer namespace isolation, cache hydration, and distributed flush locking.
- Adds a dedicated CI job for the mocked Chatwoot suite and documents real staging secrets separately from dummy CI values.

## Changes
| File | Change |
|------|--------|
| `backend/tests/test_chatwoot_scenarios.py` | Added endpoint + handler scenario tests for contact messages, human-agent cancellation, duplicates, escalation order, invalid signatures/payloads, and disabled mode. |
| `backend/tests/test_chatwoot_redis_integration.py` | Added fakeredis integration tests for Redis-backed session/buffer state interactions. |
| `backend/tests/test_chatwoot_auth.py` | Expanded signature coverage for raw hex, `sha256=`, garbage input, empty bodies, and missing secrets. |
| `backend/tests/test_chatwoot_endpoints.py` | Added endpoint security cases for missing webhook secret and empty-body signature handling. |
| `backend/app/auth.py` | Allows valid HMAC verification for empty request bodies so endpoint validation can return 422 after auth. |
| `.github/workflows/ci.yml` | Adds `test-chatwoot-integration` with dummy env vars and no real Chatwoot API calls. |
| `.env.example` | Clarifies dummy CI values and never-commit guidance for Chatwoot secrets. |
| `docs/guides/chatwoot_testing_ci.md` | Documents local commands, CI-equivalent command, GitHub secrets/variables, and staging guardrails. |

## Test Plan
- [x] RED: `uv run pytest backend/tests/test_chatwoot_auth.py backend/tests/test_chatwoot_endpoints.py backend/tests/test_chatwoot_scenarios.py backend/tests/test_chatwoot_redis_integration.py` initially failed on empty-body HMAC handling and duplicate test loop-safety.
- [x] GREEN: `uv run pytest backend/tests/test_chatwoot_auth.py backend/tests/test_chatwoot_endpoints.py backend/tests/test_chatwoot_scenarios.py backend/tests/test_chatwoot_redis_integration.py` → 32 passed, 2 warnings.
- [x] Affected component suite: `uv run pytest backend/tests/test_channel_profile.py backend/tests/test_config_provider.py backend/tests/test_redis_cache.py backend/tests/test_chatwoot_client.py backend/tests/test_message_buffer_redis.py backend/tests/test_session_manager_hybrid.py backend/tests/test_escalation_handler.py backend/tests/test_chatwoot_handler.py backend/tests/test_chatwoot_auth.py backend/tests/test_chatwoot_endpoints.py backend/tests/test_chatwoot_scenarios.py backend/tests/test_chatwoot_redis_integration.py` → 176 passed, 5 warnings.
- [x] CI-equivalent mocked command with dummy Chatwoot env vars → 32 passed, 3 warnings.
- [x] `uv run ruff check backend/app/auth.py backend/tests/test_chatwoot_auth.py backend/tests/test_chatwoot_endpoints.py backend/tests/test_chatwoot_scenarios.py backend/tests/test_chatwoot_redis_integration.py` → passed.
- [x] `uv run ruff format --check backend/app/auth.py backend/tests/test_chatwoot_auth.py backend/tests/test_chatwoot_endpoints.py backend/tests/test_chatwoot_scenarios.py backend/tests/test_chatwoot_redis_integration.py` → passed.
- [x] CI workflow YAML parsed with Python `yaml.safe_load`.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts (no shell scripts modified)
- [x] Skills tested in at least one agent
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Notes
- Mocked CI tests do not require real Chatwoot secrets and do not call a real Chatwoot API.
- Real Chatwoot staging/e2e tests should be added later behind a protected GitHub Environment.
- Branch name follows the SDD user-provided chained PR name, not the generic Agent Teams branch regex.