### PR TITLE
feat(admin): add backend admin foundation

### DIFF
--- a/backend/app/admin_auth.py
+++ b/backend/app/admin_auth.py
@@ -1,0 +1,9 @@
+"""Admin authentication wrapper.
+
+Re-exports verify_admin_key so that admin routers can import it cleanly
+from a dedicated auth module without pulling in the generic auth module.
+"""
+
+from backend.app.auth import verify_admin_key
+
+__all__ = ["verify_admin_key"]

--- a/backend/app/admin_router.py
+++ b/backend/app/admin_router.py
@@ -1,0 +1,27 @@
+"""Admin panel router for FastAPI backend.
+
+Groups all admin endpoints under the /admin prefix.
+"""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+
+from backend.app.admin_auth import verify_admin_key
+
+admin_router = APIRouter(prefix="/admin")
+
+
+@admin_router.get("/health")
+async def admin_health(
+    _admin_key: Annotated[str, Depends(verify_admin_key)],
+) -> dict[str, str]:
+    """Health check endpoint for the admin panel service.
+
+    Returns:
+        Static JSON payload indicating the admin service is healthy.
+    """
+    return {
+        "status": "healthy",
+        "service": "arte-chatbot-admin",
+    }

--- a/backend/app/admin_schemas.py
+++ b/backend/app/admin_schemas.py
@@ -1,0 +1,194 @@
+"""Pydantic v2 models for the admin panel domain.
+
+These schemas define the request/response payloads for all /admin endpoints
+and mirror the Zod schemas used by the Next.js frontend.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class ProductVariant(BaseModel):
+    """A single product variant with model name and key parameters."""
+
+    modelo: str
+    parametros_clave: Dict[str, Any] = Field(default_factory=dict)
+
+
+class CatalogProduct(BaseModel):
+    """A product entry in the catalog index."""
+
+    nombre_comercial: str
+    fabricante: str
+    categoria: str
+    subcategoria: Optional[str] = None
+    descripcion: Optional[str] = None
+    ruta_s3: str
+    variantes: List[ProductVariant] = Field(default_factory=list)
+    parametros_comunes: Dict[str, Any] = Field(default_factory=dict)
+
+
+class CatalogIndex(BaseModel):
+    """Root catalog index containing all products."""
+
+    products: List[CatalogProduct] = Field(default_factory=list)
+
+
+class GuideMeta(BaseModel):
+    """Metadata for a single guide markdown file."""
+
+    intent: str
+    title: str
+    updated_at: Optional[str] = None
+
+
+class GuideContent(BaseModel):
+    """Content payload for a guide markdown file."""
+
+    intent: str
+    content: str
+
+
+class DashboardMetrics(BaseModel):
+    """Aggregated metrics for the admin dashboard."""
+
+    active_sessions: int
+    total_input_tokens: int
+    total_output_tokens: int
+    total_tokens: int
+    escalation_rate: float = Field(..., ge=0.0, le=1.0)
+    intent_distribution: Dict[str, int] = Field(default_factory=dict)
+
+
+class ConversationLogSummary(BaseModel):
+    """Summary of a single conversation session."""
+
+    session_id: str
+    turn_count: int
+    last_timestamp: Optional[str] = None
+    intent_types: List[str] = Field(default_factory=list)
+    escalated: bool = False
+
+
+class ConversationLogEntry(BaseModel):
+    """Structured log entry for a single conversation turn."""
+
+    session_id: str
+    turn_number: int
+    timestamp: str
+    user_message: str
+    bot_response: str
+    intent_type: str
+    escalate: bool
+    source_documents: List[str] = Field(default_factory=list)
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    response_time_ms: float
+    model: str
+    git_commit_hash: str
+    user_profile: Optional[str] = None
+
+
+class MutableSettings(BaseModel):
+    """Fields that can be updated at runtime via settings.reload()."""
+
+    llm_model: Optional[str] = None
+    log_level: Optional[str] = None
+    escalation_confidence_threshold: Optional[float] = Field(
+        default=None, ge=0.0, le=1.0
+    )
+    false_positive_limit: Optional[float] = Field(
+        default=None, ge=0.0, le=1.0
+    )
+    false_negative_limit: Optional[float] = Field(
+        default=None, ge=0.0, le=1.0
+    )
+    whatsapp_formatter_enabled: Optional[bool] = None
+    split_messages_enabled: Optional[bool] = None
+    msg_delay_min_ms: Optional[int] = Field(default=None, ge=1000, le=10000)
+    msg_delay_max_ms: Optional[int] = Field(default=None, ge=1000, le=15000)
+    greeting_enabled: Optional[bool] = None
+    greeting_timezone: Optional[str] = None
+    multi_message_buffer_enabled: Optional[bool] = None
+    buffer_window_seconds: Optional[int] = Field(default=None, ge=1, le=15)
+    conversation_logging_enabled: Optional[bool] = None
+    conversation_log_prefix: Optional[str] = None
+    admin_api_key: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _validate_delays(self) -> "MutableSettings":
+        """Ensure msg_delay_min_ms <= msg_delay_max_ms when both are set."""
+        if (
+            self.msg_delay_min_ms is not None
+            and self.msg_delay_max_ms is not None
+            and self.msg_delay_min_ms > self.msg_delay_max_ms
+        ):
+            raise ValueError("msg_delay_min_ms must be <= msg_delay_max_ms")
+        return self
+
+
+class ImmutableSettings(BaseModel):
+    """Fields that require container restart to change."""
+
+    openai_api_key: Optional[str] = None
+    aws_access_key_id: Optional[str] = None
+    aws_secret_access_key: Optional[str] = None
+    aws_bucket_name: str
+    aws_region: str
+    chat_api_key: Optional[str] = None
+    git_commit_hash: str
+
+
+class CurrentSettingsSnapshot(BaseModel):
+    """Combined snapshot of mutable and immutable settings."""
+
+    mutable: MutableSettings
+    immutable: ImmutableSettings
+
+
+class S3TreeNode(BaseModel):
+    """A node in the hierarchical S3 tree view."""
+
+    model_config = {"populate_by_name": True}
+
+    name: str
+    key: str
+    type: str  # "folder" | "file"
+    size: Optional[int] = None
+    last_modified: Optional[str] = None
+    children: Optional[List["S3TreeNode"]] = None
+
+
+class PresignedUploadRequest(BaseModel):
+    """Request body for generating a presigned S3 POST URL."""
+
+    key: str
+    content_type: str = "application/pdf"
+
+
+class PresignedUploadResponse(BaseModel):
+    """Response containing presigned S3 POST URL and fields."""
+
+    url: str
+    fields: Dict[str, str] = Field(default_factory=dict)
+    key: str
+
+
+class DeleteS3ObjectsRequest(BaseModel):
+    """Request body for batch-deleting S3 objects."""
+
+    keys: List[str]
+
+
+class LogFilterParams(BaseModel):
+    """Query parameters for filtering conversation logs."""
+
+    session_id: Optional[str] = None
+    intent_type: Optional[str] = None
+    escalated: Optional[bool] = None
+    date_from: Optional[str] = None
+    date_to: Optional[str] = None
+    limit: int = Field(default=50, ge=1, le=200)
+    offset: int = Field(default=0, ge=0)

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -7,6 +7,7 @@ from fastapi.security import APIKeyHeader
 from backend.app.config import settings
 
 API_KEY_HEADER = APIKeyHeader(name="X-API-Key", auto_error=False)
+ADMIN_API_KEY_HEADER = APIKeyHeader(name="X-Admin-API-Key", auto_error=False)
 
 
 def _get_chat_api_key() -> Optional[str]:
@@ -38,3 +39,36 @@ def verify_api_key(api_key: str = Security(API_KEY_HEADER)) -> str:
             detail="Invalid API key",
         )
     return api_key
+
+
+def verify_admin_key(admin_key: str = Security(ADMIN_API_KEY_HEADER)) -> str:
+    """Dependency that validates the X-Admin-API-Key header.
+
+    Args:
+        admin_key: The X-Admin-API-Key header value.
+
+    Returns:
+        The validated admin API key.
+
+    Raises:
+        HTTPException: 401 if missing, 403 if invalid, 503 if not configured.
+    """
+    if not admin_key:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing admin API key",
+        )
+
+    valid_key = settings.admin_api_key
+    if not valid_key:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="ADMIN_API_KEY not configured",
+        )
+
+    if not hmac.compare_digest(admin_key, valid_key):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid admin API key",
+        )
+    return admin_key

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -54,6 +54,9 @@ class Settings(BaseSettings):
     chat_api_key: Optional[str] = Field(
         default=None, description="API key for authenticating /chat endpoint clients"
     )
+    admin_api_key: Optional[str] = Field(
+        default=None, description="API key for authenticating /admin endpoint clients"
+    )
 
     # App
     log_level: str = Field(default="INFO", description="Logging level")
@@ -174,6 +177,16 @@ class _SettingsProxy:
         access creates a fresh Settings() that reads the updated env.
         """
         self._instance = None
+
+    def reload(self) -> None:
+        """Atomically reload settings from environment variables.
+
+        Creates a new Settings() instance and swaps the internal reference.
+        Concurrent reads are safe because Python reference assignment is
+        atomic under the GIL; readers will see either the old or new
+        instance, never a partially constructed one.
+        """
+        self._instance = Settings()
 
     def _ensure_instance(self) -> Settings:
         if self._instance is None:

--- a/backend/app/s3_client.py
+++ b/backend/app/s3_client.py
@@ -4,9 +4,10 @@ This module provides a client to interact with AWS S3 for downloading
 PDF files containing technical product datasheets.
 """
 
+import asyncio
 import logging
 import os
-from typing import Optional
+from typing import Any, Dict, List, Optional
 
 import boto3
 from botocore.exceptions import ClientError, NoCredentialsError
@@ -199,3 +200,145 @@ class S3Client:
         except Exception as e:
             logger.exception("Unexpected error uploading to S3: %s", e)
             raise S3UploadError(f"Unexpected S3 upload error: {e}") from e
+
+    async def list_objects(self, prefix: str = "") -> List[Dict[str, Any]]:
+        """List objects under a prefix using list_objects_v2.
+
+        Args:
+            prefix: S3 key prefix to filter objects.
+
+        Returns:
+            List of dicts with keys such as Key, Size, LastModified.
+
+        Raises:
+            S3DownloadError: If the listing fails or bucket is not configured.
+        """
+        if not self.bucket_name:
+            raise S3DownloadError("S3 bucket name not configured")
+
+        def _list() -> List[Dict[str, Any]]:
+            try:
+                paginator = self.client.get_paginator("list_objects_v2")
+                results: List[Dict[str, Any]] = []
+                for page in paginator.paginate(
+                    Bucket=self.bucket_name, Prefix=prefix
+                ):
+                    results.extend(page.get("Contents", []))
+                return results
+            except ClientError as e:
+                raise S3DownloadError(f"S3 list failed: {e}") from e
+
+        return await asyncio.to_thread(_list)
+
+    async def head_object(self, key: str) -> Dict[str, Any]:
+        """Return metadata for a single S3 object.
+
+        Args:
+            key: The S3 key (path) to inspect.
+
+        Returns:
+            Dict with metadata fields such as ETag, ContentLength, LastModified.
+
+        Raises:
+            S3DownloadError: If the object does not exist or the request fails.
+        """
+        if not self.bucket_name:
+            raise S3DownloadError("S3 bucket name not configured")
+
+        def _head() -> Dict[str, Any]:
+            try:
+                response = self.client.head_object(
+                    Bucket=self.bucket_name, Key=key
+                )
+                return dict(response)
+            except ClientError as e:
+                raise S3DownloadError(f"S3 head_object failed: {e}") from e
+
+        return await asyncio.to_thread(_head)
+
+    async def delete_object(self, key: str) -> None:
+        """Delete a single object from S3.
+
+        Args:
+            key: The S3 key (path) to delete.
+
+        Raises:
+            S3UploadError: If the deletion fails or bucket is not configured.
+        """
+        if not self.bucket_name:
+            raise S3UploadError("S3 bucket name not configured")
+
+        def _delete() -> None:
+            try:
+                self.client.delete_object(Bucket=self.bucket_name, Key=key)
+            except ClientError as e:
+                raise S3UploadError(f"S3 delete failed: {e}") from e
+
+        await asyncio.to_thread(_delete)
+
+    async def delete_objects(self, keys: List[str]) -> None:
+        """Delete multiple objects via delete_objects batch API.
+
+        Args:
+            keys: List of S3 keys to delete.
+
+        Raises:
+            S3UploadError: If the batch deletion fails or bucket is not configured.
+        """
+        if not self.bucket_name:
+            raise S3UploadError("S3 bucket name not configured")
+
+        def _delete_batch() -> None:
+            try:
+                self.client.delete_objects(
+                    Bucket=self.bucket_name,
+                    Delete={
+                        "Objects": [{"Key": k} for k in keys],
+                        "Quiet": True,
+                    },
+                )
+            except ClientError as e:
+                raise S3UploadError(f"S3 batch delete failed: {e}") from e
+
+        await asyncio.to_thread(_delete_batch)
+
+    async def generate_presigned_post(
+        self,
+        key: str,
+        content_type: str = "application/pdf",
+        expires: int = 3600,
+    ) -> Dict[str, Any]:
+        """Generate a presigned POST URL for direct browser upload.
+
+        Args:
+            key: The S3 key (path) where the uploaded object will be stored.
+            content_type: Expected Content-Type of the upload. Defaults to application/pdf.
+            expires: Expiration time in seconds. Defaults to 3600.
+
+        Returns:
+            Dict with "url" and "fields" for the presigned POST.
+
+        Raises:
+            S3UploadError: If generation fails or bucket is not configured.
+        """
+        if not self.bucket_name:
+            raise S3UploadError("S3 bucket name not configured")
+
+        def _generate() -> Dict[str, Any]:
+            try:
+                return self.client.generate_presigned_post(
+                    Bucket=self.bucket_name,
+                    Key=key,
+                    Fields={"Content-Type": content_type},
+                    Conditions=[
+                        {"Content-Type": content_type},
+                        ["content-length-range", 1024, 104_857_600],
+                    ],
+                    ExpiresIn=expires,
+                )
+            except ClientError as e:
+                raise S3UploadError(
+                    f"Presigned post generation failed: {e}"
+                ) from e
+
+        return await asyncio.to_thread(_generate)

--- a/backend/app/tests/test_admin_slice1.py
+++ b/backend/app/tests/test_admin_slice1.py
@@ -1,0 +1,286 @@
+"""Tests for Slice 1: Backend Foundation — Auth + S3 + Config.
+
+Covers:
+- Admin health endpoint authentication (200, 401, 403)
+- S3Client extensions (list_objects, presigned_post, delete_objects)
+- Settings reload atomicity
+"""
+
+import asyncio
+import os
+from typing import Any, Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Import before any settings access so monkeypatch works reliably
+from backend.app.config import settings
+
+
+def _reset_settings() -> None:
+    """Reset the settings proxy so next access reads fresh env."""
+    settings.reset()
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, None, None]:
+    """FastAPI TestClient with admin key configured.
+
+    Yields a TestClient after resetting settings and setting ADMIN_API_KEY.
+    """
+    monkeypatch.setenv("ADMIN_API_KEY", "test-admin-key")
+    _reset_settings()
+
+    # We must import main AFTER patching env so module-level settings reads
+    # the correct value.
+    from backend.main import app
+
+    with TestClient(app) as tc:
+        yield tc
+
+    _reset_settings()
+
+
+class TestAdminHealth:
+    """Authentication and health checks for the admin router."""
+
+    def test_admin_health_authenticated(
+        self, client: TestClient
+    ) -> None:
+        """GET /admin/health with valid key returns 200 and correct payload."""
+        response = client.get(
+            "/admin/health",
+            headers={"X-Admin-API-Key": "test-admin-key"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "healthy"
+        assert data["service"] == "arte-chatbot-admin"
+
+    def test_admin_health_missing_key(
+        self, client: TestClient
+    ) -> None:
+        """GET /admin/health without key returns 401."""
+        response = client.get("/admin/health")
+        assert response.status_code == 401
+        assert "Missing admin API key" in response.json()["detail"]
+
+    def test_admin_health_invalid_key(
+        self, client: TestClient
+    ) -> None:
+        """GET /admin/health with wrong key returns 403."""
+        response = client.get(
+            "/admin/health",
+            headers={"X-Admin-API-Key": "bad-key"},
+        )
+        assert response.status_code == 403
+        assert "Invalid admin API key" in response.json()["detail"]
+
+    def test_admin_health_not_configured(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """GET /admin/health when ADMIN_API_KEY is unset returns 503."""
+        monkeypatch.delenv("ADMIN_API_KEY", raising=False)
+        _reset_settings()
+
+        from backend.main import app
+
+        with TestClient(app) as client:
+            response = client.get(
+                "/admin/health",
+                headers={"X-Admin-API-Key": "some-key"},
+            )
+            assert response.status_code == 503
+            assert "ADMIN_API_KEY not configured" in response.json()["detail"]
+
+        _reset_settings()
+
+
+class TestS3Extensions:
+    """Unit tests for S3Client extension methods with mocked boto3."""
+
+    @pytest.fixture
+    def s3_client(self) -> Any:
+        """Return an S3Client with a mocked boto3 client."""
+        from backend.app.s3_client import S3Client
+
+        client = S3Client(bucket_name="test-bucket")
+        client._client = MagicMock()
+        return client
+
+    @pytest.mark.asyncio
+    async def test_s3_list_objects_mock(self, s3_client: Any) -> None:
+        """list_objects uses paginator and returns Contents."""
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [
+            {"Contents": [{"Key": "a.pdf", "Size": 123}]},
+            {"Contents": [{"Key": "b.pdf", "Size": 456}]},
+        ]
+        s3_client.client.get_paginator.return_value = mock_paginator
+
+        result = await s3_client.list_objects(prefix="raw/")
+
+        assert len(result) == 2
+        assert result[0]["Key"] == "a.pdf"
+        assert result[1]["Key"] == "b.pdf"
+        mock_paginator.paginate.assert_called_once_with(
+            Bucket="test-bucket", Prefix="raw/"
+        )
+
+    @pytest.mark.asyncio
+    async def test_s3_list_objects_empty(self, s3_client: Any) -> None:
+        """list_objects returns empty list when no contents."""
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [{}, {"Contents": []}]
+        s3_client.client.get_paginator.return_value = mock_paginator
+
+        result = await s3_client.list_objects(prefix="empty/")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_s3_presigned_post_mock(self, s3_client: Any) -> None:
+        """generate_presigned_post returns url and fields."""
+        s3_client.client.generate_presigned_post.return_value = {
+            "url": "https://test-bucket.s3.amazonaws.com/",
+            "fields": {
+                "key": "raw/paneles/x.pdf",
+                "AWSAccessKeyId": "AKIA...",
+            },
+        }
+
+        result = await s3_client.generate_presigned_post(
+            key="raw/paneles/x.pdf",
+            content_type="application/pdf",
+            expires=3600,
+        )
+
+        assert result["url"] == "https://test-bucket.s3.amazonaws.com/"
+        assert result["fields"]["key"] == "raw/paneles/x.pdf"
+        call_kwargs = s3_client.client.generate_presigned_post.call_args.kwargs
+        assert call_kwargs["Bucket"] == "test-bucket"
+        assert call_kwargs["Key"] == "raw/paneles/x.pdf"
+        assert call_kwargs["ExpiresIn"] == 3600
+        conditions = call_kwargs["Conditions"]
+        assert ["content-length-range", 1024, 104_857_600] in conditions
+
+    @pytest.mark.asyncio
+    async def test_s3_delete_objects_mock(self, s3_client: Any) -> None:
+        """delete_objects calls delete_objects batch API."""
+        s3_client.client.delete_objects.return_value = {}
+
+        await s3_client.delete_objects(keys=["raw/a.pdf", "raw/b.pdf"])
+
+        call_kwargs = s3_client.client.delete_objects.call_args.kwargs
+        assert call_kwargs["Bucket"] == "test-bucket"
+        delete_arg = call_kwargs["Delete"]
+        assert delete_arg["Quiet"] is True
+        assert {obj["Key"] for obj in delete_arg["Objects"]} == {
+            "raw/a.pdf",
+            "raw/b.pdf",
+        }
+
+    @pytest.mark.asyncio
+    async def test_s3_delete_object_mock(self, s3_client: Any) -> None:
+        """delete_object calls delete_object for a single key."""
+        s3_client.client.delete_object.return_value = {}
+
+        await s3_client.delete_object(key="raw/a.pdf")
+
+        call_kwargs = s3_client.client.delete_object.call_args.kwargs
+        assert call_kwargs["Bucket"] == "test-bucket"
+        assert call_kwargs["Key"] == "raw/a.pdf"
+
+    @pytest.mark.asyncio
+    async def test_s3_head_object_mock(self, s3_client: Any) -> None:
+        """head_object returns metadata dict."""
+        s3_client.client.head_object.return_value = {
+            "ETag": '"abc123"',
+            "ContentLength": 1024,
+        }
+
+        result = await s3_client.head_object(key="index/catalog_index.json")
+
+        assert result["ETag"] == '"abc123"'
+        assert result["ContentLength"] == 1024
+
+    @pytest.mark.asyncio
+    async def test_s3_list_objects_no_bucket(self) -> None:
+        """list_objects raises S3DownloadError when bucket is not configured."""
+        from backend.app.s3_client import S3Client, S3DownloadError
+
+        client = S3Client(bucket_name="")
+        with pytest.raises(S3DownloadError, match="S3 bucket name not configured"):
+            await client.list_objects()
+
+    @pytest.mark.asyncio
+    async def test_s3_presigned_post_no_bucket(self) -> None:
+        """generate_presigned_post raises S3UploadError when bucket missing."""
+        from backend.app.s3_client import S3Client, S3UploadError
+
+        client = S3Client(bucket_name="")
+        with pytest.raises(S3UploadError, match="S3 bucket name not configured"):
+            await client.generate_presigned_post(key="raw/x.pdf")
+
+
+class TestSettingsReload:
+    """Atomicity and correctness of settings.reload()."""
+
+    def test_settings_reload_atomic(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """reload() swaps the _instance so new reads pick up changed env."""
+        monkeypatch.setenv("LLM_MODEL", "gpt-test-reload")
+        _reset_settings()
+
+        # Before reload, the old cached instance may still have the old value.
+        # We force instantiation first.
+        old_model = settings.llm_model
+
+        monkeypatch.setenv("LLM_MODEL", "gpt-reloaded-value")
+        settings.reload()
+
+        # After reload, the new instance should see the updated env.
+        assert settings.llm_model == "gpt-reloaded-value"
+
+        _reset_settings()
+
+    def test_settings_reload_concurrent_reads(self) -> None:
+        """Concurrent reads during reload do not crash.
+
+        Spins up multiple threads that read settings attributes while
+        reload() is called repeatedly.
+        """
+        import threading
+        import time
+
+        _reset_settings()
+
+        errors: list[Exception] = []
+        stop_event = threading.Event()
+
+        def reader() -> None:
+            while not stop_event.is_set():
+                try:
+                    _ = settings.llm_model
+                    _ = settings.aws_region
+                    _ = settings.admin_api_key
+                except Exception as exc:
+                    errors.append(exc)
+
+        def reloader() -> None:
+            for _ in range(50):
+                settings.reload()
+
+        threads = [threading.Thread(target=reader) for _ in range(4)]
+        for t in threads:
+            t.start()
+
+        reloader()
+
+        stop_event.set()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert not errors, f"Concurrent read errors: {errors}"
+
+        _reset_settings()

--- a/backend/main.py
+++ b/backend/main.py
@@ -33,6 +33,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
+from backend.app.admin_router import admin_router
 from backend.app.auth import verify_api_key
 from backend.app.catalog import CatalogError, get_catalog
 from backend.app.config import settings
@@ -124,11 +125,13 @@ app = FastAPI(title="ARTE Chatbot Backend")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],
+    allow_origins=["http://localhost:3000", "http://localhost:3001"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.include_router(admin_router)
 
 
 # Diagnostic logging for environment configuration


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega la base backend del panel administrativo: autenticación independiente, recarga de configuración, extensiones S3, schemas Pydantic y el router `/admin`. Este PR deja el backend listo para que los siguientes slices agreguen endpoints de dominio y UI.

## Issues relacionados

Closes #175
Part of #174

## Tipo de cambio

- [x] 🆕 Nueva funcionalidad (feature)
- [ ] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [x] 🧪 Tests
- [ ] 📄 Documentación / configuración
- [ ] 🔧 Infra / CI

## Chain Context

| Field | Value |
|-------|-------|
| Chain | Admin Panel MVP |
| Tracker | #174 |
| Position | 1 of 6 |
| Base | `feature/admin-panel` |
| Depends on | None |
| Follow-up | US-16 / Slice 2 |
| Review budget | 713 changed lines / 400 — `size:exception` requested |
| Starts at | tracker branch with no admin implementation |
| Ends with | backend admin foundation ready |

### Chain Overview

```text
main
 └── feature/admin-panel tracker (#174)
      └── 📍 Slice 1: Backend Foundation (#175)
           └── Slice 2: Backend Domain (#176)
                └── Slice 3: Dashboard + Bootstrap (#177)
                     └── Slice 4: Dashboard/Config/Escalation UI (#178)
                          └── Slice 5: S3/Catalog/Guides UI (#179)
                               └── Slice 6: Logs/Docker/CI (#180)
```

## Checklist antes de pedir review

- [x] El código corre localmente sin errores (tests pasan; build no ejecutado por regla del proyecto)
- [x] Los criterios de aceptación del issue relacionado están cumplidos
- [x] No hay credenciales, API keys ni rutas absolutas hardcodeadas
- [x] Si agregué dependencias nuevas, actualicé `requirements.txt` / `pyproject.toml` (no aplica)
- [x] Si modifiqué el schema del endpoint, verifiqué que `/docs` refleja los cambios mediante FastAPI schemas
- [x] Si modifiqué el harness o el dataset, corrí `python evaluation/harness.py` (no aplica)

## Cómo probar este PR

1. `uv run pytest backend/app/tests/test_admin_slice1.py -v`
2. Verificar `GET /admin/health` con `X-Admin-API-Key` válido.
3. Verificar que requests sin admin key devuelven 401 y con key inválida 403.

## Notas para el reviewer

- `size:exception` solicitado por los tests + schemas incluidos en el mismo work unit.
- El router se monta como `APIRouter(prefix="/admin")` y `app.include_router(admin_router)` para evitar `/admin/admin/health`.
