### PR TITLE
fix(#165,#166): close Chatwoot verification gaps and add runbook

### DIFF
--- a/backend/app/chatwoot_handler.py
+++ b/backend/app/chatwoot_handler.py
@@ -5,7 +5,7 @@ idempotency via Redis, and logs all events with structured context.
 """
 
 import logging
-from typing import Any, Optional
+from typing import Any, Awaitable, Callable, Optional
 
 from backend.app.chatwoot_client import ChatwootClient
 from backend.app.config_provider import ConfigProvider
@@ -22,6 +22,9 @@ from backend.app.schemas import (
 logger = logging.getLogger(__name__)
 
 _PROCESSED_SET_TTL_SECONDS = 3600
+_MAX_BUFFER_MESSAGES = 5
+
+ProcessMessageCallback = Callable[[str, str, list[Any]], Awaitable[str]]
 
 
 class ChatwootHandler:
@@ -41,6 +44,7 @@ class ChatwootHandler:
         message_buffer: Optional[RedisMessageBuffer] = None,
         session_manager: Optional[Any] = None,
         escalation_handler: Optional[EscalationHandler] = None,
+        process_message: Optional[ProcessMessageCallback] = None,
     ) -> None:
         self._client = chatwoot_client
         self._redis = redis_cache
@@ -48,6 +52,7 @@ class ChatwootHandler:
         self._buffer = message_buffer
         self._sessions = session_manager
         self._escalation = escalation_handler
+        self._process_message = process_message
 
     async def handle_event(self, payload: ChatwootWebhookPayload) -> None:
         """Route a webhook payload to the correct handler.
@@ -106,6 +111,34 @@ class ChatwootHandler:
         conversation_key = str(conversation_id)
         sender_type = payload.sender.type
         content = payload.message.content or ""
+        message_type = payload.message.message_type
+
+        if payload.message.private or message_type == "outgoing":
+            logger.info(
+                "chatwoot_message_ignored conversation_id=%s message_id=%s",
+                conversation_id,
+                payload.message.id,
+                extra={
+                    "conversation_id": conversation_id,
+                    "message_id": payload.message.id,
+                    "message_type": message_type,
+                    "private": payload.message.private,
+                },
+            )
+            return
+
+        if sender_type == "agent_bot":
+            logger.info(
+                "chatwoot_agent_bot_self_message_ignored conversation_id=%s message_id=%s",
+                conversation_id,
+                payload.message.id,
+                extra={
+                    "conversation_id": conversation_id,
+                    "message_id": payload.message.id,
+                    "sender_type": sender_type,
+                },
+            )
+            return
 
         if sender_type == "user":
             if self._buffer is not None:
@@ -122,20 +155,30 @@ class ChatwootHandler:
             )
         elif sender_type == "contact":
             account_id = int(payload.account.get("id", 1))
+            session_id: Optional[str] = None
             if self._sessions is not None:
-                await self._sessions.get_or_create_session_for_conversation(
-                    conversation_key, account_id=account_id
+                session_id = (
+                    await self._sessions.get_or_create_session_for_conversation(
+                        conversation_key, account_id=account_id
+                    )
                 )
 
             profile = self._config.get_channel_profile(
                 str(payload.conversation.inbox_id)
             )
             window_seconds = int(getattr(profile, "buffer_window_seconds", 5))
+            buffer_state: Any = None
             if self._buffer is not None:
-                await self._buffer.add_message(
+                buffer_state = await self._buffer.add_message(
                     conversation_key, content, window_seconds
                 )
             await self._client.send_typing_indicator(conversation_id)
+            if self._should_process_full_buffer(buffer_state):
+                await self._process_full_buffer(
+                    conversation_id=conversation_id,
+                    conversation_key=conversation_key,
+                    session_id=session_id,
+                )
             logger.info(
                 "user message received conversation_id=%s message_id=%s",
                 conversation_id,
@@ -164,8 +207,15 @@ class ChatwootHandler:
     ) -> None:
         """Handle a ``conversation_created`` webhook.
 
-        Currently a stub that logs the event.
+        Creates the conversation-to-session mapping through SessionManager.
+        ``SessionManager`` owns idempotency, so repeated webhooks reuse the
+        existing mapping rather than generating a new session ID.
         """
+        account_id = int(payload.account.get("id", 1))
+        if self._sessions is not None:
+            await self._sessions.get_or_create_session_for_conversation(
+                str(payload.conversation.id), account_id=account_id
+            )
         logger.info(
             "conversation_created conversation_id=%s inbox_id=%s",
             payload.conversation.id,
@@ -175,6 +225,40 @@ class ChatwootHandler:
                 "inbox_id": payload.conversation.inbox_id,
                 "contact_id": payload.conversation.contact_id,
             },
+        )
+
+    def _should_process_full_buffer(self, buffer_state: Any) -> bool:
+        """Return true when a buffer state has reached the processing limit."""
+        messages = getattr(buffer_state, "messages", None)
+        return isinstance(messages, list) and len(messages) >= _MAX_BUFFER_MESSAGES
+
+    async def _process_full_buffer(
+        self,
+        conversation_id: int,
+        conversation_key: str,
+        session_id: Optional[str],
+    ) -> None:
+        """Flush a full buffer, call the injected processor, and persist history."""
+        if (
+            self._buffer is None
+            or self._process_message is None
+            or self._sessions is None
+            or session_id is None
+        ):
+            return
+
+        joined_message = await self._buffer.flush(conversation_key)
+        if not joined_message:
+            return
+
+        history = await self._sessions.get_history_async(session_id)
+        response_text = await self._process_message(session_id, joined_message, history)
+        await self._client.send_message(conversation_id, response_text)
+        await self._sessions.add_turn_async(
+            session_id,
+            joined_message,
+            response_text,
+            [],
         )
 
     async def _handle_conversation_status_changed(

--- a/backend/app/chatwoot_handler.py
+++ b/backend/app/chatwoot_handler.py
@@ -229,6 +229,9 @@ class ChatwootHandler:
 
     def _should_process_full_buffer(self, buffer_state: Any) -> bool:
         """Return true when a buffer state has reached the processing limit."""
+        if buffer_state is None:
+            return False
+
         messages = getattr(buffer_state, "messages", None)
         return isinstance(messages, list) and len(messages) >= _MAX_BUFFER_MESSAGES
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -32,6 +32,7 @@ class ChatwootMessage(BaseModel):
     id: int
     content: Optional[str] = None
     content_type: str = "text"
+    message_type: Literal["incoming", "outgoing", "activity"] = "incoming"
     private: bool = False
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -441,7 +441,12 @@ async def chatwoot_webhook(
     x_chatwoot_signature: Annotated[Optional[str], Header()] = None,
     x_hub_signature_256: Annotated[Optional[str], Header()] = None,
 ) -> JSONResponse:
-    """Receive, verify, validate, and dispatch Chatwoot webhooks."""
+    """Receive, verify, validate, and dispatch Chatwoot webhooks.
+
+    The handler is intentionally awaited instead of scheduled with
+    ``BackgroundTasks`` so processing failures return HTTP 500. Chatwoot can
+    then retry the webhook instead of receiving a false-positive 200 ack.
+    """
     if not settings.chatwoot_enabled:
         return JSONResponse(
             status_code=503,

--- a/backend/tests/test_chatwoot_handler.py
+++ b/backend/tests/test_chatwoot_handler.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from backend.app.chatwoot_handler import ChatwootHandler
+from backend.app.message_buffer import BufferState
 from backend.app.schemas import (
     ChatwootConversation,
     ChatwootMessage,
@@ -89,6 +90,8 @@ def _message_payload(
     sender_type: str = "contact",
     message_id: int = 101,
     content: str = "hello",
+    message_type: str = "incoming",
+    private: bool = False,
 ) -> MessageCreatedPayload:
     return MessageCreatedPayload(
         event="message_created",
@@ -97,7 +100,12 @@ def _message_payload(
             id=42, status="open", inbox_id=1, contact_id=5
         ),
         sender=ChatwootSender(id=7, type=sender_type, name="Test"),
-        message=ChatwootMessage(id=message_id, content=content),
+        message=ChatwootMessage(
+            id=message_id,
+            content=content,
+            message_type=message_type,
+            private=private,
+        ),
     )
 
 
@@ -168,6 +176,91 @@ class TestHandleMessageCreated:
         message_buffer.flush_and_cancel.assert_awaited_once_with("42")
 
     @pytest.mark.asyncio
+    async def test_private_message_is_ignored_without_side_effects(
+        self,
+        handler: ChatwootHandler,
+        session_manager: Any,
+        message_buffer: Any,
+        chatwoot_client: Any,
+    ) -> None:
+        payload = _message_payload(sender_type="contact", private=True)
+
+        await handler._handle_message_created(payload)
+
+        session_manager.get_or_create_session_for_conversation.assert_not_awaited()
+        message_buffer.add_message.assert_not_awaited()
+        chatwoot_client.send_typing_indicator.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_outgoing_message_is_ignored_without_side_effects(
+        self,
+        handler: ChatwootHandler,
+        session_manager: Any,
+        message_buffer: Any,
+        chatwoot_client: Any,
+    ) -> None:
+        payload = _message_payload(sender_type="contact", message_type="outgoing")
+
+        await handler._handle_message_created(payload)
+
+        session_manager.get_or_create_session_for_conversation.assert_not_awaited()
+        message_buffer.add_message.assert_not_awaited()
+        chatwoot_client.send_typing_indicator.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_agent_bot_self_message_is_ignored_without_side_effects(
+        self,
+        handler: ChatwootHandler,
+        message_buffer: Any,
+        chatwoot_client: Any,
+    ) -> None:
+        payload = _message_payload(sender_type="agent_bot", message_type="outgoing")
+
+        await handler._handle_message_created(payload)
+
+        message_buffer.flush_and_cancel.assert_not_awaited()
+        message_buffer.add_message.assert_not_awaited()
+        chatwoot_client.send_typing_indicator.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_full_buffer_processes_callback_and_appends_history(
+        self,
+        chatwoot_client: Any,
+        redis_cache: Any,
+        config_provider: Any,
+        message_buffer: Any,
+        session_manager: Any,
+        escalation_handler: Any,
+    ) -> None:
+        process_message = AsyncMock(return_value="Respuesta técnica")
+        handler = ChatwootHandler(
+            chatwoot_client=chatwoot_client,
+            redis_cache=redis_cache,
+            config_provider=config_provider,
+            message_buffer=message_buffer,
+            session_manager=session_manager,
+            escalation_handler=escalation_handler,
+            process_message=process_message,
+        )
+        payload = _message_payload(sender_type="contact", content="Mensaje 5")
+        session_manager.get_history_async.return_value = []
+        message_buffer.add_message.return_value = BufferState(
+            conversation_id="42",
+            messages=["Uno", "Dos", "Tres", "Cuatro", "Mensaje 5"],
+        )
+        message_buffer.flush.return_value = "Uno\nDos\nTres\nCuatro\nMensaje 5"
+
+        await handler._handle_message_created(payload)
+
+        process_message.assert_awaited_once_with(
+            "session-42", "Uno\nDos\nTres\nCuatro\nMensaje 5", []
+        )
+        chatwoot_client.send_message.assert_awaited_once_with(42, "Respuesta técnica")
+        session_manager.add_turn_async.assert_awaited_once_with(
+            "session-42", "Uno\nDos\nTres\nCuatro\nMensaje 5", "Respuesta técnica", []
+        )
+
+    @pytest.mark.asyncio
     async def test_duplicate_message_ignored_before_buffer(
         self, handler: ChatwootHandler, message_buffer: Any
     ) -> None:
@@ -223,6 +316,25 @@ class TestHandleConversationCreated:
             await handler._handle_conversation_created(payload)
         assert "conversation_created" in caplog.text
         assert "conversation_id=99" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_creates_session_mapping(
+        self, handler: ChatwootHandler, session_manager: Any
+    ) -> None:
+        payload = ConversationCreatedPayload(
+            event="conversation_created",
+            account={"id": 1},
+            conversation=ChatwootConversation(
+                id=99, status="open", inbox_id=1, contact_id=5
+            ),
+            sender=ChatwootSender(id=7, type="contact"),
+        )
+
+        await handler._handle_conversation_created(payload)
+
+        session_manager.get_or_create_session_for_conversation.assert_awaited_once_with(
+            "99", account_id=1
+        )
 
 
 class TestHandleConversationStatusChanged:

--- a/backend/tests/test_chatwoot_handler.py
+++ b/backend/tests/test_chatwoot_handler.py
@@ -298,6 +298,12 @@ class TestHandleMessageCreated:
             await handler._handle_message_created(payload)
         assert "conversation_id=42" in caplog.text
 
+    def test_none_buffer_state_does_not_trigger_full_processing(
+        self, handler: ChatwootHandler
+    ) -> None:
+        """Missing buffer state should fail closed without processing."""
+        assert handler._should_process_full_buffer(None) is False
+
 
 class TestHandleConversationCreated:
     """Dispatch of 'conversation_created' events."""

--- a/backend/tests/test_chatwoot_redis_integration.py
+++ b/backend/tests/test_chatwoot_redis_integration.py
@@ -6,8 +6,14 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fakeredis import FakeAsyncRedis
 
+from backend.app.chatwoot_handler import ChatwootHandler
 from backend.app.message_buffer import MessageBuffer
 from backend.app.redis_cache import RedisCache
+from backend.app.schemas import (
+    ChatwootConversation,
+    ChatwootSender,
+    ConversationCreatedPayload,
+)
 from backend.app.session import SessionManager
 
 
@@ -57,6 +63,41 @@ async def test_session_mapping_and_buffer_share_namespace_without_collisions(
     assert await message_buffer.get_count("42") == 1
     assert await fake_redis.exists("chatwoot:1:conversation:42:metadata") == 1
     assert await fake_redis.exists("chatwoot:1:buffer:42") == 1
+
+
+@pytest.mark.asyncio
+async def test_conversation_created_handler_mapping_is_idempotent(
+    fake_redis: FakeAsyncRedis,
+) -> None:
+    """Repeated conversation_created webhooks should keep one session mapping."""
+    redis_cache = _cache(fake_redis, account_id=1)
+    session_manager = SessionManager(redis_cache=redis_cache)
+    handler = ChatwootHandler(
+        chatwoot_client=AsyncMock(),
+        redis_cache=redis_cache,
+        config_provider=DummyConfigProvider(),
+        session_manager=session_manager,
+    )
+    payload = ConversationCreatedPayload(
+        event="conversation_created",
+        account={"id": 1},
+        conversation=ChatwootConversation(
+            id=314, status="open", inbox_id=7, contact_id=9
+        ),
+        sender=ChatwootSender(id=9, type="contact"),
+    )
+
+    await handler._handle_conversation_created(payload)
+    first_session = await session_manager.get_session_id("314")
+    await handler._handle_conversation_created(payload)
+    second_session = await session_manager.get_session_id("314")
+
+    assert first_session is not None
+    assert second_session == first_session
+    assert (
+        await fake_redis.hget("chatwoot:1:conversation:314:metadata", "session_id")
+        == first_session
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_chatwoot_scenarios.py
+++ b/backend/tests/test_chatwoot_scenarios.py
@@ -17,6 +17,7 @@ from fastapi.testclient import TestClient
 from backend.app.chatwoot_handler import ChatwootHandler
 from backend.app.config import settings
 from backend.app.escalation_handler import EscalationHandler
+from backend.app.message_buffer import BufferState
 
 
 class InMemoryRedisCache:
@@ -110,6 +111,7 @@ def _message_payload(
             "id": message_id,
             "content": "Hola",
             "content_type": "text",
+            "message_type": "incoming",
             "private": False,
         },
     }
@@ -166,6 +168,7 @@ def _override_handler(
     main_module: Any,
     redis_cache: InMemoryRedisCache,
     dependencies: dict[str, Any],
+    process_message: Any | None = None,
 ) -> ChatwootHandler:
     """Install a FastAPI override returning a real ChatwootHandler."""
     handler = ChatwootHandler(
@@ -174,6 +177,7 @@ def _override_handler(
         config_provider=dependencies["config"],
         message_buffer=dependencies["buffer"],
         session_manager=dependencies["sessions"],
+        process_message=process_message,
     )
     main_module.app.dependency_overrides[main_module.get_chatwoot_handler] = lambda: (
         handler
@@ -206,6 +210,50 @@ def test_valid_contact_message_dispatches_through_handler(
     )
     handler_dependencies["buffer"].add_message.assert_awaited_once_with("42", "Hola", 5)
     handler_dependencies["client"].send_typing_indicator.assert_awaited_once_with(42)
+    main_module.app.dependency_overrides.clear()
+
+
+def test_webhook_full_buffer_flow_sends_response_and_appends_history(
+    client: TestClient,
+    main_module: Any,
+    redis_cache: InMemoryRedisCache,
+    handler_dependencies: dict[str, Any],
+) -> None:
+    """Full buffer should process and send a mocked bot response via Chatwoot."""
+    process_message = AsyncMock(return_value="Respuesta desde el bot")
+    _override_handler(
+        main_module,
+        redis_cache,
+        handler_dependencies,
+        process_message=process_message,
+    )
+    handler_dependencies[
+        "sessions"
+    ].get_or_create_session_for_conversation.return_value = "session-42"
+    handler_dependencies["sessions"].get_history_async.return_value = []
+    handler_dependencies["buffer"].add_message.return_value = BufferState(
+        conversation_id="42",
+        messages=["Uno", "Dos", "Tres", "Cuatro", "Hola"],
+    )
+    handler_dependencies["buffer"].flush.return_value = "Uno\nDos\nTres\nCuatro\nHola"
+    body = json.dumps(_message_payload(message_id=105)).encode()
+
+    response = client.post(
+        "/webhook/chatwoot",
+        content=body,
+        headers=_signed_headers(body),
+    )
+
+    assert response.status_code == 200
+    process_message.assert_awaited_once_with(
+        "session-42", "Uno\nDos\nTres\nCuatro\nHola", []
+    )
+    handler_dependencies["client"].send_message.assert_awaited_once_with(
+        42, "Respuesta desde el bot"
+    )
+    handler_dependencies["sessions"].add_turn_async.assert_awaited_once_with(
+        "session-42", "Uno\nDos\nTres\nCuatro\nHola", "Respuesta desde el bot", []
+    )
     main_module.app.dependency_overrides.clear()
 
 

--- a/docs/guides/chatwoot_deployment_runbook.md
+++ b/docs/guides/chatwoot_deployment_runbook.md
@@ -1,0 +1,176 @@
+# Chatwoot deployment runbook
+
+This runbook explains how to connect the ARTE backend to a self-hosted Chatwoot AgentBot safely. Start with the happy path, verify with mocked/local checks first, and only then capture staging screenshots from a real Chatwoot workspace.
+
+> Current scope: backend webhook, Redis-backed state, mocked CI coverage, and operational rollout. Admin-panel Chatwoot configuration is intentionally deferred until the `feature/admin-panel-slice-*` work is integrated coherently.
+
+## Quick path
+
+1. Configure Chatwoot AgentBot and webhook events.
+2. Set backend environment variables and GitHub staging secrets.
+3. Deploy with `CHATWOOT_ENABLED=true` only after the webhook URL is reachable.
+4. Run the smoke checklist below.
+5. Roll back immediately with `CHATWOOT_ENABLED=false` if webhook processing is unhealthy.
+
+## Prerequisites
+
+| Requirement | Why it matters | Status to confirm |
+|-------------|----------------|-------------------|
+| Self-hosted Chatwoot workspace | Source of AgentBot webhooks and Application API calls | Workspace URL is reachable over HTTPS |
+| Backend HTTPS host | Chatwoot must call the webhook publicly | `https://<backend-host>/health` responds |
+| Redis 7+ | Stores idempotency, buffers, mappings, and history cache | `/health/chatwoot` reports Redis healthy or degraded intentionally |
+| AgentBot access token | Allows bot responses through Chatwoot API | Token is stored only as a secret |
+| Webhook HMAC secret | Prevents unsigned webhook processing | Secret is generated and stored in backend config |
+| Existing backend secrets | `/chat` and LLM tooling still require them | `OPENAI_API_KEY`, `CHAT_API_KEY`, AWS vars are configured where needed |
+
+## Chatwoot AgentBot setup
+
+### 1. Create the AgentBot
+
+1. In Chatwoot, open **Settings → Integrations → Agent Bots**.
+2. Create an AgentBot for ARTE.
+3. Copy the AgentBot access token.
+4. Assign the AgentBot to the target inbox, usually the WhatsApp inbox.
+
+### 2. Configure the webhook
+
+| Field | Value |
+|-------|-------|
+| Webhook URL | `https://<backend-host>/webhook/chatwoot` |
+| Signature/HMAC secret | Same value as `CHATWOOT_WEBHOOK_SECRET` |
+| Events to enable | `message_created`, `conversation_created`, `conversation_status_changed` |
+
+The backend intentionally awaits webhook processing instead of scheduling `BackgroundTasks`. That means handler failures return HTTP 500 so Chatwoot can retry the webhook; a premature HTTP 200 would hide failed state updates or missed bot responses.
+
+### 3. Confirm event filtering expectations
+
+| Chatwoot message | Backend behavior |
+|------------------|------------------|
+| Incoming contact message | Creates/reuses session mapping, buffers, and can trigger bot processing |
+| Private message | Ignored |
+| Outgoing message | Ignored to avoid bot self-loops |
+| AgentBot/self message | Ignored to avoid recursive replies |
+| Human-agent message | Flushes/cancels active bot buffer so the human response wins |
+
+## Backend environment variables
+
+| Variable | Required | Example | Notes |
+|----------|----------|---------|-------|
+| `CHATWOOT_ENABLED` | Yes | `true` | Rollback switch: set `false` to disable webhook processing. |
+| `CHATWOOT_API_URL` | Yes | `https://chatwoot.example.com` | Chatwoot base URL, no trailing slash preferred. |
+| `CHATWOOT_AGENT_BOT_TOKEN` | Yes | secret | Application API token; never commit. |
+| `CHATWOOT_ACCOUNT_ID` | Yes | `1` | Numeric account ID used in API paths and Redis namespace. |
+| `CHATWOOT_INBOX_ID` | Recommended | `7` | Inbox used for initial channel mapping. |
+| `CHATWOOT_WEBHOOK_SECRET` | Yes | secret | Shared HMAC secret for webhook verification. |
+| `CHATWOOT_HANDOFF_TEAM_ID` | Optional | `55` | Enables team assignment during escalation. |
+| `CHATWOOT_BOT_LABEL` | Optional | `bot` | Label configuration remains env-driven for now. |
+| `CHATWOOT_ESCALATED_LABEL` | Optional | `escalated` | Label applied during human handoff. |
+| `REDIS_URL` | Yes | `redis://redis:6379/0` | Redis state backend. |
+| `REDIS_PASSWORD` | If used | secret | Required only for secured Redis deployments. |
+| `REDIS_SOCKET_TIMEOUT` | Optional | `2.0` | Keep low to preserve graceful degradation. |
+| `REDIS_MAX_CONNECTIONS` | Optional | `20` | Tune with traffic. |
+
+## GitHub staging notes
+
+Use a protected GitHub Environment such as `staging` before enabling workflows that touch real Chatwoot.
+
+| Secret or variable | Mocked CI | Real staging |
+|--------------------|-----------|--------------|
+| `CHATWOOT_API_URL` | Dummy value in CI | Real Chatwoot URL |
+| `CHATWOOT_AGENT_BOT_TOKEN` | Dummy value in CI | Real AgentBot token |
+| `CHATWOOT_ACCOUNT_ID` | Dummy value in CI | Real numeric account ID |
+| `CHATWOOT_INBOX_ID` | Dummy value in CI | Real inbox ID |
+| `CHATWOOT_WEBHOOK_SECRET` | Dummy value in CI | Real webhook secret |
+| `OPENAI_API_KEY` | Dummy for mocked Chatwoot CI | Real LLM key if staging invokes LLM |
+| `CHAT_API_KEY` | Dummy for mocked Chatwoot CI | Real backend API key |
+
+Mocked CI MUST remain the default PR gate. Real Chatwoot end-to-end checks are not currently in CI because credentials and a stable external Chatwoot connection are not available yet.
+
+## Smoke test checklist
+
+Run these checks after deployment. They do not require a CI workflow.
+
+### Backend checks
+
+- [ ] `GET https://<backend-host>/health` returns healthy baseline status.
+- [ ] `GET https://<backend-host>/health/chatwoot` returns `healthy` or an explicitly understood `degraded` status.
+- [ ] `POST /webhook/chatwoot` with an invalid signature returns `401`.
+- [ ] `POST /webhook/chatwoot` with `CHATWOOT_ENABLED=false` returns `503`.
+- [ ] Logs show `chatwoot_event_received` for a test webhook.
+- [ ] Logs do not expose `CHATWOOT_AGENT_BOT_TOKEN` or `CHATWOOT_WEBHOOK_SECRET`.
+
+### Chatwoot checks
+
+- [ ] AgentBot is assigned to the intended inbox.
+- [ ] Webhook URL is exactly `https://<backend-host>/webhook/chatwoot`.
+- [ ] Enabled events are exactly `message_created`, `conversation_created`, and `conversation_status_changed`.
+- [ ] A new conversation creates a session mapping in Redis.
+- [ ] Incoming contact message receives a bot response in Chatwoot.
+- [ ] Private/outgoing AgentBot messages do not trigger additional bot responses.
+- [ ] Human-agent reply during a pending bot buffer prevents duplicate bot follow-up.
+
+### Local mocked command
+
+```bash
+CHAT_API_KEY=test-chat-api-key \
+OPENAI_API_KEY=test-openai-key \
+CHATWOOT_ENABLED=true \
+CHATWOOT_API_URL=https://chatwoot.test \
+CHATWOOT_AGENT_BOT_TOKEN=test-token \
+CHATWOOT_ACCOUNT_ID=1 \
+CHATWOOT_INBOX_ID=7 \
+CHATWOOT_WEBHOOK_SECRET=test-secret \
+uv run pytest \
+  backend/tests/test_chatwoot_auth.py \
+  backend/tests/test_chatwoot_endpoints.py \
+  backend/tests/test_chatwoot_scenarios.py \
+  backend/tests/test_chatwoot_redis_integration.py
+```
+
+## Rollback
+
+Fast rollback is configuration-only:
+
+```bash
+CHATWOOT_ENABLED=false
+```
+
+Expected rollback behavior:
+
+| Area | Result |
+|------|--------|
+| `/webhook/chatwoot` | Returns `503` and does not parse or dispatch payloads |
+| `/chat` | Existing standalone API remains available |
+| Redis state | Existing keys can expire naturally |
+| Chatwoot AgentBot | Can remain configured, but backend will not process webhooks |
+
+If Chatwoot keeps retrying after rollback, temporarily disable the Chatwoot webhook or AgentBot assignment in Chatwoot.
+
+## Limitations and deferred work
+
+| Limitation | Current decision |
+|------------|------------------|
+| Attachments | Not supported yet; text content is processed first, attachment-only messages are not a production-ready flow. |
+| Admin-panel Chatwoot config | Deferred. Existing admin panel work lives on `feature/admin-panel-slice-*` and must be integrated coherently rather than patched into this branch. |
+| Real Chatwoot e2e in CI | Deferred until stable credentials, staging workspace, and protected environment approval are available. |
+| BackgroundTasks ack | Not used for webhook dispatch because retry safety is currently more important than early ack semantics. |
+
+## Screenshot checklist for rollout evidence
+
+Capture these screenshots when real Chatwoot access exists:
+
+- [ ] AgentBot list showing the ARTE AgentBot enabled.
+- [ ] AgentBot details with token redacted.
+- [ ] Inbox assignment showing the AgentBot connected to the target inbox.
+- [ ] Webhook configuration showing URL and enabled events.
+- [ ] Backend deployment environment showing Chatwoot variables present, with secret values hidden.
+- [ ] `/health/chatwoot` response in staging.
+- [ ] Chatwoot conversation where an incoming contact message gets one bot response.
+- [ ] Chatwoot conversation where a private/outgoing message does not cause a bot loop.
+- [ ] Human handoff example showing status/label/team behavior if escalation is enabled.
+
+## References
+
+- `docs/guides/chatwoot_testing_ci.md` — mocked CI and local command guide.
+- `backend/app/chatwoot_handler.py` — webhook dispatch, filtering, mapping, and processing seam.
+- `backend/main.py` — webhook HMAC validation and retry-safe awaited dispatch.

--- a/docs/guides/chatwoot_deployment_runbook.md
+++ b/docs/guides/chatwoot_deployment_runbook.md
@@ -10,7 +10,20 @@ This runbook explains how to connect the ARTE backend to a self-hosted Chatwoot 
 2. Set backend environment variables and GitHub staging secrets.
 3. Deploy with `CHATWOOT_ENABLED=true` only after the webhook URL is reachable.
 4. Run the smoke checklist below.
-5. Roll back immediately with `CHATWOOT_ENABLED=false` if webhook processing is unhealthy.
+5. Capture the screenshot evidence listed in `chatwoot_screenshot_capture_guide.md`.
+6. Roll back immediately with `CHATWOOT_ENABLED=false` if webhook processing is unhealthy.
+
+## What good looks like
+
+| Checkpoint | Expected evidence |
+|------------|-------------------|
+| AgentBot configured | Chatwoot shows the ARTE AgentBot assigned to the WhatsApp inbox. |
+| Webhook protected | Invalid signatures return `401`; valid signed mocked tests pass in CI. |
+| State healthy | `/health/chatwoot` reports `healthy` or a known `degraded` state. |
+| Bot response flow | A contact message receives exactly one bot response in Chatwoot. |
+| No self-loop | Private/outgoing/AgentBot messages do not trigger recursive replies. |
+| Human handoff | Escalation applies label/status/assignment according to env config. |
+| Rollback ready | `CHATWOOT_ENABLED=false` disables webhook processing without breaking `/chat`. |
 
 ## Prerequisites
 
@@ -32,6 +45,9 @@ This runbook explains how to connect the ARTE backend to a self-hosted Chatwoot 
 3. Copy the AgentBot access token.
 4. Assign the AgentBot to the target inbox, usually the WhatsApp inbox.
 
+Screenshot evidence: capture the AgentBot detail screen with tokens hidden. See
+`docs/guides/chatwoot_screenshot_capture_guide.md` for the full capture list.
+
 ### 2. Configure the webhook
 
 | Field | Value |
@@ -41,6 +57,10 @@ This runbook explains how to connect the ARTE backend to a self-hosted Chatwoot 
 | Events to enable | `message_created`, `conversation_created`, `conversation_status_changed` |
 
 The backend intentionally awaits webhook processing instead of scheduling `BackgroundTasks`. That means handler failures return HTTP 500 so Chatwoot can retry the webhook; a premature HTTP 200 would hide failed state updates or missed bot responses.
+
+> Decision: do not change this to background dispatch unless the implementation
+> introduces durable queueing before ACK. Reliability beats early ACK for this
+> integration because dropped webhooks can lose customer messages.
 
 ### 3. Confirm event filtering expectations
 
@@ -109,6 +129,33 @@ Run these checks after deployment. They do not require a CI workflow.
 - [ ] Private/outgoing AgentBot messages do not trigger additional bot responses.
 - [ ] Human-agent reply during a pending bot buffer prevents duplicate bot follow-up.
 
+## Troubleshooting quick table
+
+| Symptom | Likely cause | Check | Fix |
+|---------|--------------|-------|-----|
+| Chatwoot gets `401` from webhook | HMAC secret mismatch | Compare Chatwoot secret with `CHATWOOT_WEBHOOK_SECRET` | Rotate/update both values, then retry webhook. |
+| Chatwoot gets `503` | Integration disabled | Check `CHATWOOT_ENABLED` | Set `CHATWOOT_ENABLED=true` after config is complete. |
+| `/health/chatwoot` is `degraded` | Redis unavailable or Chatwoot config missing | Inspect `redis` and `chatwoot_api` fields | Fix Redis URL or required Chatwoot env vars. |
+| Bot replies twice | Duplicate webhook/idempotency failure or self-loop filtering issue | Check logs for same `message.id` twice | Verify Redis is reachable and outgoing/private filtering is enabled. |
+| Human replied but bot still answered | Race window or missing human-agent event | Check webhook event order and `sender.type` | Confirm `message_created` events include agent messages. |
+| Escalation does not assign team | Missing `CHATWOOT_HANDOFF_TEAM_ID` | Check env and logs | Configure team ID or accept label/status-only handoff. |
+
+## Observability checks
+
+Use backend logs during staging. At minimum, confirm logs include enough context
+to trace a webhook without exposing secrets:
+
+| Log context | Why it matters |
+|-------------|----------------|
+| event type | Distinguishes `message_created` from lifecycle events. |
+| conversation ID | Lets support correlate backend logs with Chatwoot UI. |
+| message ID | Lets maintainers verify idempotency. |
+| sender type | Confirms contact vs human agent vs AgentBot filtering. |
+| handler result | Confirms accepted, ignored, escalated, or failed path. |
+
+Never log raw tokens, webhook secrets, customer PII beyond what is already
+needed for operational correlation.
+
 ### Local mocked command
 
 ```bash
@@ -157,7 +204,9 @@ If Chatwoot keeps retrying after rollback, temporarily disable the Chatwoot webh
 
 ## Screenshot checklist for rollout evidence
 
-Capture these screenshots when real Chatwoot access exists:
+Capture these screenshots when real Chatwoot access exists. Track the work in
+GitHub issue #186 and use the detailed capture guide in
+`docs/guides/chatwoot_screenshot_capture_guide.md`.
 
 - [ ] AgentBot list showing the ARTE AgentBot enabled.
 - [ ] AgentBot details with token redacted.
@@ -172,5 +221,6 @@ Capture these screenshots when real Chatwoot access exists:
 ## References
 
 - `docs/guides/chatwoot_testing_ci.md` — mocked CI and local command guide.
+- `docs/guides/chatwoot_screenshot_capture_guide.md` — screenshot capture plan and redaction rules.
 - `backend/app/chatwoot_handler.py` — webhook dispatch, filtering, mapping, and processing seam.
 - `backend/main.py` — webhook HMAC validation and retry-safe awaited dispatch.

--- a/docs/guides/chatwoot_screenshot_capture_guide.md
+++ b/docs/guides/chatwoot_screenshot_capture_guide.md
@@ -1,0 +1,207 @@
+# Chatwoot screenshot capture guide
+
+Use this guide when real Chatwoot access exists. The goal is to produce rollout
+evidence that a maintainer can verify quickly without exposing secrets or
+customer data.
+
+## Quick path
+
+1. Capture configuration screenshots first: AgentBot, webhook, inbox, account,
+   labels, and handoff team.
+2. Capture behavior screenshots second: health check, bot reply, ignored
+   private/outgoing message, and human handoff.
+3. Redact secrets and customer data before attaching screenshots to docs or
+   issues.
+4. Link screenshots from GitHub issue #186 and the final runbook update.
+
+## Redaction rules
+
+| Must hide | Why |
+|-----------|-----|
+| AgentBot token | Allows sending messages through Chatwoot API. |
+| Webhook HMAC secret | Allows signing spoofed webhooks. |
+| Customer phone numbers and names | PII. |
+| Message contents from real customers | PII/business context. Use a test contact. |
+| GitHub secret values | Secrets must be names-only in screenshots. |
+
+Prefer a dedicated staging/test contact so screenshots can show realistic flow
+without exposing customer data.
+
+## Screenshot set
+
+### 1. AgentBot details
+
+**Capture:** Chatwoot AgentBot detail page.
+
+**Must show:**
+
+- AgentBot name, e.g. `ARTE Chatbot`.
+- Enabled/active state.
+- Assigned inbox if visible.
+- Token field redacted.
+
+**Use it to verify:** `CHATWOOT_AGENT_BOT_TOKEN` exists and belongs to the bot.
+
+### 2. Webhook configuration
+
+**Capture:** AgentBot/webhook configuration screen.
+
+**Must show:**
+
+- URL: `https://<backend-host>/webhook/chatwoot`.
+- Events: `message_created`, `conversation_created`,
+  `conversation_status_changed`.
+- HMAC/signature secret redacted.
+
+**Use it to verify:** Chatwoot calls the correct endpoint. Do not use `/chat`.
+
+### 3. WhatsApp inbox assignment
+
+**Capture:** Inbox settings for the WhatsApp inbox.
+
+**Must show:**
+
+- Inbox name.
+- Channel type/provider.
+- Inbox ID if visible, or URL containing the ID.
+- AgentBot assignment.
+
+**Use it to verify:** `CHATWOOT_INBOX_ID` and channel profile assumptions.
+
+### 4. Account ID source
+
+**Capture:** Browser URL or account settings showing the account ID.
+
+**Must show:**
+
+- A URL segment such as `/accounts/1/` or equivalent settings display.
+
+**Use it to verify:** `CHATWOOT_ACCOUNT_ID`.
+
+### 5. Handoff team
+
+**Capture:** Team settings for the handoff target.
+
+**Must show:**
+
+- Team name.
+- Team ID if visible, or URL containing the ID.
+- Team members can be blurred if needed.
+
+**Use it to verify:** `CHATWOOT_HANDOFF_TEAM_ID`.
+
+### 6. Labels
+
+**Capture:** Labels/settings page.
+
+**Must show:**
+
+- Bot label, e.g. `bot`.
+- Escalation label, e.g. `escalated`.
+- Technical label, e.g. `technical`.
+
+**Use it to verify:** label env values match Chatwoot labels.
+
+### 7. GitHub secrets names
+
+**Capture:** Repository or environment secrets list.
+
+**Must show names only:**
+
+- `CHATWOOT_API_URL`
+- `CHATWOOT_AGENT_BOT_TOKEN`
+- `CHATWOOT_ACCOUNT_ID`
+- `CHATWOOT_INBOX_ID`
+- `CHATWOOT_WEBHOOK_SECRET`
+- `CHATWOOT_HANDOFF_TEAM_ID` when assignment is enabled
+
+**Never show:** secret values.
+
+### 8. `/health/chatwoot`
+
+**Capture:** terminal or API client response.
+
+**Healthy example:**
+
+```json
+{
+  "status": "healthy",
+  "chatwoot_enabled": true,
+  "redis": "healthy",
+  "chatwoot_api": "configured"
+}
+```
+
+**Use it to verify:** backend config and Redis readiness.
+
+### 9. Incoming contact message response
+
+**Capture:** Chatwoot conversation with a staging contact.
+
+**Must show:**
+
+- One incoming contact message.
+- Exactly one bot response.
+- No duplicate bot messages after retry window.
+
+**Use it to verify:** webhook → buffer/session → bot response flow.
+
+### 10. Private/outgoing message does not loop
+
+**Capture:** Chatwoot conversation after an internal/private note or outgoing
+agent message.
+
+**Must show:**
+
+- The private/outgoing message.
+- No follow-up bot reply caused by that message.
+
+**Use it to verify:** self-loop filtering.
+
+### 11. Human handoff
+
+**Capture:** Escalated conversation.
+
+**Must show:**
+
+- Conversation status changed to open.
+- Escalation label applied.
+- Team assigned when configured.
+- Handoff message sent to the contact.
+
+**Use it to verify:** escalation handler behavior.
+
+### 12. Rollback state
+
+**Capture:** backend response with `CHATWOOT_ENABLED=false`.
+
+**Expected:**
+
+```json
+{
+  "detail": "Chatwoot integration disabled"
+}
+```
+
+from `POST /webhook/chatwoot`, and `/chat` remains available.
+
+## Attachment checklist for the documentation issue
+
+- [ ] AgentBot details screenshot.
+- [ ] Webhook URL/events screenshot.
+- [ ] WhatsApp inbox assignment screenshot.
+- [ ] Account ID evidence screenshot.
+- [ ] Handoff team screenshot.
+- [ ] Labels screenshot.
+- [ ] GitHub secrets names screenshot.
+- [ ] `/health/chatwoot` screenshot.
+- [ ] Contact message → bot response screenshot.
+- [ ] Private/outgoing no-loop screenshot.
+- [ ] Human handoff screenshot.
+- [ ] Rollback screenshot.
+
+## Where to link screenshots
+
+Attach screenshots to GitHub issue #186 first. After review, add
+selected redacted images to the runbook or link the issue from the runbook,
+depending on repository documentation size limits and maintainer preference.

--- a/docs/guides/chatwoot_testing_ci.md
+++ b/docs/guides/chatwoot_testing_ci.md
@@ -75,3 +75,10 @@ Before enabling any workflow that calls a real Chatwoot API, configure a
 protected GitHub Environment such as `staging`. Store the real Chatwoot secrets
 there, require approval, and keep the mocked deterministic suite as the default
 PR gate.
+
+## Related rollout docs
+
+- `docs/guides/chatwoot_deployment_runbook.md` — production/staging setup,
+  smoke checks, rollback, and operational troubleshooting.
+- `docs/guides/chatwoot_screenshot_capture_guide.md` — screenshot checklist and
+  redaction rules for high-quality rollout documentation.


### PR DESCRIPTION
## Linked Issue
Closes #165
Refs #164, #166, #168, #171

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Creates/reuses Chatwoot conversation→session mappings for `conversation_created`, with fakeredis idempotency coverage.
- Filters private, outgoing, and AgentBot self messages before bot side effects, and proves full buffered response flow through an injected processing seam.
- Documents the deployment runbook, smoke checklist, screenshot checklist, rollback, and the intentional admin-panel config deferral.

## Changes
| File | Change |
|------|--------|
| `backend/app/chatwoot_handler.py` | Adds mapping behavior, message filtering, retry-safe full-buffer processing seam, and response/history append flow. |
| `backend/app/schemas.py` | Adds `message_type` to Chatwoot message payloads. |
| `backend/main.py` | Documents why webhook dispatch is awaited for Chatwoot retry semantics. |
| `backend/tests/test_chatwoot_handler.py` | Adds RED/GREEN coverage for mapping, filtering, and processing callback flow. |
| `backend/tests/test_chatwoot_scenarios.py` | Adds endpoint-level mocked full buffer → callback → Chatwoot response → history scenario. |
| `backend/tests/test_chatwoot_redis_integration.py` | Adds fakeredis idempotent `conversation_created` mapping coverage. |
| `docs/guides/chatwoot_deployment_runbook.md` | Adds production/staging runbook, smoke tests, rollback, limitations, and screenshot checklist. |

## Test Plan
- [x] Baseline: `uv run pytest backend/tests/test_chatwoot_handler.py backend/tests/test_chatwoot_endpoints.py backend/tests/test_chatwoot_scenarios.py backend/tests/test_chatwoot_redis_integration.py` → 41 passed, 2 warnings
- [x] RED: `uv run pytest backend/tests/test_chatwoot_handler.py backend/tests/test_chatwoot_redis_integration.py` → 5 failed, 22 passed
- [x] GREEN: `uv run pytest backend/tests/test_chatwoot_handler.py backend/tests/test_chatwoot_redis_integration.py` → 27 passed
- [x] Scenario triangulation: `uv run pytest backend/tests/test_chatwoot_scenarios.py` → 8 passed
- [x] Targeted Chatwoot suite: `uv run pytest backend/tests/test_chatwoot_auth.py backend/tests/test_chatwoot_endpoints.py backend/tests/test_chatwoot_scenarios.py backend/tests/test_chatwoot_redis_integration.py backend/tests/test_chatwoot_handler.py` → 57 passed, 2 warnings
- [x] Affected component suite: `uv run pytest backend/tests/test_channel_profile.py backend/tests/test_config_provider.py backend/tests/test_redis_cache.py backend/tests/test_chatwoot_client.py backend/tests/test_message_buffer_redis.py backend/tests/test_session_manager_hybrid.py backend/tests/test_escalation_handler.py backend/tests/test_chatwoot_handler.py backend/tests/test_chatwoot_auth.py backend/tests/test_chatwoot_endpoints.py backend/tests/test_chatwoot_scenarios.py backend/tests/test_chatwoot_redis_integration.py` → 184 passed, 5 warnings
- [x] `uv run ruff check backend/app/chatwoot_handler.py backend/app/schemas.py backend/main.py backend/tests/test_chatwoot_handler.py backend/tests/test_chatwoot_scenarios.py backend/tests/test_chatwoot_redis_integration.py` → passed
- [x] `uv run ruff format --check backend/app/chatwoot_handler.py backend/app/schemas.py backend/main.py backend/tests/test_chatwoot_handler.py backend/tests/test_chatwoot_scenarios.py backend/tests/test_chatwoot_redis_integration.py` → passed

## Scope Notes
- Webhook dispatch remains awaited intentionally. Returning 500 on handler failures preserves Chatwoot retry semantics.
- Admin-panel Chatwoot configuration remains deferred until the existing `feature/admin-panel-slice-*` work is integrated coherently.
- No real Chatwoot credentials or network calls are required; tests stay mocked/fakeredis only.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts — N/A, no scripts modified
- [x] Skills tested in at least one agent
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers