### PR TITLE
feat(admin): add catalog guides and logs endpoints

### DIFF
--- a/backend/app/admin_catalog.py
+++ b/backend/app/admin_catalog.py
@@ -1,0 +1,95 @@
+"""Admin catalog endpoints for managing the product catalog index."""
+
+import logging
+from typing import Annotated, Optional
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+
+from backend.app.admin_auth import verify_admin_key
+from backend.app.admin_schemas import CatalogIndex
+from backend.app.catalog import get_catalog, reload_catalog, save_catalog
+from backend.app.s3_client import S3Client, S3DownloadError
+
+logger = logging.getLogger(__name__)
+
+catalog_router = APIRouter()
+s3_client = S3Client()
+
+
+@catalog_router.get("/catalog", response_model=CatalogIndex)
+async def admin_get_catalog(
+    _admin_key: Annotated[str, Depends(verify_admin_key)],
+) -> CatalogIndex:
+    """Download and validate the current catalog index from S3.
+
+    Returns:
+        CatalogIndex model containing all products.
+    """
+    try:
+        catalog = get_catalog(force_reload=False)
+        products = [p.model_dump() for p in catalog.products]
+        return CatalogIndex(products=products)
+    except Exception as e:
+        logger.error("Failed to load catalog: %s", e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to load catalog index",
+        ) from e
+
+
+@catalog_router.put("/catalog", response_model=CatalogIndex)
+async def admin_put_catalog(
+    data: CatalogIndex,
+    _admin_key: Annotated[str, Depends(verify_admin_key)],
+    if_match: Optional[str] = Header(None),
+) -> CatalogIndex:
+    """Update the catalog index with optimistic locking.
+
+    Args:
+        data: The new catalog index.
+        if_match: ETag of the current catalog index for optimistic locking.
+
+    Returns:
+        The saved catalog index.
+
+    Raises:
+        HTTPException: 409 if ETag mismatch, 500 on S3 errors.
+    """
+    if if_match is not None:
+        try:
+            metadata = await s3_client.head_object("index/catalog_index.json")
+            current_etag = metadata.get("ETag", "")
+            if current_etag != if_match:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="Catalog index was modified by another user",
+                )
+        except S3DownloadError as e:
+            error_msg = str(e).lower()
+            if (
+                "not found" in error_msg
+                or "404" in error_msg
+                or "nosuchkey" in error_msg
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="Catalog index was modified by another user",
+                ) from e
+            logger.error("S3 head_object failed: %s", e)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to check catalog index version",
+            ) from e
+
+    try:
+        save_catalog(data.model_dump())
+        reload_catalog()
+        return data
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Failed to save catalog: %s", e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to save catalog index",
+        ) from e

--- a/backend/app/admin_guides.py
+++ b/backend/app/admin_guides.py
@@ -1,0 +1,217 @@
+"""Admin guides endpoints for managing markdown guide files."""
+
+import asyncio
+import logging
+import re
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from backend.app.admin_auth import verify_admin_key
+from backend.app.admin_schemas import GuideContent, GuideMeta
+from backend.app.s3_client import S3Client, S3DownloadError, S3UploadError
+
+logger = logging.getLogger(__name__)
+
+guides_router = APIRouter()
+s3_client = S3Client()
+
+GUIDES_PREFIX = "guides/"
+INTENT_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+def _sanitize_intent(intent: str) -> str:
+    """Validate intent string against allowed characters.
+
+    Args:
+        intent: The intent string to validate.
+
+    Returns:
+        The sanitized intent string.
+
+    Raises:
+        HTTPException: 422 if intent contains invalid characters.
+    """
+    if not INTENT_PATTERN.match(intent):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Invalid intent format: {intent}",
+        )
+    return intent
+
+
+@guides_router.get("/guides", response_model=list[GuideMeta])
+async def admin_list_guides(
+    _admin_key: Annotated[str, Depends(verify_admin_key)],
+) -> list[GuideMeta]:
+    """List all markdown guides under the guides/ prefix.
+
+    Returns:
+        List of GuideMeta objects.
+    """
+    try:
+        objects = await s3_client.list_objects(prefix=GUIDES_PREFIX)
+    except S3DownloadError as e:
+        logger.error("Failed to list guides: %s", e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list guides",
+        ) from e
+
+    guides: list[GuideMeta] = []
+    for obj in objects:
+        key: str = obj.get("Key", "")
+        if not key.endswith(".md"):
+            continue
+        filename = key.split("/")[-1]
+        intent = filename.replace(".md", "")
+        last_modified = obj.get("LastModified")
+        updated_at = None
+        if last_modified is not None:
+            try:
+                from datetime import datetime
+
+                if isinstance(last_modified, datetime):
+                    updated_at = last_modified.isoformat()
+                else:
+                    updated_at = str(last_modified)
+            except Exception:
+                updated_at = str(last_modified)
+        guides.append(
+            GuideMeta(
+                intent=intent,
+                title=intent.replace("_", " ").replace("-", " ").title(),
+                updated_at=updated_at,
+            )
+        )
+
+    return guides
+
+
+@guides_router.get("/guides/{intent}", response_model=GuideContent)
+async def admin_get_guide(
+    intent: str,
+    _admin_key: Annotated[str, Depends(verify_admin_key)],
+) -> GuideContent:
+    """Download a single guide markdown file.
+
+    Args:
+        intent: The guide intent identifier.
+
+    Returns:
+        GuideContent with the markdown text.
+
+    Raises:
+        HTTPException: 404 if guide not found.
+    """
+    sanitized = _sanitize_intent(intent)
+    key = f"{GUIDES_PREFIX}{sanitized}.md"
+
+    try:
+        data = await asyncio.to_thread(s3_client.download_pdf, key)
+    except S3DownloadError as e:
+        error_msg = str(e).lower()
+        if "not found" in error_msg or "nosuchkey" in error_msg:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Guide not found: {sanitized}",
+            ) from e
+        logger.error("Failed to download guide: %s", e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to download guide",
+        ) from e
+
+    content = data.decode("utf-8")
+    return GuideContent(intent=sanitized, content=content)
+
+
+@guides_router.put("/guides/{intent}", response_model=GuideContent)
+async def admin_update_guide(
+    intent: str,
+    data: GuideContent,
+    _admin_key: Annotated[str, Depends(verify_admin_key)],
+) -> GuideContent:
+    """Upload or overwrite a guide markdown file.
+
+    Args:
+        intent: The guide intent identifier.
+        data: GuideContent payload.
+
+    Returns:
+        The saved guide content.
+
+    Raises:
+        HTTPException: 422 if intent invalid or body empty.
+    """
+    sanitized = _sanitize_intent(intent)
+    if not data.content or not data.content.strip():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Guide content cannot be empty",
+        )
+
+    key = f"{GUIDES_PREFIX}{sanitized}.md"
+    body = data.content.encode("utf-8")
+
+    try:
+        await asyncio.to_thread(
+            s3_client.put_object,
+            key=key,
+            data=body,
+            content_type="text/markdown",
+        )
+    except S3UploadError as e:
+        logger.error("Failed to upload guide: %s", e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to save guide",
+        ) from e
+
+    return GuideContent(intent=sanitized, content=data.content)
+
+
+@guides_router.delete("/guides/{intent}")
+async def admin_delete_guide(
+    intent: str,
+    _admin_key: Annotated[str, Depends(verify_admin_key)],
+) -> dict[str, bool]:
+    """Delete a guide markdown file.
+
+    Args:
+        intent: The guide intent identifier.
+
+    Returns:
+        Confirmation dict with deleted=True.
+
+    Raises:
+        HTTPException: 404 if guide not found.
+    """
+    sanitized = _sanitize_intent(intent)
+    key = f"{GUIDES_PREFIX}{sanitized}.md"
+
+    try:
+        await s3_client.head_object(key)
+    except S3DownloadError as e:
+        error_msg = str(e).lower()
+        if "not found" in error_msg or "nosuchkey" in error_msg or "404" in error_msg:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Guide not found: {sanitized}",
+            ) from e
+        logger.error("Failed to check guide existence: %s", e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to verify guide existence",
+        ) from e
+
+    try:
+        await s3_client.delete_object(key)
+    except S3UploadError as e:
+        logger.error("Failed to delete guide: %s", e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to delete guide",
+        ) from e
+
+    return {"deleted": True}

--- a/backend/app/admin_logs.py
+++ b/backend/app/admin_logs.py
@@ -1,0 +1,88 @@
+"""Admin conversation logs endpoints."""
+
+import logging
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from backend.app.admin_auth import verify_admin_key
+from backend.app.admin_schemas import (
+    ConversationLogEntry,
+    ConversationLogSummary,
+    LogFilterParams,
+)
+from backend.app.conversation_logger import get_log, list_logs
+
+logger = logging.getLogger(__name__)
+
+logs_router = APIRouter()
+
+
+@logs_router.get("/logs")
+async def admin_list_logs(
+    _admin_key: Annotated[str, Depends(verify_admin_key)],
+    session_id: str | None = None,
+    intent_type: str | None = None,
+    escalated: bool | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """List conversation logs with optional filtering and pagination.
+
+    Query parameters mirror LogFilterParams fields.
+    """
+    filters = LogFilterParams(
+        session_id=session_id,
+        intent_type=intent_type,
+        escalated=escalated,
+        date_from=date_from,
+        date_to=date_to,
+        limit=limit,
+        offset=offset,
+    )
+    try:
+        summaries, total = await list_logs(filters)
+    except Exception as e:
+        logger.error("Failed to list logs: %s", e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list conversation logs",
+        ) from e
+
+    return {"items": summaries, "total": total}
+
+
+@logs_router.get("/logs/{session_id}", response_model=list[ConversationLogEntry])
+async def admin_get_log_detail(
+    session_id: str,
+    _admin_key: Annotated[str, Depends(verify_admin_key)],
+) -> list[ConversationLogEntry]:
+    """Retrieve the full transcript for a single session.
+
+    Args:
+        session_id: The session identifier.
+
+    Returns:
+        List of ConversationLogEntry sorted by turn_number.
+
+    Raises:
+        HTTPException: 404 if session has no logs.
+    """
+    try:
+        entries = await get_log(session_id)
+    except Exception as e:
+        logger.error("Failed to get log detail: %s", e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to retrieve session logs",
+        ) from e
+
+    if not entries:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Session not found: {session_id}",
+        )
+
+    return entries

--- a/backend/app/admin_router.py
+++ b/backend/app/admin_router.py
@@ -8,8 +8,15 @@ from typing import Annotated
 from fastapi import APIRouter, Depends
 
 from backend.app.admin_auth import verify_admin_key
+from backend.app.admin_catalog import catalog_router
+from backend.app.admin_guides import guides_router
+from backend.app.admin_logs import logs_router
 
 admin_router = APIRouter(prefix="/admin")
+
+admin_router.include_router(catalog_router)
+admin_router.include_router(guides_router)
+admin_router.include_router(logs_router)
 
 
 @admin_router.get("/health")

--- a/backend/app/catalog.py
+++ b/backend/app/catalog.py
@@ -117,6 +117,27 @@ class Catalog:
 _catalog_instance: Optional[Catalog] = None
 
 
+def save_catalog(index_data: dict, etag: Optional[str] = None) -> None:
+    """Serialize catalog index to JSON and upload to S3.
+
+    Args:
+        index_data: Dictionary representing the catalog index.
+        etag: Optional ETag for conditional upload (optimistic locking
+            is handled by the caller before invoking this function).
+    """
+    json_bytes = json.dumps(index_data, ensure_ascii=False, indent=2).encode("utf-8")
+    s3_client.put_object(
+        key=CATALOG_INDEX_PATH,
+        data=json_bytes,
+        content_type="application/json",
+    )
+
+
+def reload_catalog() -> None:
+    """Invalidate the cached catalog and force a reload from S3."""
+    get_catalog(force_reload=True)
+
+
 def get_catalog(force_reload: bool = False) -> Catalog:
     """
     Get the singleton catalog instance. Loads from S3 if not already loaded.

--- a/backend/app/conversation_logger.py
+++ b/backend/app/conversation_logger.py
@@ -5,14 +5,20 @@ conversation is serialized as a Pydantic model and uploaded to S3
 as a JSON file. Failures are caught silently to never block responses.
 """
 
+import asyncio
 import logging
-from typing import Optional
+from collections import defaultdict
+from typing import Optional, Tuple
 
 from pydantic import BaseModel, Field
 
+from backend.app.admin_schemas import ConversationLogSummary, LogFilterParams
+from backend.app.config import settings
 from backend.app.s3_client import S3Client
 
 logger = logging.getLogger(__name__)
+
+_log_reader_s3 = S3Client()
 
 
 class ConversationLogEntry(BaseModel):
@@ -105,8 +111,6 @@ class ConversationLogger:
             entry: The conversation log entry to log.
         """
         try:
-            import asyncio
-
             await asyncio.to_thread(self._upload, entry)
         except Exception:
             logger.warning(
@@ -115,3 +119,96 @@ class ConversationLogger:
                 entry.turn_number,
                 exc_info=True,
             )
+
+
+async def list_logs(
+    filters: LogFilterParams,
+) -> Tuple[list[ConversationLogSummary], int]:
+    """List and filter conversation logs from S3.
+
+    Args:
+        filters: Filtering and pagination parameters.
+
+    Returns:
+        Tuple of (paginated summaries, total count).
+    """
+    prefix = f"{settings.conversation_log_prefix}/"
+    objects = await _log_reader_s3.list_objects(prefix=prefix)
+
+    entries: list[ConversationLogEntry] = []
+    for obj in objects:
+        key = obj.get("Key", "")
+        if not key.endswith(".json"):
+            continue
+        try:
+            data = await asyncio.to_thread(_log_reader_s3.download_pdf, key)
+            entry = ConversationLogEntry.model_validate_json(data)
+            entries.append(entry)
+        except Exception:
+            continue
+
+    filtered = entries
+    if filters.session_id:
+        filtered = [e for e in filtered if e.session_id == filters.session_id]
+    if filters.intent_type:
+        filtered = [e for e in filtered if e.intent_type == filters.intent_type]
+    if filters.escalated is not None:
+        filtered = [e for e in filtered if e.escalate == filters.escalated]
+    if filters.date_from:
+        filtered = [e for e in filtered if e.timestamp >= filters.date_from]
+    if filters.date_to:
+        filtered = [e for e in filtered if e.timestamp <= filters.date_to]
+
+    sessions: dict[str, list[ConversationLogEntry]] = defaultdict(list)
+    for e in filtered:
+        sessions[e.session_id].append(e)
+
+    summaries: list[ConversationLogSummary] = []
+    for session_id, session_entries in sessions.items():
+        sorted_entries = sorted(session_entries, key=lambda x: x.turn_number)
+        intent_types = list({e.intent_type for e in sorted_entries})
+        escalated = any(e.escalate for e in sorted_entries)
+        last_ts = sorted_entries[-1].timestamp if sorted_entries else None
+        summaries.append(
+            ConversationLogSummary(
+                session_id=session_id,
+                turn_count=len(sorted_entries),
+                last_timestamp=last_ts,
+                intent_types=intent_types,
+                escalated=escalated,
+            )
+        )
+
+    summaries.sort(key=lambda s: s.last_timestamp or "", reverse=True)
+
+    total = len(summaries)
+    paginated = summaries[filters.offset : filters.offset + filters.limit]
+    return paginated, total
+
+
+async def get_log(session_id: str) -> list[ConversationLogEntry]:
+    """Retrieve the full transcript for a session.
+
+    Args:
+        session_id: The session identifier.
+
+    Returns:
+        List of ConversationLogEntry sorted by turn_number.
+    """
+    prefix = f"{settings.conversation_log_prefix}/{session_id}/"
+    objects = await _log_reader_s3.list_objects(prefix=prefix)
+
+    entries: list[ConversationLogEntry] = []
+    for obj in objects:
+        key = obj.get("Key", "")
+        if not key.endswith(".json"):
+            continue
+        try:
+            data = await asyncio.to_thread(_log_reader_s3.download_pdf, key)
+            entry = ConversationLogEntry.model_validate_json(data)
+            entries.append(entry)
+        except Exception:
+            continue
+
+    entries.sort(key=lambda e: e.turn_number)
+    return entries

--- a/backend/app/tests/test_admin_slice2.py
+++ b/backend/app/tests/test_admin_slice2.py
@@ -1,0 +1,367 @@
+"""Tests for Slice 2: Backend Domain — Catalog + Guides + Logs.
+
+Covers:
+- Catalog CRUD with optimistic locking (ETag)
+- Guides CRUD with intent sanitization
+- Conversation logs listing, filtering, and detail retrieval
+"""
+
+import json
+from datetime import datetime
+from typing import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.app.config import settings
+from backend.app.conversation_logger import ConversationLogEntry
+
+
+def _reset_settings() -> None:
+    """Reset the settings proxy so next access reads fresh env."""
+    settings.reset()
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, None, None]:
+    """FastAPI TestClient with admin key configured."""
+    monkeypatch.setenv("ADMIN_API_KEY", "test-admin-key")
+    _reset_settings()
+
+    from backend.main import app
+
+    with TestClient(app) as tc:
+        yield tc
+
+    _reset_settings()
+
+
+@pytest.fixture(autouse=True)
+def reset_catalog() -> Generator[None, None, None]:
+    """Reset the catalog singleton between tests."""
+    from backend.app import catalog as catalog_module
+
+    catalog_module._catalog_instance = None
+    yield
+    catalog_module._catalog_instance = None
+
+
+class TestCatalog:
+    """Tests for GET /admin/catalog and PUT /admin/catalog."""
+
+    def test_get_catalog(self, client: TestClient) -> None:
+        """GET /admin/catalog returns parsed catalog index."""
+        catalog_data = {
+            "products": [
+                {
+                    "nombre_comercial": "Panel X",
+                    "fabricante": "TestCo",
+                    "categoria": "paneles",
+                    "ruta_s3": "raw/paneles/x.pdf",
+                    "variantes": [{"modelo": "X-100", "parametros_clave": {}}],
+                }
+            ]
+        }
+        with patch("backend.app.catalog.s3_client") as mock_s3:
+            mock_s3.download_pdf = MagicMock(
+                return_value=json.dumps(catalog_data).encode("utf-8")
+            )
+            response = client.get(
+                "/admin/catalog",
+                headers={"X-Admin-API-Key": "test-admin-key"},
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert len(data["products"]) == 1
+            assert data["products"][0]["nombre_comercial"] == "Panel X"
+
+    def test_put_catalog_optimistic_lock(self, client: TestClient) -> None:
+        """PUT /admin/catalog with matching ETag succeeds and reloads cache."""
+        catalog_data = {
+            "products": [
+                {
+                    "nombre_comercial": "Panel Y",
+                    "fabricante": "TestCo",
+                    "categoria": "inversores",
+                    "ruta_s3": "raw/inv/y.pdf",
+                    "variantes": [],
+                }
+            ]
+        }
+        with (
+            patch("backend.app.catalog.s3_client") as mock_cat_s3,
+            patch("backend.app.admin_catalog.s3_client") as mock_adm_s3,
+        ):
+            mock_cat_s3.download_pdf = MagicMock(
+                return_value=json.dumps(catalog_data).encode("utf-8")
+            )
+            mock_cat_s3.put_object = MagicMock(return_value=None)
+            mock_adm_s3.head_object = AsyncMock(return_value={"ETag": '"abc123"'})
+
+            response = client.put(
+                "/admin/catalog",
+                headers={
+                    "X-Admin-API-Key": "test-admin-key",
+                    "If-Match": '"abc123"',
+                },
+                json=catalog_data,
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert data["products"][0]["nombre_comercial"] == "Panel Y"
+            mock_adm_s3.head_object.assert_awaited_once()
+            mock_cat_s3.put_object.assert_called_once()
+
+    def test_put_catalog_etag_mismatch(self, client: TestClient) -> None:
+        """PUT /admin/catalog with mismatched ETag returns 409 Conflict."""
+        with patch("backend.app.admin_catalog.s3_client") as mock_s3:
+            mock_s3.head_object = AsyncMock(return_value={"ETag": '"different"'})
+            response = client.put(
+                "/admin/catalog",
+                headers={
+                    "X-Admin-API-Key": "test-admin-key",
+                    "If-Match": '"abc123"',
+                },
+                json={"products": []},
+            )
+            assert response.status_code == 409
+            assert "modified by another user" in response.json()["detail"]
+
+    def test_put_catalog_validation_error(self, client: TestClient) -> None:
+        """PUT /admin/catalog with invalid body returns 422."""
+        response = client.put(
+            "/admin/catalog",
+            headers={"X-Admin-API-Key": "test-admin-key"},
+            json={"products": [{"nombre_comercial": "X"}]},
+        )
+        assert response.status_code == 422
+
+
+class TestGuides:
+    """Tests for guides CRUD endpoints."""
+
+    def test_list_guides(self, client: TestClient) -> None:
+        """GET /admin/guides lists markdown files under guides/."""
+        with patch("backend.app.admin_guides.s3_client") as mock_s3:
+            mock_s3.list_objects = AsyncMock(
+                return_value=[
+                    {
+                        "Key": "guides/faq.md",
+                        "LastModified": datetime(2026, 5, 1, 10, 0, 0),
+                    },
+                    {
+                        "Key": "guides/pricing.md",
+                        "LastModified": datetime(2026, 5, 2, 10, 0, 0),
+                    },
+                    {"Key": "guides/other.txt"},
+                ]
+            )
+            response = client.get(
+                "/admin/guides",
+                headers={"X-Admin-API-Key": "test-admin-key"},
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert len(data) == 2
+            intents = {g["intent"] for g in data}
+            assert intents == {"faq", "pricing"}
+
+    def test_get_guide(self, client: TestClient) -> None:
+        """GET /admin/guides/{intent} returns markdown content."""
+        with patch("backend.app.admin_guides.s3_client") as mock_s3:
+            mock_s3.download_pdf = MagicMock(
+                return_value=b"# FAQ\n\nThis is the FAQ."
+            )
+            response = client.get(
+                "/admin/guides/faq",
+                headers={"X-Admin-API-Key": "test-admin-key"},
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert data["intent"] == "faq"
+            assert "# FAQ" in data["content"]
+
+    def test_update_guide(self, client: TestClient) -> None:
+        """PUT /admin/guides/{intent} uploads markdown to S3."""
+        with patch("backend.app.admin_guides.s3_client") as mock_s3:
+            mock_s3.put_object = MagicMock(return_value=None)
+            response = client.put(
+                "/admin/guides/faq",
+                headers={"X-Admin-API-Key": "test-admin-key"},
+                json={"intent": "faq", "content": "# Updated FAQ"},
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert data["content"] == "# Updated FAQ"
+            mock_s3.put_object.assert_called_once()
+
+    def test_delete_guide(self, client: TestClient) -> None:
+        """DELETE /admin/guides/{intent} removes the file from S3."""
+        with patch("backend.app.admin_guides.s3_client") as mock_s3:
+            mock_s3.head_object = AsyncMock(return_value={"ETag": '"x"'})
+            mock_s3.delete_object = AsyncMock(return_value=None)
+            response = client.delete(
+                "/admin/guides/faq",
+                headers={"X-Admin-API-Key": "test-admin-key"},
+            )
+            assert response.status_code == 200
+            assert response.json() == {"deleted": True}
+            mock_s3.head_object.assert_awaited_once()
+            mock_s3.delete_object.assert_awaited_once()
+
+    def test_delete_guide_not_found(self, client: TestClient) -> None:
+        """DELETE /admin/guides/{intent} returns 404 when guide missing."""
+        from backend.app.s3_client import S3DownloadError
+
+        with patch("backend.app.admin_guides.s3_client") as mock_s3:
+            mock_s3.head_object = AsyncMock(
+                side_effect=S3DownloadError("NoSuchKey")
+            )
+            response = client.delete(
+                "/admin/guides/faq",
+                headers={"X-Admin-API-Key": "test-admin-key"},
+            )
+            assert response.status_code == 404
+            assert "Guide not found" in response.json()["detail"]
+
+
+class TestLogs:
+    """Tests for conversation logs endpoints."""
+
+    def test_list_logs_filtered(self, client: TestClient) -> None:
+        """GET /admin/logs with filters returns correct summaries."""
+        entry1 = ConversationLogEntry(
+            session_id="sess1",
+            turn_number=1,
+            timestamp="2026-05-01T10:00:00Z",
+            user_message="hi",
+            bot_response="hello",
+            intent_type="FAQ",
+            escalate=False,
+            input_tokens=10,
+            output_tokens=5,
+            total_tokens=15,
+            response_time_ms=100.0,
+            model="gpt-4",
+            git_commit_hash="abc",
+        )
+        entry2 = ConversationLogEntry(
+            session_id="sess1",
+            turn_number=2,
+            timestamp="2026-05-01T10:05:00Z",
+            user_message="bye",
+            bot_response="goodbye",
+            intent_type="FAQ",
+            escalate=True,
+            input_tokens=5,
+            output_tokens=5,
+            total_tokens=10,
+            response_time_ms=50.0,
+            model="gpt-4",
+            git_commit_hash="abc",
+        )
+        entry3 = ConversationLogEntry(
+            session_id="sess2",
+            turn_number=1,
+            timestamp="2026-05-02T10:00:00Z",
+            user_message="hello",
+            bot_response="hi",
+            intent_type="product_info",
+            escalate=False,
+            input_tokens=8,
+            output_tokens=4,
+            total_tokens=12,
+            response_time_ms=80.0,
+            model="gpt-4",
+            git_commit_hash="abc",
+        )
+
+        with patch("backend.app.conversation_logger._log_reader_s3") as mock_s3:
+            mock_s3.list_objects = AsyncMock(
+                return_value=[
+                    {"Key": "conversations/sess1/1_2026-05-01T10:00:00Z.json"},
+                    {"Key": "conversations/sess1/2_2026-05-01T10:05:00Z.json"},
+                    {"Key": "conversations/sess2/1_2026-05-02T10:00:00Z.json"},
+                ]
+            )
+
+            def mock_download(key: str) -> bytes:
+                if "sess1/1_" in key:
+                    return entry1.model_dump_json().encode("utf-8")
+                elif "sess1/2_" in key:
+                    return entry2.model_dump_json().encode("utf-8")
+                elif "sess2/1_" in key:
+                    return entry3.model_dump_json().encode("utf-8")
+                return b"{}"
+
+            mock_s3.download_pdf = MagicMock(side_effect=mock_download)
+
+            response = client.get(
+                "/admin/logs?escalated=true",
+                headers={"X-Admin-API-Key": "test-admin-key"},
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert data["total"] == 1
+            assert len(data["items"]) == 1
+            assert data["items"][0]["session_id"] == "sess1"
+            assert data["items"][0]["escalated"] is True
+
+    def test_get_log_detail(self, client: TestClient) -> None:
+        """GET /admin/logs/{session_id} returns sorted transcript."""
+        entry1 = ConversationLogEntry(
+            session_id="sess1",
+            turn_number=1,
+            timestamp="2026-05-01T10:00:00Z",
+            user_message="hi",
+            bot_response="hello",
+            intent_type="FAQ",
+            escalate=False,
+            input_tokens=10,
+            output_tokens=5,
+            total_tokens=15,
+            response_time_ms=100.0,
+            model="gpt-4",
+            git_commit_hash="abc",
+        )
+        entry2 = ConversationLogEntry(
+            session_id="sess1",
+            turn_number=2,
+            timestamp="2026-05-01T10:05:00Z",
+            user_message="bye",
+            bot_response="goodbye",
+            intent_type="FAQ",
+            escalate=False,
+            input_tokens=5,
+            output_tokens=5,
+            total_tokens=10,
+            response_time_ms=50.0,
+            model="gpt-4",
+            git_commit_hash="abc",
+        )
+
+        with patch("backend.app.conversation_logger._log_reader_s3") as mock_s3:
+            mock_s3.list_objects = AsyncMock(
+                return_value=[
+                    {"Key": "conversations/sess1/2_2026-05-01T10:05:00Z.json"},
+                    {"Key": "conversations/sess1/1_2026-05-01T10:00:00Z.json"},
+                ]
+            )
+
+            def mock_download(key: str) -> bytes:
+                if "1_" in key:
+                    return entry1.model_dump_json().encode("utf-8")
+                return entry2.model_dump_json().encode("utf-8")
+
+            mock_s3.download_pdf = MagicMock(side_effect=mock_download)
+
+            response = client.get(
+                "/admin/logs/sess1",
+                headers={"X-Admin-API-Key": "test-admin-key"},
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert len(data) == 2
+            assert data[0]["turn_number"] == 1
+            assert data[1]["turn_number"] == 2

--- a/openspec/changes/admin-panel-mvp/design.md
+++ b/openspec/changes/admin-panel-mvp/design.md
@@ -1,0 +1,805 @@
+# Design: Admin Panel MVP
+
+> **Artifact**: `openspec/changes/admin-panel-mvp/design.md`  
+> **Change**: admin-panel-mvp  
+> **Format**: OpenSpec delta design  
+> **Standard**: RFC 2119 (MUST / SHALL / SHOULD / MAY)
+
+---
+
+## 1. Arquitectura de Alto Nivel
+
+### 1.1 Flujo de Datos
+
+```mermaid
+graph LR
+    subgraph Browser["Admin Browser"]
+        A[Next.js 16 App Router]
+    end
+
+    subgraph Backend["FastAPI Backend"]
+        B[Admin Router /admin/*]
+        C[verify_admin_key]
+        D[SessionManager]
+        E[SettingsProxy]
+        F[S3Client]
+        G[CatalogManager]
+        H[ConversationLogger]
+    end
+
+    subgraph Storage["AWS S3"]
+        S1[index/catalog_index.json]
+        S2[raw/ PDFs]
+        S3[guides/ .md]
+        S4[conversations/ JSON]
+        S5[config via env vars]
+    end
+
+    A -- X-Admin-API-Key --> B
+    B -- depends --> C
+    B -- metrics --> D
+    B -- hot reload --> E
+    B -- list/upload/delete --> F
+    B -- read/write --> S1
+    B -- read/write --> S3
+    B -- read --> S4
+    F -- presigned POST --> S2
+    F -- get_object/put_object --> S1
+    F -- list_objects_v2 --> S2
+    F -- list_objects_v2 --> S3
+    F -- list_objects_v2 --> S4
+```
+
+### 1.2 Diagrama de Despliegue
+
+```mermaid
+graph TB
+    subgraph Host["Docker Host"]
+        subgraph Network["arte-chatbot_default"]
+            FE["admin-panel<br/>Next.js 16 standalone<br/>Port: 3000 (container) → 3001 (host)"]
+            BE["backend<br/>FastAPI + Admin Routers<br/>Port: 8000"]
+            FE2["frontend<br/>Chat UI<br/>Port: 3000"]
+        end
+    end
+    S3[(AWS S3<br/>arte-chatbot-data)]
+    BE --> S3
+    FE --> BE
+    FE2 --> BE
+```
+
+### 1.3 Separacion de Responsabilidades
+
+| Capa | Responsabilidad | Tecnologia |
+|------|----------------|------------|
+| **Frontend** | UI/UX, formularios, tablas, charts, routing client-side, auth guard. Nunca toca S3 directamente salvo presigned POST. | Next.js 16, React, Tailwind, shadcn/ui |
+| **Backend** | Auth, validacion Pydantic, orquestacion de S3, agregacion de metricas, hot reload de settings. | FastAPI, Python 3.11 |
+| **S3** | Fuente de verdad para catalogo, fichas tecnicas, guias markdown, logs de conversacion. | AWS S3 via boto3 |
+
+---
+
+## 2. Diseno del Backend (FastAPI)
+
+### 2.1 Estructura de Modulos
+
+#### Archivos Nuevos
+
+| Archivo | Responsabilidad |
+|---------|----------------|
+| `backend/app/admin_router.py` | Router principal `APIRouter(prefix="/admin")` que agrupa todos los sub-routers via `include_router`. |
+| `backend/app/admin_schemas.py` | Modelos Pydantic v2 del dominio admin: `CatalogIndex`, `GuideMeta`, `DashboardMetrics`, `MutableSettings`, `S3TreeNode`, etc. |
+| `backend/app/admin_auth.py` | `verify_admin_key` dependency usando `APIKeyHeader(name="X-Admin-API-Key")` y `hmac.compare_digest`. |
+| `backend/app/admin_dashboard.py` | Endpoints `GET /admin/dashboard/metrics`. Agrega datos de `SessionManager` + scan S3 `conversations/`. |
+| `backend/app/admin_s3.py` | Endpoints `GET /admin/s3/tree`, `POST /admin/s3/presigned-upload`, `DELETE /admin/s3/objects`. |
+| `backend/app/admin_catalog.py` | Endpoints `GET /admin/catalog`, `PUT /admin/catalog` con ETag optimistic locking. |
+| `backend/app/admin_guides.py` | Endpoints `GET /admin/guides`, `GET /admin/guides/{intent}`, `PUT /admin/guides/{intent}`, `DELETE /admin/guides/{intent}`. |
+| `backend/app/admin_config.py` | Endpoints `GET /admin/config`, `PUT /admin/config`. Expone snapshot mutable/inmutable. |
+| `backend/app/admin_logs.py` | Endpoints `GET /admin/logs`, `GET /admin/logs/{session_id}`. Filtrado + paginacion en memoria. |
+
+#### Archivos Modificados
+
+| Archivo | Cambios |
+|---------|---------|
+| `backend/app/auth.py` | Agregar `ADMIN_API_KEY_HEADER` y `verify_admin_key()`; reutilizar `hmac.compare_digest` del patron existente. |
+| `backend/app/config.py` | Agregar campo `admin_api_key: Optional[str]`. Agregar metodo `reload()` a `_SettingsProxy` que cree nueva instancia `Settings()` y la swappee atomicamente. |
+| `backend/app/s3_client.py` | Agregar `list_objects()`, `delete_object()`, `delete_objects()`, `generate_presigned_post()`, `head_object()`. |
+| `backend/app/catalog.py` | Agregar `save_catalog(index_data: dict, etag: Optional[str])` y `reload_catalog()`. `get_catalog(force_reload=True)` ya existe; expandir su uso. |
+| `backend/app/session.py` | Agregar `get_all_token_totals()`, `get_intent_distribution()`, `get_escalation_rate()` para agregacion de metricas. |
+| `backend/app/conversation_logger.py` | Agregar `list_logs(filters)`, `get_log(session_id)` para lectura desde S3 prefix `conversations/`. |
+| `backend/main.py` | Importar y montar `admin_router` con `app.include_router(admin_router, prefix="/admin")`. Agregar origen `http://localhost:3001` a `CORSMiddleware`. |
+
+### 2.2 Diagrama de Clases / Protocolos
+
+```text
+┌──────────────────────┐
+│   AdminAuthDep       │  ← dependency
+│   verify_admin_key() │     returns str (the key)
+└──────────┬───────────┘
+           │ injected into every admin endpoint
+┌──────────▼───────────┐     ┌──────────────────────┐
+│   S3Client           │     │   SettingsProxy      │
+│   + list_objects()   │     │   + reload()         │
+│   + delete_object()  │     │   + get_snapshot()   │
+│   + delete_objects() │     │   - _instance swap   │
+│   + generate_presigned_post()     └──────────┬───────────┘
+│   + head_object()    │                       │
+│   + put_object()     │                       │
+└──────────┬───────────┘                       │
+           │                                   │
+┌──────────▼───────────┐     ┌─────────────────┴──────────┐
+│ SessionManager       │     │   CatalogManager           │
+│ + get_session_count()│     │   + save_catalog()         │
+│ + get_all_token_totals()    │   + reload_catalog()       │
+│ + get_intent_distribution() │   - get_catalog(force=True)│
+│ + get_escalation_rate()     └────────────────────────────┘
+└──────────┬───────────┘
+           │
+┌──────────▼───────────┐
+│ ConversationLogger   │
+│ + list_logs()        │
+│ + get_log(session_id)│
+└──────────────────────┘
+```
+
+**Tipos de retorno clave:**
+- `verify_admin_key` → `str` (la API key validada).
+- `S3Client.list_objects(prefix)` → `List[Dict[str, Any]]` (raw boto3 Contents).
+- `S3Client.generate_presigned_post(...)` → `Dict[str, Any]` (url, fields).
+- `SessionManager.get_all_token_totals()` → `Dict[str, TokenTotals]`.
+- `SettingsProxy.reload()` → `None` (side effect: atomic swap).
+
+### 2.3 Flujos de Datos Detallados
+
+#### Dashboard
+1. `GET /admin/dashboard/metrics` recibe request con `X-Admin-API-Key`.
+2. `verify_admin_key` valida contra `settings.admin_api_key`.
+3. Endpoint llama `session_manager.get_session_count()` y `get_all_token_totals()`.
+4. Para escalation rate e intent distribution: escanea S3 prefix `conversations/` (ultimas 24h), parsea JSONs, agrega. Si >1000 objetos, usa sampling o cached aggregate.
+5. Construye `DashboardMetrics` y responde 200.
+
+#### S3 Explorer
+1. `GET /admin/s3/tree?prefix=raw/` → valida prefix (no `..`, no absoluto).
+2. `s3_client.list_objects(prefix=prefix)` devuelve lista plana de boto3.
+3. Backend construye arbol jerarquico dividiendo `Key` por `/`.
+4. Serializa a `List[S3TreeNode]` y responde.
+
+#### Catalog CRUD
+1. `GET /admin/catalog` → `s3_client.download_pdf("index/catalog_index.json")` (o nuevo `get_object`).
+2. Parsea bytes a dict, valida con `CatalogIndex` Pydantic, responde.
+3. `PUT /admin/catalog` → valida body `CatalogIndex`.
+4. (Optimistic locking) Si header `If-Match` presente, compara ETag via `head_object`.
+5. Si mismatch → 409 Conflict.
+6. Serializa a JSON bytes, `s3_client.put_object(key="index/catalog_index.json", data=bytes)`.
+7. Invalida cache: `get_catalog(force_reload=True)`.
+8. Responde con catalogo guardado.
+
+#### Guides
+1. `GET /admin/guides` → `list_objects(prefix="guides/")`, filtra `.md`, extrae `intent` de filename.
+2. `GET /admin/guides/{intent}` → sanitiza intent (regex `^[a-zA-Z0-9_-]+$`), descarga `guides/{intent}.md`.
+3. `PUT /admin/guides/{intent}` → valida body `GuideContent`, sanitiza intent, `put_object` con `content_type="text/markdown"`.
+4. `DELETE /admin/guides/{intent}` → `head_object` para verificar existencia, luego `delete_object`.
+
+#### Config (Hot Reload)
+1. `GET /admin/config` → lee `settings` proxy, divide en `MutableSettings` e `ImmutableSettings`, responde `CurrentSettingsSnapshot`.
+2. `PUT /admin/config` → valida body `MutableSettings` (partial updates permitidos).
+3. Actualiza variables de entorno internas o estado del proxy.
+4. Llama `settings.reload()` → crea nueva instancia `Settings()`, asigna a `_instance`.
+5. Responde nuevo snapshot.
+
+#### Logs
+1. `GET /admin/logs` → `list_objects(prefix="conversations/")` paginado.
+2. Filtra en memoria por `date_from`, `date_to`, `intent_type`, `escalated`.
+3. Agrupa por `session_id`, resume en `ConversationLogSummary`.
+4. Aplica `limit`/`offset`.
+5. `GET /admin/logs/{session_id}` → lista objetos bajo `conversations/{session_id}/`, descarga cada JSON, parsea `ConversationLogEntry`, ordena por `turn_number`.
+
+### 2.4 Manejo de Errores y Seguridad
+
+- **Auth**: `hmac.compare_digest(admin_key, valid_key)` para evitar timing attacks. Retorna 401 (missing), 403 (invalid), 503 (not configured).
+- **Sanitizacion S3**: Regex `^[a-zA-Z0-9_\-/]+(\.[a-zA-Z0-9]+)?$`. Rechaza `..`, paths absolutos (`/`), y prefijos no permitidos (`raw/`, `guides/`, `index/` solo para escritura).
+- **Optimistic Locking Catalog**: Cliente envia `If-Match` con ETag previo. Backend hace `head_object` antes de `put_object`. Mismatch → 409.
+- **Rate Limiting**: No en MVP. En v2 se puede agregar `slowapi` con limites por IP/admin key.
+
+---
+
+## 3. Diseno del Frontend (Next.js 16)
+
+### 3.1 Arquitectura de Componentes
+
+```text
+AdminLayout (app/admin/layout.tsx)
+├── Sidebar (navegacion fija)
+├── Header (titulo + logout)
+├── AuthGuard (redirect a /admin/login si no hay key)
+└── children
+    ├── DashboardPage (app/admin/dashboard/page.tsx)
+    │   ├── StatsCards
+    │   ├── IntentChart (Recharts Pie)
+    │   └── EscalationChart (Recharts Line)
+    ├── CatalogPage (app/admin/catalog/page.tsx)
+    │   ├── DataTable<CatalogProduct>
+    │   └── ProductFormDialog
+    ├── GuidesPage (app/admin/guides/page.tsx)
+    │   └── DataTable<GuideMeta>
+    ├── GuideEditorPage (app/admin/guides/[intent]/page.tsx)
+    │   ├── MarkdownEditor (@uiw/react-md-editor)
+    │   └── MarkdownPreview (react-markdown)
+    ├── S3ExplorerPage (app/admin/s3-explorer/page.tsx)
+    │   ├── S3Tree (recursivo + shadcn Collapsible)
+    │   ├── UploadDialog
+    │   └── DeleteConfirmDialog
+    ├── ConfigPage (app/admin/config/page.tsx)
+    │   └── ConfigForm (React Hook Form + Zod)
+    ├── EscalationPage (app/admin/escalation/page.tsx)
+    │   └── EscalationForm (slider + tag input)
+    └── LogsPage (app/admin/logs/page.tsx)
+        ├── DataTable<ConversationLogSummary>
+        ├── LogFilterBar
+        └── LogDetailDrawer (ChatTranscript)
+```
+
+### 3.2 Capa de API / State
+
+#### `lib/api.ts` — TanStack Query Hooks
+
+```typescript
+// Ejemplo de hook pattern para cada recurso
+export function useDashboardMetrics() {
+  return useQuery({
+    queryKey: ["admin", "dashboard", "metrics"],
+    queryFn: async () => {
+      const res = await fetch(`${API_URL}/admin/dashboard/metrics`, {
+        headers: { "X-Admin-API-Key": getAdminKey() },
+      });
+      if (!res.ok) throw new Error(await res.text());
+      return res.json() as Promise<DashboardMetrics>;
+    },
+    staleTime: 30_000,
+  });
+}
+
+// Mutations invalidan cache tras exito
+export function useUpdateCatalog() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: CatalogIndex) => { ... },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin", "catalog"] });
+      toast.success("Catalogo guardado");
+    },
+  });
+}
+```
+
+#### `lib/types.ts` — TypeScript Interfaces
+
+Mapeo 1:1 desde Pydantic v2 a TypeScript/Zod:
+- `CatalogProduct`, `CatalogIndex`, `GuideMeta`, `GuideContent`
+- `DashboardMetrics`, `ConversationLogSummary`, `ConversationLogEntry`
+- `MutableSettings`, `CurrentSettingsSnapshot`, `S3TreeNode`
+- `PresignedUploadRequest`, `PresignedUploadResponse`
+
+#### Estrategia de Fetching: Server vs Client Components
+
+- **Server Components**: Practicamente ninguna pagina admin sera Server Component porque requieren auth dinamica (API key en `localStorage`, no cookie) y mutaciones interactivas. El `AdminLayout` puede ser un Server Component que envuelve un Client Component para el auth guard.
+- **Client Components**: Todas las paginas bajo `app/admin/*` usan `"use client"` + TanStack Query para fetching, caching y mutaciones.
+
+#### Estrategia de Cache
+
+- `staleTime`: 30s para metricas, 60s para catalogo/config, 0 para logs.
+- `cacheTime` (gcTime en v5): 5 minutos para datos pesados.
+- Invalidacion manual post-mutacion: `queryClient.invalidateQueries({ queryKey: ["admin", "catalog"] })`.
+
+### 3.3 Autenticacion y Routing
+
+#### `AdminAuthProvider` (providers/admin-auth-provider.tsx)
+
+```typescript
+interface AdminAuthContextType {
+  apiKey: string | null;
+  setApiKey: (key: string) => void;
+  logout: () => void;
+  isAuthenticated: boolean;
+}
+```
+
+- Lee `arte_admin_key` de `localStorage` en `useEffect` (mount del cliente).
+- Expone `setApiKey` que persiste en `localStorage` y actualiza estado React.
+- `logout` limpia `localStorage`, invalida `QueryClient`, redirige a `/admin/login`.
+
+#### `useAdminAuth()` Hook
+
+Consumer del contexto. Usado por `queryFn` para inyectar header dinamicamente.
+
+#### Auth Guard
+
+- `app/admin/layout.tsx`: Client Component que consume `useAdminAuth()`. Si `!isAuthenticated`, `router.replace("/admin/login")`.
+- `app/admin/login/page.tsx`: Client Component. Si `isAuthenticated`, redirige a `/admin/dashboard`.
+
+#### Middleware `middleware.ts`
+
+```typescript
+// Recomendado para evitar flash de contenido no autenticado
+import { NextResponse } from "next/server";
+import type { NextRequest };
+
+export function middleware(request: NextRequest) {
+  const adminKey = request.cookies.get("arte_admin_key")?.value;
+  // Nota: localStorage no es accesible en middleware.
+  // Opcion A: Duplicar key en cookie (mas seguro con httpOnly en v2).
+  // Opcion B: Dejar el guard en layout.tsx y aceptar el flash.
+  // Decision MVP: Sin middleware para auth; guard 100% en layout.tsx.
+}
+```
+
+> **Nota de arquitectura**: En MVP no usamos `middleware.ts` para proteccion de auth porque `localStorage` no esta disponible en el edge. El guard en `layout.tsx` es suficiente. En v2, se puede migrar a cookie `httpOnly` + middleware.
+
+### 3.4 Manejo de Formularios
+
+#### Zod Schemas (`lib/schemas.ts`)
+
+```typescript
+import { z } from "zod";
+
+export const CatalogProductSchema = z.object({
+  nombre_comercial: z.string().min(1).max(200),
+  fabricante: z.string().min(1).max(100),
+  categoria: z.string().min(1).max(50),
+  subcategoria: z.string().max(50).optional(),
+  descripcion: z.string().max(2000).optional(),
+  ruta_s3: z.string().regex(/^[a-zA-Z0-9_\-/]+\.[a-zA-Z0-9]+$/),
+  variantes: z.array(
+    z.object({
+      modelo: z.string().min(1),
+      parametros_clave: z.record(z.any()).default({}),
+    })
+  ).default([]),
+  parametros_comunes: z.record(z.any()).default({}),
+});
+
+export const MutableSettingsSchema = z.object({
+  llm_model: z.string().optional(),
+  escalation_confidence_threshold: z.number().min(0).max(1).optional(),
+  // ... resto de campos con mismos constraints que Pydantic
+}).refine((data) => {
+  if (data.msg_delay_min_ms && data.msg_delay_max_ms) {
+    return data.msg_delay_min_ms <= data.msg_delay_max_ms;
+  }
+  return true;
+}, { message: "min debe ser <= max" });
+```
+
+#### React Hook Form Integration
+
+```typescript
+const form = useForm<MutableSettings>({
+  resolver: zodResolver(MutableSettingsSchema),
+  defaultValues: configSnapshot.mutable,
+});
+```
+
+- Validacion server-side reflejada en cliente: mismos limites numericos, regex de S3 keys, etc.
+- Errores 422 de FastAPI se mapean a campos individuales via `form.setError`.
+
+### 3.5 Styling y Temas
+
+- **Base**: Tailwind CSS (requerido por shadcn/ui).
+- **Layout admin**: Sidebar fijo de 240px (`w-60`), contenido scrollable (`flex-1 overflow-auto`).
+- **Responsive**: En mobile (<768px), sidebar colapsa a drawer (`Sheet` de shadcn/ui) activado por hamburger menu.
+- **Dark mode**: Documentado como post-MVP. `next-themes` se puede instalar pero no es prioridad. Los componentes de shadcn/ui ya soportan `dark` class.
+
+---
+
+## 4. Diseno de Infraestructura y Despliegue
+
+### 4.1 Docker
+
+#### `admin-panel/Dockerfile`
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM node:20-alpine AS base
+
+FROM base AS deps
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+COPY package.json package-lock.json* pnpm-lock.yaml* ./
+RUN npm ci
+
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN npm run build
+
+FROM base AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+USER nextjs
+EXPOSE 3000
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+CMD ["node", "server.js"]
+```
+
+> Requiere `output: 'standalone'` en `next.config.ts`.
+
+#### `docker-compose.yml` — Servicio Admin Panel
+
+```yaml
+services:
+  # ... existing backend and frontend ...
+
+  admin-panel:
+    build:
+      context: ./admin-panel
+      dockerfile: Dockerfile
+    container_name: arte-admin-panel
+    ports:
+      - "3001:3000"
+    environment:
+      - NEXT_PUBLIC_API_URL=http://backend:8000
+    depends_on:
+      - backend
+    restart: unless-stopped
+    networks:
+      - arte-chatbot_default
+```
+
+### 4.2 Variables de Entorno
+
+| Variable | Scope | Required | Description |
+|----------|-------|----------|-------------|
+| `ADMIN_API_KEY` | Backend | Yes | API key para `/admin/*`. >=32 chars. |
+| `NEXT_PUBLIC_API_URL` | Frontend (build + runtime) | Yes | URL base del backend FastAPI. |
+| `AWS_ACCESS_KEY_ID` | Backend | Yes | Ya existente; usado por S3Client admin. |
+| `AWS_SECRET_ACCESS_KEY` | Backend | Yes | Ya existente; usado por S3Client admin. |
+| `AWS_BUCKET_NAME` | Backend | Yes | Ya existente. |
+| `AWS_REGION` | Backend | Yes | Ya existente. |
+| `OPENAI_API_KEY` | Backend | Yes | Ya existente; NO expuesta en `/admin/config`. |
+| `CHAT_API_KEY` | Backend | Yes | Ya existente; NO expuesta en `/admin/config`. |
+| `GIT_COMMIT_HASH` | Backend | No | Ya existente; expuesta como inmutable. |
+
+### 4.3 CI/CD
+
+Nuevo workflow `.github/workflows/admin-panel.yml`:
+
+```yaml
+name: Admin Panel CI
+on:
+  push:
+    paths: ["admin-panel/**"]
+  pull_request:
+    paths: ["admin-panel/**"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: admin-panel/package-lock.json
+      - run: cd admin-panel && npm ci
+      - run: cd admin-panel && npm run lint
+      - run: cd admin-panel && npm run typecheck
+      - run: cd admin-panel && npm run test:unit
+      - run: cd admin-panel && npm run build
+```
+
+Scripts en `admin-panel/package.json`:
+```json
+{
+  "lint": "next lint",
+  "typecheck": "tsc --noEmit",
+  "test:unit": "vitest run",
+  "build": "next build"
+}
+```
+
+---
+
+## 5. Decisiones Tecnicas Detalladas
+
+### 5.1 Server Components vs Client Components
+
+| Opcion | Pros | Contras |
+|--------|------|---------|
+| **Server Components** (eleccion descartada) | Menor bundle, SEO, fetching directo. | No acceso a `localStorage` para auth; mutaciones requieren Server Actions (mas complejo). |
+| **Client Components** (eleccion MVP) | Auth dinamico via Context; TanStack Query maneja cache/mutaciones; patron familiar para CRUD. | Bundle mayor, pero admin panel no requiere SEO ni TTFB extremo. |
+
+**Razon final**: Todas las paginas admin requieren auth interactiva y mutaciones. Client Components simplifica el modelo mental y reduce complejidad de Server Actions en MVP.
+
+### 5.2 TanStack Query vs fetch nativo + useState
+
+| Opcion | Pros | Contras |
+|--------|------|---------|
+| **TanStack Query v5** (eleccion) | Caching inteligente, revalidacion automatica, deduplicacion, estados loading/error global, devtools. | Dependency adicional (~50KB), curva de aprendizaje ligera. |
+| **fetch + useState** | Sin dependencies, control total. | Boilerplate masivo, bugs comunes de race conditions, cache manual fragil. |
+
+**Razon final**: Productividad y robustez. El overhead de bundle es aceptable para un panel de administracion.
+
+### 5.3 Presigned POST vs Upload via Backend Proxy
+
+| Opcion | Pros | Contras |
+|--------|------|---------|
+| **Presigned POST** (eleccion) | Backend nunca ve bytes del PDF; escalable; soporta archivos grandes. | Requiere manejo de CORS en S3 bucket policy. |
+| **Backend proxy** | Control total, logging, validacion extra. | Backend recibe bytes en memoria; bottleneck, riesgo de OOM con PDFs grandes. |
+
+**Razon final**: Evitar que FastAPI maneje streams de PDF en memoria. La carga directa a S3 es el patron AWS estandar.
+
+### 5.4 `settings.reload()` vs Reiniciar Contenedor
+
+| Opcion | Pros | Contras |
+|--------|------|---------|
+| **`settings.reload()`** (eleccion) | Cambios inmediatos sin downtime; UX de admin fluida. | Requiere thread-safe proxy; riesgo de race conditions si no se implementa atomic swap. |
+| **Reiniciar contenedor** | Simplicidad, statelessness total. | Downtime de ~5-10s; experiencia admin pobre para ajustes rapidos. |
+
+**Razon final**: La atomic swap del proxy (`_instance = Settings()`) es segura porque `_ensure_instance` nunca reasigna mientras otro thread lee el objeto antiguo (Python GIL + asignacion atomica de referencias). Lecturas concurrentes usan el objeto viejo hasta que `_instance` apunta al nuevo.
+
+### 5.5 S3-only vs PostgreSQL para Sesiones/Logs
+
+| Opcion | Pros | Contras |
+|--------|------|---------|
+| **S3-only** (eleccion, ADR-001) | Consistencia arquitectonica; sin infra adicional; costo bajo. | Consultas complejas son lentas; listado de logs requiere escanear prefijos. |
+| **PostgreSQL** | Queries SQL rapidas; indices; transacciones. | Nueva infraestructura; migrations; backup; rompe decision arquitectonica previa. |
+
+**Razon final**: ADR-001 decidio intencionalmente S3-only. Agregar PostgreSQL seria un cambio arquitectonico mayor fuera del scope del admin panel.
+
+### 5.6 `output: 'standalone'` vs `output: 'export'`
+
+| Opcion | Pros | Contras |
+|--------|------|---------|
+| **`standalone`** (eleccion) | Permite API routes internas, Server Components dinamicos, Docker con Node server. | Imagen Docker ligeramente mayor (~150MB vs ~50MB). |
+| **`export`** | HTML estatico puro; imagen minima (nginx). | Sin API routes; sin Server Components dinamicos; requiere `generateStaticParams` para rutas dinamicas como `[intent]`. |
+
+**Razon final**: Flexibilidad futura. `standalone` permite evolucionar a Server Components o API routes sin cambiar la infraestructura Docker.
+
+---
+
+## 6. Diagramas de Secuencia (Mermaid)
+
+### 6.1 Login + Carga de Dashboard
+
+```mermaid
+sequenceDiagram
+    actor Admin
+    participant Browser
+    participant AdminPanel as Next.js Admin Panel
+    participant FastAPI
+    participant SessionManager
+    participant S3
+
+    Admin->>Browser: Navega a /admin/login
+    Browser->>AdminPanel: Render LoginForm
+    Admin->>Browser: Ingresa API key + click Ingresar
+    Browser->>AdminPanel: setApiKey(key) en localStorage
+    AdminPanel->>Browser: redirect /admin/dashboard
+    Browser->>AdminPanel: DashboardPage mount
+    AdminPanel->>FastAPI: GET /admin/dashboard/metrics<br/>Header: X-Admin-API-Key
+    FastAPI->>FastAPI: verify_admin_key(key)
+    FastAPI->>SessionManager: get_session_count()<br/>get_all_token_totals()
+    FastAPI->>S3: list_objects_v2(Prefix="conversations/")
+    S3-->>FastAPI: Lista de objetos JSON
+    FastAPI->>FastAPI: Agrega escalation_rate + intent_distribution
+    FastAPI-->>AdminPanel: 200 DashboardMetrics
+    AdminPanel->>Browser: Render StatsCards + Charts
+```
+
+### 6.2 CRUD de Catalogo
+
+```mermaid
+sequenceDiagram
+    actor Admin
+    participant Browser
+    participant AdminPanel as CatalogPage
+    participant FastAPI
+    participant S3
+
+    Admin->>Browser: Navega a /admin/catalog
+    Browser->>AdminPanel: mount CatalogPage
+    AdminPanel->>FastAPI: GET /admin/catalog
+    FastAPI->>S3: get_object("index/catalog_index.json")
+    S3-->>FastAPI: JSON bytes
+    FastAPI->>FastAPI: CatalogIndex.model_validate_json()
+    FastAPI-->>AdminPanel: 200 CatalogIndex
+    AdminPanel->>Browser: Render DataTable
+
+    Admin->>Browser: Edita producto + click Guardar
+    Browser->>AdminPanel: onSubmit(formData)
+    AdminPanel->>FastAPI: PUT /admin/catalog<br/>Body: CatalogIndex<br/>Header: If-Match (ETag previo)
+    FastAPI->>FastAPI: validate body
+    FastAPI->>S3: head_object("index/catalog_index.json")
+    S3-->>FastAPI: ETag actual
+    FastAPI->>FastAPI: Compara ETag
+    alt ETag match
+        FastAPI->>S3: put_object("index/catalog_index.json", bytes)
+        S3-->>FastAPI: 200 OK
+        FastAPI->>FastAPI: get_catalog(force_reload=True)
+        FastAPI-->>AdminPanel: 200 CatalogIndex
+        AdminPanel->>Browser: Toast success + refresh table
+    else ETag mismatch
+        FastAPI-->>AdminPanel: 409 Conflict
+        AdminPanel->>Browser: Toast error: "Catalogo modificado por otro usuario"
+    end
+```
+
+### 6.3 Upload de PDF con Presigned URL
+
+```mermaid
+sequenceDiagram
+    actor Admin
+    participant Browser
+    participant AdminPanel as S3ExplorerPage
+    participant FastAPI
+    participant S3
+
+    Admin->>Browser: Click "Subir archivo" en S3Explorer
+    Browser->>AdminPanel: Abre UploadDialog
+    Admin->>Browser: Selecciona PDF + confirma
+    AdminPanel->>FastAPI: POST /admin/s3/presigned-upload<br/>Body: {key: "raw/paneles/nuevo.pdf", content_type: "application/pdf"}
+    FastAPI->>FastAPI: Sanitiza key (prefix raw/ o guides/)
+    FastAPI->>S3: head_object(key) // verifica existencia
+    S3-->>FastAPI: 404 (no existe)
+    FastAPI->>S3: generate_presigned_post(key, content_type)
+    S3-->>FastAPI: {url, fields}
+    FastAPI-->>AdminPanel: 200 PresignedUploadResponse
+    AdminPanel->>Browser: POST multipart/form-data directo a S3
+    Browser->>S3: Upload PDF con presigned URL
+    S3-->>Browser: 200 OK
+    Browser->>AdminPanel: Notifica exito
+    AdminPanel->>FastAPI: GET /admin/s3/tree?prefix=raw/
+    FastAPI-->>AdminPanel: Tree actualizado
+    AdminPanel->>Browser: Render arbol con nuevo archivo
+```
+
+### 6.4 Cambio de Configuracion (Hot Reload)
+
+```mermaid
+sequenceDiagram
+    actor Admin
+    participant Browser
+    participant AdminPanel as ConfigPage
+    participant FastAPI
+    participant SettingsProxy
+
+    Admin->>Browser: Modifica "System Prompt" en ConfigPage
+    Browser->>AdminPanel: React Hook Form onChange
+    Admin->>Browser: Click "Guardar configuracion"
+    AdminPanel->>FastAPI: PUT /admin/config<br/>Body: MutableSettings (partial)
+    FastAPI->>FastAPI: validate MutableSettings
+    FastAPI->>SettingsProxy: Actualiza valores internos
+    FastAPI->>SettingsProxy: reload()
+    SettingsProxy->>SettingsProxy: _instance = Settings() // atomic swap
+    FastAPI->>FastAPI: Construye CurrentSettingsSnapshot
+    FastAPI-->>AdminPanel: 200 CurrentSettingsSnapshot
+    AdminPanel->>Browser: Toast success: "Configuracion actualizada"
+
+    Note over FastAPI,SettingsProxy: Proximas requests a /chat usan Settings() nuevo
+```
+
+---
+
+## 7. Consideraciones de Performance
+
+### 7.1 S3 list_objects_v2
+
+- **Paginacion**: Usar `MaxKeys=1000` (default de S3) y `ContinuationToken` para arboles grandes.
+- **Prefijos**: Siempre filtrar por `prefix` antes de paginar. Evitar listar todo el bucket.
+- **Tree building**: El backend construye el arbol en memoria. Para >10k objetos, esto puede tomar ~500ms. Documentar limite MVP: <20k objetos en un prefijo.
+
+### 7.2 Logs
+
+- **MVP**: `conversations/` se lista completo y se filtra en memoria. Aceptable si <10k objetos.
+- **V2**: Migrar a S3 Select (SQL sobre objetos JSON) o Amazon Athena si el volumen crece.
+- **Caching**: `staleTime: 0` para logs porque son datos historicos que cambian constantemente.
+
+### 7.3 Frontend Bundle
+
+- **Lazy loading**: Usar `next/dynamic` para paginas pesadas:
+  ```typescript
+  const MarkdownEditor = dynamic(() => import("@uiw/react-md-editor"), { ssr: false });
+  ```
+- **Recharts**: Importar solo componentes necesarios: `import { PieChart, Pie, Cell } from "recharts"`.
+- **TanStack Table**: Tree-shaking funciona bien; importar solo `useReactTable`.
+
+### 7.4 Backend
+
+- **Async S3 ops**: Todos los endpoints admin que tocan S3 deben usar `await asyncio.to_thread(...)` porque boto3 es bloqueante.
+- **Dashboard metrics**: El scan de `conversations/` cada 30 segundos puede ser costoso. Considerar cachear resultado en memoria por 60s.
+
+---
+
+## 8. Consideraciones de Seguridad
+
+### 8.1 Proteccion de API Key
+
+- `ADMIN_API_KEY` nunca se emite en el bundle de Next.js. Solo `NEXT_PUBLIC_API_URL` es publica.
+- La key se ingresa manualmente en el login y vive solo en `localStorage` del browser admin.
+- Comparacion timing-safe: `hmac.compare_digest(request_key, settings.admin_api_key)`.
+
+### 8.2 Sanitizacion de Inputs
+
+- **S3 keys**: Regex `^[a-zA-Z0-9_\-/]+(\.[a-zA-Z0-9]+)?$`. Rechaza `..`, paths absolutos, y prefijos de escritura no permitidos.
+- **Intent**: Regex `^[a-zA-Z0-9_-]+$` para guias. Solo alphanumeric + hyphens/underscores.
+- **Config**: `MutableSettings` Pydantic valida rangos numericos (e.g., `escalation_confidence_threshold` entre 0.0 y 1.0).
+
+### 8.3 CORS
+
+- Backend debe permitir origen del admin panel en `CORSMiddleware`:
+  ```python
+  allow_origins=["http://localhost:3000", "http://localhost:3001"]
+  ```
+- En produccion, usar variable de entorno `ADMIN_PANEL_ORIGIN`.
+
+### 8.4 Exclusion de Secrets
+
+- Endpoint `GET /admin/config` nunca incluye `openai_api_key`, `aws_secret_access_key`, `chat_api_key` en la respuesta. Estos campos existen en `ImmutableSettings` pero se sobreescriben con `"***REDACTED***"` antes de serializar.
+
+### 8.5 Presigned URLs
+
+- `generate_presigned_post` usa `Conditions` con `content-length-range: [1024, 104_857_600]` (1 KB - 100 MB) para evitar uploads gigantes.
+- Expiracion de 1 hora (`ExpiresIn=3600`).
+
+---
+
+## 9. Plan de Rollback
+
+El admin panel es un componente **aditivo** que no modifica la logica existente de `/chat`. El rollback es seguro y no afecta el chat:
+
+1. **Detener servicio admin**:
+   ```bash
+   docker compose stop admin-panel
+   docker compose rm admin-panel
+   ```
+
+2. **Revertir docker-compose.yml**:
+   - Eliminar bloque `admin-panel` del `docker-compose.yml`.
+   - No afecta `backend` ni `frontend`.
+
+3. **Revertir backend** (FastAPI):
+   - En `backend/main.py`: eliminar linea `app.include_router(admin_router, prefix="/admin")`.
+   - En `backend/app/auth.py`: eliminar `verify_admin_key` (o dejarlo sin usar; no afecta `verify_api_key`).
+   - En `backend/app/config.py`: eliminar campo `admin_api_key` y metodo `reload()`.
+   - En `backend/app/s3_client.py`: eliminar metodos nuevos si no son usados por chat.
+   - En `backend/app/catalog.py`: eliminar `save_catalog()` y `reload_catalog()`.
+   - En `backend/app/session.py`: eliminar metodos de agregacion.
+   - En `backend/app/conversation_logger.py`: eliminar `list_logs()` y `get_log()`.
+   - Opcional: eliminar archivos `backend/app/admin_*.py`.
+
+4. **Eliminar frontend**:
+   ```bash
+   rm -rf admin-panel/
+   ```
+
+5. **Variables de entorno**:
+   - Eliminar `ADMIN_API_KEY` de `.env` (opcional; si existe pero no se usa, no hay riesgo).
+
+6. **Verificar chat**:
+   ```bash
+   curl http://localhost:8000/health
+   curl -H "X-API-Key: $CHAT_API_KEY" -X POST http://localhost:8000/chat -d '{"message":"hola"}'
+   ```
+
+> **Nota critica**: Los endpoints `/chat`, `/health`, `/buffer-result` permanecen intactos durante todo el rollback porque el admin router es un router separado montado bajo `/admin`.
+
+---
+
+## 10. Resumen de Artefactos y Estado
+
+| Campo | Valor |
+|-------|-------|
+| **status** | `design_complete` |
+| **executive_summary** | Se disena un admin panel MVP con Next.js 16 (frontend) y extensiones FastAPI (backend) que gestionan catalogo, fichas tecnicas S3, guias markdown, configuracion mutable con hot reload, y logs de conversacion. S3 sigue siendo la fuente de verdad. Auth separado via X-Admin-API-Key. |
+| **artifacts** | `openspec/changes/admin-panel-mvp/design.md` |
+| **next_recommended** | `sdd-tasks` (desglose en tareas de implementacion) |
+| **risks** | 1. Concurrent catalog edits: mitigado con ETag. 2. Large S3 lists: mitigado con paginacion y limites documentados. 3. Settings reload race: mitigado con atomic swap. 4. CORS: mitigado con origenes explicitos. |
+| **skill_resolution** | sdd-design completado. Documento guardado en openspec. |

--- a/openspec/changes/admin-panel-mvp/proposal.md
+++ b/openspec/changes/admin-panel-mvp/proposal.md
@@ -1,0 +1,132 @@
+# Proposal: Admin Panel MVP
+
+## Intent
+
+Build a web-based admin panel to manage the ARTE chatbot's data and configuration without requiring direct S3 access or code changes. Currently, catalog, PDFs, settings, and conversation logs are only manageable via manual S3 edits or env vars.
+
+## Scope
+
+### In Scope
+- Next.js frontend with admin routes (`/admin/*`) and shared layout
+- Dashboard: active sessions, token totals, escalation rate, intent distribution
+- S3 Explorer: browse `raw/`, upload/delete PDFs, tree view
+- Catalog Editor: CRUD for `catalog_index.json` with validation
+- Markdown Guides Editor: new entity, split-pane editor, linked to intents
+- Config Editor: system prompt, LLM model selector, dynamic Settings reload
+- Escalation Thresholds: confidence slider, forced keywords editor
+- Conversation Logs: table with filters, detail view with full transcript
+- Admin auth: separate `X-Admin-API-Key` header, protected admin endpoints
+
+### Out of Scope
+- Intent & sales flow builder (fase 2)
+- Debug simulator (fase 2)
+- Live sessions viewer (fase 2)
+- Evaluation dashboard (fase 2)
+- Multi-user auth / RBAC (fase 2)
+- Webhooks / notifications (fase 2)
+
+## Capabilities
+
+### New Capabilities
+- `admin-dashboard`: metrics aggregation from session manager and conversation logs
+- `admin-s3-explorer`: tree listing, presigned upload/delete for `raw/` prefix
+- `admin-catalog-editor`: read/write `index/catalog_index.json` with schema validation
+- `admin-guides-editor`: CRUD markdown files in S3 `guides/`, intent association
+- `admin-config-editor`: hot-reload system prompt, model, thresholds, feature flags
+- `admin-conversation-logs`: list/filter logs, transcript detail, metadata
+- `admin-auth`: separate API key middleware for admin endpoints
+
+### Modified Capabilities
+- `chat-session`: expose session metrics (counts, token totals) for dashboard
+- `conversation-logging`: add list/query endpoints for log retrieval
+- `catalog`: add save/reload endpoint for index mutations
+
+## Approach
+
+**Frontend**: Next.js 16 (App Router) in `admin-panel/`, standalone service. Consumes backend REST API. Deployed as separate container or static export.
+
+**Backend**: Extend FastAPI with `/admin/*` routers. S3 remains the single source of truth. Admin endpoints use a new `verify_admin_key` dependency (`ADMIN_API_KEY`). Settings proxy gains a `reload()` method for hot config updates without restart.
+
+**Data Flow**:
+- Frontend → Backend → S3 (for metadata/config)
+- Frontend → Backend → Presigned S3 URL (for direct PDF upload/download)
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Frontend framework | Next.js 16 | User-requested; SSR, routing, and component ecosystem out of the box |
+| Admin auth | Separate API key (`ADMIN_API_KEY`) | Keeps chat and admin concerns isolated; no RBAC complexity in MVP |
+| Config reload | Runtime `settings.reload()` | Avoids container restart for prompt/threshold changes |
+| S3 access pattern | Backend proxy + presigned URLs | Avoids CORS and credential exposure in browser |
+| Guides storage | S3 `guides/{intent}.md` | Consistent with existing S3-first architecture |
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `admin-panel/` | New | Next.js 16 application with all admin UI modules |
+| `backend/main.py` | Modified | Mount admin routers behind new auth dependency |
+| `backend/app/auth.py` | Modified | Add `verify_admin_key` dependency |
+| `backend/app/config.py` | Modified | Add `reload()` to `_SettingsProxy`; add `admin_api_key` field |
+| `backend/app/catalog.py` | Modified | Add `save_catalog()` and `reload_catalog()` helpers |
+| `backend/app/s3_client.py` | Modified | Add `list_objects()`, `delete_object()`, `generate_presigned_post()` |
+| `backend/app/session.py` | Modified | Expose aggregated metrics (session count, tokens, intents) |
+| `backend/app/conversation_logger.py` | Modified | Add `list_logs()`, `get_log()` for querying S3 conversations prefix |
+| `docker-compose.yml` | Modified | Add `admin-panel` service, expose port 3001 |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Concurrent catalog edits corrupt `catalog_index.json` | Med | Optimistic locking with ETag / versionId on S3 put |
+| Large PDF uploads timeout or memory-bloat backend | Med | Use presigned POST URLs; frontend uploads directly to S3 |
+| Dynamic Settings reload introduces race conditions | Low | Reload swaps proxy instance atomically; reads are unaffected |
+| CORS between admin panel and backend in prod | Low | Configure `allow_origins` to include admin panel origin |
+| Admin key leakage grants full control | Med | Store in env var only; rotate via deployment |
+
+## Rollback Plan
+
+1. Revert docker-compose to remove `admin-panel` service.
+2. Revert FastAPI to remove `/admin` routers (backend chat endpoints remain untouched).
+3. Delete `admin-panel/` directory.
+4. Rollback `backend/app/config.py`, `auth.py`, `s3_client.py` to pre-change commits.
+
+## Dependencies
+
+- Node.js 20+ for Next.js build
+- `ADMIN_API_KEY` env var in `.env`
+- S3 bucket policy allowing delete/list operations from backend credentials
+
+## Success Criteria
+
+- [ ] Admin panel loads at `http://localhost:3001/admin` with navigation sidebar
+- [ ] Dashboard displays real session count, token totals, and escalation rate
+- [ ] Catalog CRUD persists to `index/catalog_index.json` and chatbot uses updated data within 30s
+- [ ] PDF upload/delete updates `raw/` tree and reflects in catalog editor
+- [ ] System prompt and model changes apply without backend restart
+- [ ] Escalation thresholds and keywords editable and effective immediately
+- [ ] Markdown guides CRUD works in split-pane editor and links to intents
+- [ ] Conversation logs table lists transcripts with filtering by date/intent/session
+- [ ] All admin endpoints reject requests without valid `X-Admin-API-Key`
+- [ ] Existing `/chat` and `/health` endpoints remain unchanged and functional
+
+## Backend Endpoints Map
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| GET | `/admin/health` | Admin | Admin router health check |
+| GET | `/admin/dashboard/metrics` | Admin | Sessions, tokens, escalations, intents |
+| GET | `/admin/s3/tree` | Admin | List S3 objects under prefix (tree) |
+| POST | `/admin/s3/presigned-upload` | Admin | Get presigned URL for PDF upload |
+| DELETE | `/admin/s3/objects` | Admin | Delete S3 object(s) |
+| GET | `/admin/catalog` | Admin | Fetch `catalog_index.json` |
+| PUT | `/admin/catalog` | Admin | Save updated catalog index |
+| GET | `/admin/guides` | Admin | List guides (intent + title) |
+| GET | `/admin/guides/{intent}` | Admin | Get markdown content for intent |
+| PUT | `/admin/guides/{intent}` | Admin | Save markdown guide for intent |
+| DELETE | `/admin/guides/{intent}` | Admin | Delete guide |
+| GET | `/admin/config` | Admin | Get current Settings snapshot |
+| PUT | `/admin/config` | Admin | Update mutable settings (prompt, model, thresholds) |
+| GET | `/admin/logs` | Admin | List conversation logs with filters |
+| GET | `/admin/logs/{session_id}` | Admin | Get full transcript for session |

--- a/openspec/changes/admin-panel-mvp/spec.md
+++ b/openspec/changes/admin-panel-mvp/spec.md
@@ -1,0 +1,841 @@
+# Admin Panel MVP — Technical Specification
+
+> **Artifact**: `openspec/changes/admin-panel-mvp/spec.md`  
+> **Change**: admin-panel-mvp  
+> **Format**: OpenSpec delta spec (single-file composite)  
+> **Standard**: RFC 2119 (MUST / SHALL / SHOULD / MAY)
+
+---
+
+## 1. UI Libraries for Next.js 16
+
+### 1.1 Research & Decisions
+
+| Category | Options Evaluated | Decision | Justification |
+|----------|-------------------|----------|---------------|
+| **Component Base** | shadcn/ui, Radix UI direct | **shadcn/ui** | Copy-paste components built on Radix + Tailwind. Zero lock-in, full Server Component support where possible, `"use client"` auto-marked for interactive pieces. Native App Router support in Next.js 16. |
+| **Data Tables** | TanStack Table v8, AG Grid | **TanStack Table v8** | Headless, fully composable with shadcn/ui `<Table>`. AG Grid is overkill for MVP (heavy bundle, licensing complexity). TanStack supports server-side pagination/sorting/filtering out of the box. |
+| **Forms & Validation** | React Hook Form + Zod, Formik + Yup | **React Hook Form + Zod** | shadcn/ui Form primitive is built on this combo. Zod provides schema-first validation that maps cleanly to Pydantic v2 via similar type semantics. Minimal re-renders. |
+| **S3 Tree** | Custom recursion + shadcn Collapsible, react-arborist | **Custom recursion + Collapsible** | MVP tree is read-only/browse + basic upload/delete actions. react-arborist adds 30+ KB and DnD complexity we don't need yet. A recursive component using shadcn Collapsible + Checkbox is sufficient. |
+| **Markdown Editor** | @uiw/react-md-editor, react-simplemde-editor | **@uiw/react-md-editor** (preview + edit) + **react-markdown** | Split-pane editing is native in @uiw. EasyMDE (simplemde) requires `document` access and dynamic import with `ssr: false`. Both work in Next.js 16 with dynamic import; @uiw has better React 19 compatibility track record. |
+| **Charts / Dashboard** | Recharts, Tremor | **Recharts** | Pure React, lightweight, covers line/bar/pie needs. Tremor (built on Recharts) is nice but adds opinionated Tailwind classes that may conflict with shadcn theming. Recharts gives full control. |
+| **Fetching / State** | TanStack Query v5, SWR, Zustand | **TanStack Query v5** | First-class caching, background revalidation, devtools, and automatic loading/error states. SWR lacks some mutation helpers; Zustand/Redux are global state managers, not data-fetching layers. TanStack Query is the de-facto standard for Next.js 16. |
+| **Toast / Notifications** | Sonner, react-hot-toast | **Sonner** | shadcn/ui ecosystem native (installable via `npx shadcn add sonner`). Stacks, promises, and action toasts out of the box. Better Tailwind integration than react-hot-toast. |
+| **Routing / Layout** | Next.js 16 App Router, React Router | **Next.js 16 App Router** | Requirement from proposal. File-system routing, nested layouts, server components, and parallel routes for advanced admin layouts. No extra dependency. |
+
+### 1.2 Pydantic ↔ Zod Mapping Strategy
+
+The frontend SHALL define Zod schemas that mirror backend Pydantic v2 models. A shared naming convention MUST be enforced:
+
+- Pydantic `CatalogProduct` → Zod `CatalogProductSchema`
+- Pydantic `ConversationLogEntry` → Zod `ConversationLogEntrySchema`
+- Validation errors returned as FastAPI `422` SHALL be parsed by TanStack Query `meta.errorMessage` and surfaced via Sonner toast.
+
+---
+
+## 2. Backend Specifications (FastAPI)
+
+### 2.1 Shared Pydantic Models
+
+```python
+# backend/app/admin_schemas.py
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field
+
+
+class ProductVariant(BaseModel):
+    modelo: str
+    parametros_clave: Dict[str, Any] = Field(default_factory=dict)
+
+
+class CatalogProduct(BaseModel):
+    nombre_comercial: str
+    fabricante: str
+    categoria: str
+    subcategoria: Optional[str] = None
+    descripcion: Optional[str] = None
+    ruta_s3: str
+    variantes: List[ProductVariant] = Field(default_factory=list)
+    parametros_comunes: Dict[str, Any] = Field(default_factory=dict)
+
+
+class CatalogIndex(BaseModel):
+    products: List[CatalogProduct] = Field(default_factory=list)
+
+
+class GuideMeta(BaseModel):
+    intent: str
+    title: str
+    updated_at: Optional[str] = None
+
+
+class GuideContent(BaseModel):
+    intent: str
+    content: str
+
+
+class DashboardMetrics(BaseModel):
+    active_sessions: int
+    total_input_tokens: int
+    total_output_tokens: int
+    total_tokens: int
+    escalation_rate: float  # 0.0 - 1.0
+    intent_distribution: Dict[str, int]
+
+
+class ConversationLogSummary(BaseModel):
+    session_id: str
+    turn_count: int
+    last_timestamp: Optional[str] = None
+    intent_types: List[str] = Field(default_factory=list)
+    escalated: bool = False
+
+
+class ConversationLogEntry(BaseModel):
+    # Reuses existing model; exposed here for completeness
+    session_id: str
+    turn_number: int
+    timestamp: str
+    user_message: str
+    bot_response: str
+    intent_type: str
+    escalate: bool
+    source_documents: List[str] = Field(default_factory=list)
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    response_time_ms: float
+    model: str
+    git_commit_hash: str
+    user_profile: Optional[str] = None
+
+
+class MutableSettings(BaseModel):
+    """Fields that can be updated at runtime via settings.reload()."""
+
+    llm_model: Optional[str] = None
+    log_level: Optional[str] = None
+    escalation_confidence_threshold: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    false_positive_limit: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    false_negative_limit: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    whatsapp_formatter_enabled: Optional[bool] = None
+    split_messages_enabled: Optional[bool] = None
+    msg_delay_min_ms: Optional[int] = Field(default=None, ge=1000, le=10000)
+    msg_delay_max_ms: Optional[int] = Field(default=None, ge=1000, le=15000)
+    greeting_enabled: Optional[bool] = None
+    greeting_timezone: Optional[str] = None
+    multi_message_buffer_enabled: Optional[bool] = None
+    buffer_window_seconds: Optional[int] = Field(default=None, ge=1, le=15)
+    conversation_logging_enabled: Optional[bool] = None
+    conversation_log_prefix: Optional[str] = None
+    admin_api_key: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _validate_delays(self) -> "MutableSettings":
+        if self.msg_delay_min_ms is not None and self.msg_delay_max_ms is not None:
+            if self.msg_delay_min_ms > self.msg_delay_max_ms:
+                raise ValueError("msg_delay_min_ms must be <= msg_delay_max_ms")
+        return self
+
+
+class ImmutableSettings(BaseModel):
+    """Fields that require container restart to change."""
+
+    openai_api_key: Optional[str] = None
+    aws_access_key_id: Optional[str] = None
+    aws_secret_access_key: Optional[str] = None
+    aws_bucket_name: str
+    aws_region: str
+    chat_api_key: Optional[str] = None
+    git_commit_hash: str
+
+
+class CurrentSettingsSnapshot(BaseModel):
+    mutable: MutableSettings
+    immutable: ImmutableSettings
+
+
+class S3TreeNode(BaseModel):
+    name: str
+    key: str
+    type: str  # "folder" | "file"
+    size: Optional[int] = None
+    last_modified: Optional[str] = None
+    children: Optional[List["S3TreeNode"]] = None
+
+
+class PresignedUploadRequest(BaseModel):
+    key: str  # e.g. "raw/paneles/nuevo-panel.pdf"
+    content_type: str = "application/pdf"
+
+
+class PresignedUploadResponse(BaseModel):
+    url: str
+    fields: Dict[str, str] = Field(default_factory=dict)
+    key: str
+
+
+class DeleteS3ObjectsRequest(BaseModel):
+    keys: List[str]
+
+
+class LogFilterParams(BaseModel):
+    session_id: Optional[str] = None
+    intent_type: Optional[str] = None
+    escalated: Optional[bool] = None
+    date_from: Optional[str] = None  # ISO 8601
+    date_to: Optional[str] = None
+    limit: int = Field(default=50, ge=1, le=200)
+    offset: int = Field(default=0, ge=0)
+```
+
+### 2.2 Auth Dependency
+
+```python
+# backend/app/auth.py (addition)
+from fastapi import Security
+from fastapi.security import APIKeyHeader
+
+ADMIN_API_KEY_HEADER = APIKeyHeader(name="X-Admin-API-Key", auto_error=False)
+
+
+def verify_admin_key(admin_key: str = Security(ADMIN_API_KEY_HEADER)) -> str:
+    """Dependency that validates the X-Admin-API-Key header."""
+    if not admin_key:
+        raise HTTPException(status_code=401, detail="Missing admin API key")
+    valid_key = settings.admin_api_key
+    if not valid_key:
+        raise HTTPException(status_code=503, detail="ADMIN_API_KEY not configured")
+    if not hmac.compare_digest(admin_key, valid_key):
+        raise HTTPException(status_code=403, detail="Invalid admin API key")
+    return admin_key
+```
+
+### 2.3 S3Client Extensions
+
+```python
+# backend/app/s3_client.py (additions)
+from typing import List
+
+class S3Client:
+    # ... existing methods ...
+
+    def list_objects(self, prefix: str = "") -> List[dict]:
+        """List objects under a prefix using list_objects_v2.
+
+        Returns a list of dicts with keys: Key, Size, LastModified.
+        """
+        if not self.bucket_name:
+            raise S3DownloadError("S3 bucket name not configured")
+        try:
+            paginator = self.client.get_paginator("list_objects_v2")
+            results = []
+            for page in paginator.paginate(Bucket=self.bucket_name, Prefix=prefix):
+                results.extend(page.get("Contents", []))
+            return results
+        except ClientError as e:
+            raise S3DownloadError(f"S3 list failed: {e}") from e
+
+    def delete_object(self, key: str) -> None:
+        """Delete a single object from S3."""
+        if not self.bucket_name:
+            raise S3UploadError("S3 bucket name not configured")
+        try:
+            self.client.delete_object(Bucket=self.bucket_name, Key=key)
+        except ClientError as e:
+            raise S3UploadError(f"S3 delete failed: {e}") from e
+
+    def delete_objects(self, keys: List[str]) -> None:
+        """Delete multiple objects via delete_objects batch."""
+        if not self.bucket_name:
+            raise S3UploadError("S3 bucket name not configured")
+        try:
+            self.client.delete_objects(
+                Bucket=self.bucket_name,
+                Delete={"Objects": [{"Key": k} for k in keys], "Quiet": True},
+            )
+        except ClientError as e:
+            raise S3UploadError(f"S3 batch delete failed: {e}") from e
+
+    def generate_presigned_post(
+        self, key: str, content_type: str = "application/pdf", expires: int = 3600
+    ) -> dict:
+        """Generate a presigned POST URL for direct browser upload."""
+        if not self.bucket_name:
+            raise S3UploadError("S3 bucket name not configured")
+        try:
+            return self.client.generate_presigned_post(
+                Bucket=self.bucket_name,
+                Key=key,
+                Fields={"Content-Type": content_type},
+                Conditions=[
+                    {"Content-Type": content_type},
+                    ["content-length-range", 1024, 104_857_600],  # 1 KB - 100 MB
+                ],
+                ExpiresIn=expires,
+            )
+        except ClientError as e:
+            raise S3UploadError(f"Presigned post generation failed: {e}") from e
+```
+
+### 2.4 Endpoint Specifications
+
+#### E1. `GET /admin/health`
+
+| Attribute | Value |
+|-----------|-------|
+| **Auth** | `verify_admin_key` |
+| **Request** | None |
+| **Response** | `{"status": "healthy", "service": "arte-chatbot-admin"}` |
+| **Errors** | 401 (missing key), 403 (invalid key), 503 (ADMIN_API_KEY not configured) |
+| **Flow** | 1. Validate admin key. 2. Return static JSON health payload. |
+| **S3 Ops** | None |
+
+#### E2. `GET /admin/dashboard/metrics`
+
+| Attribute | Value |
+|-----------|-------|
+| **Auth** | `verify_admin_key` |
+| **Request** | None |
+| **Response** | `DashboardMetrics` |
+| **Errors** | 401, 403, 500 |
+| **Flow** | 1. Validate admin key. 2. Query `session_manager` for active session count and token totals aggregated across all sessions. 3. Scan `conversations/` prefix in S3 (or in-memory index if maintained) to compute escalation rate and intent distribution over the last 24h. 4. Return aggregated metrics. |
+| **S3 Ops** | `list_objects_v2` on `conversations/` prefix (or none if using an in-memory aggregation refreshed periodically). |
+
+#### E3. `GET /admin/s3/tree`
+
+| Attribute | Value |
+|-----------|-------|
+| **Auth** | `verify_admin_key` |
+| **Request** | Query param `prefix` (str, default `""`). Optional `delimiter` (str, default `"/"`). |
+| **Response** | `List[S3TreeNode]` — hierarchical tree built from S3 keys. |
+| **Errors** | 401, 403, 422 (bad prefix), 500 |
+| **Flow** | 1. Validate admin key. 2. Sanitize `prefix` (disallow `..` and absolute paths). 3. Call `s3_client.list_objects(prefix)`. 4. Build tree structure splitting keys by delimiter. 5. Return tree nodes. |
+| **S3 Ops** | `list_objects_v2` with `Prefix` and `Delimiter`. |
+
+#### E4. `POST /admin/s3/presigned-upload`
+
+| Attribute | Value |
+|-----------|-------|
+| **Auth** | `verify_admin_key` |
+| **Request Body** | `PresignedUploadRequest` |
+| **Response** | `PresignedUploadResponse` |
+| **Errors** | 401, 403, 422 (invalid key path), 409 (object already exists), 500 |
+| **Flow** | 1. Validate admin key. 2. Validate `key` starts with allowed prefix (`raw/` or `guides/`). Reject path traversal. 3. If `key` already exists, return 409. 4. Call `s3_client.generate_presigned_post(key, content_type)`. 5. Return URL and fields. |
+| **S3 Ops** | `head_object` (existence check), `generate_presigned_post`. |
+
+#### E5. `DELETE /admin/s3/objects`
+
+| Attribute | Value |
+|-----------|-------|
+| **Auth** | `verify_admin_key` |
+| **Request Body** | `DeleteS3ObjectsRequest` |
+| **Response** | `{"deleted": int}` |
+| **Errors** | 401, 403, 422 (empty list or invalid keys), 500 |
+| **Flow** | 1. Validate admin key. 2. Validate all keys start with `raw/` or `guides/` or `index/`. Reject path traversal. 3. Call `s3_client.delete_objects(keys)`. 4. Return count of deleted objects. |
+| **S3 Ops** | `delete_objects` (batch). |
+
+#### E6. `GET /admin/catalog`
+
+| Attribute | Value |
+|-----------|-------|
+| **Auth** | `verify_admin_key` |
+| **Request** | None |
+| **Response** | `CatalogIndex` |
+| **Errors** | 401, 403, 404 (index not found in S3), 500 |
+| **Flow** | 1. Validate admin key. 2. Download `index/catalog_index.json` via `s3_client.download_pdf` (or a new `get_object` method). 3. Parse JSON and validate against `CatalogIndex`. 4. Return model. |
+| **S3 Ops** | `get_object` on `index/catalog_index.json`. |
+
+#### E7. `PUT /admin/catalog`
+
+| Attribute | Value |
+|-----------|-------|
+| **Auth** | `verify_admin_key` |
+| **Request Body** | `CatalogIndex` |
+| **Response** | `CatalogIndex` (echo saved). |
+| **Errors** | 401, 403, 409 (version conflict / ETag mismatch), 422 (validation error), 500 |
+| **Flow** | 1. Validate admin key. 2. Validate request body against `CatalogIndex`. 3. (Optimistic locking) Fetch current object ETag from S3. If `If-Match` header provided and mismatched, return 409. 4. Serialize to JSON bytes. 5. Upload via `s3_client.put_object(key="index/catalog_index.json", data=bytes, content_type="application/json")`. 6. Invalidate in-memory catalog singleton (`get_catalog(force_reload=True)`). 7. Return saved catalog. |
+| **S3 Ops** | `head_object` (for ETag), `put_object`. |
+
+#### E8. `GET /admin/guides`
+
+| Attribute | Value |
+|-----------|-------|
+| **Auth** | `verify_admin_key` |
+| **Request** | None |
+| **Response** | `List[GuideMeta]` |
+| **Errors** | 401, 403, 500 |
+| **Flow** | 1. Validate admin key. 2. List S3 prefix `guides/` to obtain all `.md` keys. 3. Extract intent from filename (`{intent}.md`). 4. Optionally fetch `head_object` for `LastModified`. 5. Return list. |
+| **S3 Ops** | `list_objects_v2` on `guides/`. |
+
+#### E9. `GET /admin/guides/{intent}`
+
+| Attribute | Value |
+|-----------|-------|
+| **Auth** | `verify_admin_key` |
+| **Request** | Path param `intent` (str). |
+| **Response** | `GuideContent` |
+| **Errors** | 401, 403, 404 (guide not found), 500 |
+| **Flow** | 1. Validate admin key. 2. Sanitize `intent` (alphanumeric + hyphens/underscores). 3. Build S3 key `guides/{intent}.md`. 4. Download via `s3_client.download_pdf` (or generic get_object). 5. Decode UTF-8 and return. |
+| **S3 Ops** | `get_object` on `guides/{intent}.md`. |
+
+#### E10. `PUT /admin/guides/{intent}`
+
+| Attribute | Value |
+|-----------|-------|
+| **Auth** | `verify_admin_key` |
+| **Request Body** | `GuideContent` |
+| **Response** | `GuideContent` (echo saved). |
+| **Errors** | 401, 403, 422 (invalid intent or body), 500 |
+| **Flow** | 1. Validate admin key. 2. Sanitize `intent`. 3. Validate body `content` is non-empty string. 4. Encode to UTF-8 bytes. 5. Upload via `s3_client.put_object(key="guides/{intent}.md", data=bytes, content_type="text/markdown")`. 6. Return saved content. |
+| **S3 Ops** | `put_object` on `guides/{intent}.md`. |
+
+#### E11. `DELETE /admin/guides/{intent}`
+
+| Attribute | Value |
+|-----------|-------|
+| **Auth** | `verify_admin_key` |
+| **Request** | Path param `intent`. |
+| **Response** | `{"deleted": true}` |
+| **Errors** | 401, 403, 404, 500 |
+| **Flow** | 1. Validate admin key. 2. Sanitize `intent`. 3. Build key `guides/{intent}.md`. 4. Verify existence via `head_object`; if missing return 404. 5. Call `s3_client.delete_object(key)`. 6. Return confirmation. |
+| **S3 Ops** | `head_object`, `delete_object`. |
+
+#### E12. `GET /admin/config`
+
+| Attribute | Value |
+|-----------|-------|
+| **Auth** | `verify_admin_key` |
+| **Request** | None |
+| **Response** | `CurrentSettingsSnapshot` |
+| **Errors** | 401, 403, 500 |
+| **Flow** | 1. Validate admin key. 2. Read current settings from `settings` proxy. 3. Split into `MutableSettings` and `ImmutableSettings` snapshots. 4. Return combined snapshot. |
+| **S3 Ops** | None |
+
+#### E13. `PUT /admin/config`
+
+| Attribute | Value |
+|-----------|-------|
+| **Auth** | `verify_admin_key` |
+| **Request Body** | `MutableSettings` (partial updates allowed). |
+| **Response** | `CurrentSettingsSnapshot` |
+| **Errors** | 401, 403, 422 (validation error), 500 |
+| **Flow** | 1. Validate admin key. 2. Validate request body against `MutableSettings`. 3. Update corresponding environment variables or internal state. 4. Call `settings.reload()` to atomically swap the proxy instance. 5. Return new settings snapshot. |
+| **S3 Ops** | None |
+
+#### E14. `GET /admin/logs`
+
+| Attribute | Value |
+|-----------|-------|
+| **Auth** | `verify_admin_key` |
+| **Request** | Query params `LogFilterParams`. |
+| **Response** | `List[ConversationLogSummary]` + `total` count. |
+| **Errors** | 401, 403, 422 (bad date format), 500 |
+| **Flow** | 1. Validate admin key. 2. List S3 prefix `conversations/` (paginated). 3. Filter by query params (date range, intent, escalated). 4. Aggregate per-session summaries. 5. Apply limit/offset. 6. Return summaries and total count. |
+| **S3 Ops** | `list_objects_v2` on `conversations/` (potentially heavy; may require S3 Select or Athena in v2). |
+
+#### E15. `GET /admin/logs/{session_id}`
+
+| Attribute | Value |
+|-----------|-------|
+| **Auth** | `verify_admin_key` |
+| **Request** | Path param `session_id`. |
+| **Response** | `List[ConversationLogEntry]` (chronological). |
+| **Errors** | 401, 403, 404 (session not found), 500 |
+| **Flow** | 1. Validate admin key. 2. List S3 prefix `conversations/{session_id}/`. 3. Download all JSON objects under that prefix. 4. Parse into `ConversationLogEntry`. 5. Sort by `turn_number`. 6. Return list. |
+| **S3 Ops** | `list_objects_v2` + `get_object` (multiple) on `conversations/{session_id}/`. |
+
+---
+
+## 3. Frontend Specifications (Next.js 16)
+
+### 3.1 Directory Structure
+
+```
+admin-panel/
+├── app/
+│   ├── layout.tsx                 # Root layout (Providers, metadata)
+│   ├── page.tsx                   # Redirect / → /admin/dashboard
+│   ├── admin/
+│   │   ├── layout.tsx             # Sidebar + Header + Auth guard
+│   │   ├── dashboard/page.tsx     # Dashboard with stats & charts
+│   │   ├── catalog/page.tsx       # Catalog CRUD table
+│   │   ├── guides/page.tsx        # Guides list
+│   │   ├── guides/[intent]/page.tsx  # Guide split-pane editor
+│   │   ├── s3-explorer/page.tsx   # S3 tree + upload/delete
+│   │   ├── config/page.tsx        # Settings editor (mutable only)
+│   │   ├── escalation/page.tsx    # Thresholds & keywords
+│   │   └── logs/page.tsx          # Logs table + detail drawer
+│   ├── api/                       # (Optional) proxy routes if needed
+│   └── globals.css
+├── components/
+│   ├── ui/                        # shadcn/ui components (Button, Table, Dialog, etc.)
+│   ├── data-table.tsx             # Reusable TanStack Table wrapper
+│   ├── s3-tree.tsx                # Recursive S3 tree browser
+│   ├── markdown-editor.tsx        # Dynamic import of @uiw/react-md-editor
+│   ├── markdown-preview.tsx       # react-markdown wrapper
+│   └── dashboard-stats.tsx        # Recharts cards for metrics
+├── lib/
+│   ├── api.ts                     # TanStack Query hooks + fetch wrappers
+│   ├── types.ts                   # TypeScript types mapped from Pydantic
+│   └── utils.ts                   # cn() helper, formatters
+├── hooks/
+│   └── use-admin-auth.ts          # Auth context consumer
+├── providers/
+│   ├── query-client.tsx           # TanStack Query client setup
+│   ├── admin-auth-provider.tsx    # Context for X-Admin-API-Key
+│   └── theme-provider.tsx         # next-themes wrapper (optional)
+├── public/
+└── next.config.ts
+```
+
+### 3.2 Routes & Pages
+
+| Route | Page Content | Key Components | TanStack Query Hooks |
+|-------|--------------|----------------|----------------------|
+| `/admin/login` | Login form (API key input). Stores key in `localStorage`. | `LoginForm` | `useLogin` (custom, sets key) |
+| `/admin/dashboard` | Metrics cards, intent distribution pie chart, escalation rate line chart. | `DashboardStats`, `Recharts` components | `useDashboardMetrics` |
+| `/admin/catalog` | Data table of products. Inline editing + save. Add/remove product rows. | `DataTable`, `CatalogFormDialog` | `useCatalog`, `useUpdateCatalog` |
+| `/admin/guides` | Table of guides (intent, title, last modified). Links to editor. | `DataTable` | `useGuides` |
+| `/admin/guides/[intent]` | Split-pane markdown editor (left: edit, right: preview). Save/Delete. | `MarkdownEditor`, `MarkdownPreview` | `useGuide`, `useUpdateGuide`, `useDeleteGuide` |
+| `/admin/s3-explorer` | Tree view of `raw/` and `guides/`. Upload button (presigned), delete selected. | `S3Tree`, `UploadDialog` | `useS3Tree`, `usePresignedUpload`, `useDeleteS3Objects` |
+| `/admin/config` | Form with mutable settings only. Read-only view of immutable settings. | `ConfigForm` | `useConfig`, `useUpdateConfig` |
+| `/admin/escalation` | Confidence threshold slider, forced keywords tag input. | `EscalationForm` | `useConfig`, `useUpdateConfig` |
+| `/admin/logs` | Table of session summaries. Filters by date/intent/escalated. | `DataTable`, `LogFilterBar` | `useLogs` |
+| `/admin/logs/{session_id}` | Detail view (drawer or page) with full transcript timeline. | `LogDetailDrawer` | `useLogDetail` |
+
+### 3.3 Authentication in Frontend
+
+- **Storage**: `X-Admin-API-Key` SHALL be stored in `localStorage` under key `arte_admin_key`.
+- **Provider**: An `AdminAuthProvider` React Context SHALL wrap the app. It provides `apiKey`, `setApiKey`, and `logout`.
+- **Injection**: The TanStack Query client MUST include a default `queryFn` that reads `apiKey` from context (or `localStorage`) and injects `headers: { "X-Admin-API-Key": apiKey }` into every fetch call.
+- **Guard**: `app/admin/layout.tsx` MUST check for the presence of `apiKey`. If absent, redirect to `/admin/login` via `useRouter`.
+- **Logout**: Clearing `localStorage` and invalidating the QueryClient cache MUST trigger redirect to `/admin/login`.
+
+### 3.4 Error Handling
+
+| HTTP Status | Frontend Behavior |
+|-------------|-------------------|
+| **401** | Redirect immediately to `/admin/login`. Clear `localStorage` key. |
+| **403** | Show Sonner toast: "Acceso denegado. Verifica tu API key." Redirect to login after 3s. |
+| **404** | Show Sonner toast with specific message (e.g., "Guía no encontrada"). |
+| **409** | Show Sonner toast with conflict details (e.g., "El archivo ya existe en S3"). |
+| **422** | Parse field errors from FastAPI and display inline next to form fields (React Hook Form `setError`). |
+| **500** | Show Sonner toast: "Error del servidor. Intenta más tarde." Log to console. |
+| **Network** | TanStack Query retries 3 times with exponential backoff, then surfaces toast. |
+
+### 3.5 Build Configuration
+
+```typescript
+// admin-panel/next.config.ts
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  output: "standalone",       // Docker-friendly Node server
+  // output: "export",        // Alternative: static export if no runtime server needed
+  distDir: ".next",
+  images: {
+    unoptimized: true,        // Required for static export or simplified Docker setup
+  },
+  env: {
+    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
+  },
+};
+
+export default nextConfig;
+```
+
+> **Note**: `output: 'standalone'` is RECOMMENDED because the admin panel MAY use Next.js API routes (proxy) or server components for internal orchestration. If the panel is 100% client-side fetching the backend, `output: 'export'` is acceptable but limits dynamic behavior.
+
+---
+
+## 4. Docker / Infrastructure
+
+### 4.1 `admin-panel/Dockerfile`
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM node:20-alpine AS base
+
+# 1. Install dependencies
+FROM base AS deps
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+COPY package.json package-lock.json* pnpm-lock.yaml* ./
+RUN npm ci
+
+# 2. Build
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN npm run build
+
+# 3. Production image (standalone)
+FROM base AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+USER nextjs
+EXPOSE 3000
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+CMD ["node", "server.js"]
+```
+
+> **Requirement**: `next.config.ts` MUST set `output: 'standalone'` for this Dockerfile to work.
+
+### 4.2 `docker-compose.yml` Addition
+
+```yaml
+services:
+  # ... existing backend service ...
+
+  admin-panel:
+    build:
+      context: ./admin-panel
+      dockerfile: Dockerfile
+    container_name: arte-admin-panel
+    ports:
+      - "3001:3000"
+    environment:
+      - NEXT_PUBLIC_API_URL=http://backend:8000
+    depends_on:
+      - backend
+    restart: unless-stopped
+```
+
+### 4.3 Environment Variables
+
+| Variable | Scope | Required | Description |
+|----------|-------|----------|-------------|
+| `ADMIN_API_KEY` | Backend only | Yes | API key for `/admin/*` endpoints. Must be strong (≥32 chars). |
+| `NEXT_PUBLIC_API_URL` | Frontend (build + runtime) | Yes | Base URL of FastAPI backend (e.g., `http://localhost:8000`). |
+
+> **Security**: `ADMIN_API_KEY` MUST NOT be embedded in the frontend bundle. It lives only in backend env and is entered by the admin into the login page.
+
+---
+
+## 5. Testing Strategy
+
+### 5.1 Backend Tests (pytest)
+
+| Endpoint | Test Name | Mock Strategy |
+|----------|-----------|---------------|
+| `GET /admin/health` | `test_admin_health_authenticated` | None (static response). Assert 200 + JSON shape. |
+| `GET /admin/health` | `test_admin_health_missing_key` | Assert 401. |
+| `GET /admin/dashboard/metrics` | `test_dashboard_metrics` | Mock `session_manager` and S3 list. Assert metrics shape. |
+| `GET /admin/s3/tree` | `test_s3_tree_listing` | Mock `boto3` via `moto`. Seed S3 objects. Assert tree structure. |
+| `POST /admin/s3/presigned-upload` | `test_presigned_upload_success` | Mock `generate_presigned_post`. Assert URL returned. |
+| `DELETE /admin/s3/objects` | `test_delete_s3_objects_batch` | Mock `boto3` via `moto`. Seed objects, delete, assert gone. |
+| `GET /admin/catalog` | `test_get_catalog` | Mock S3 `get_object` with valid JSON. Assert `CatalogIndex` parsed. |
+| `PUT /admin/catalog` | `test_put_catalog_optimistic_lock` | Mock S3 `head_object` (ETag) + `put_object`. Assert 200 and reload triggered. |
+| `GET /admin/guides` | `test_list_guides` | Mock S3 list under `guides/`. Assert `List[GuideMeta]`. |
+| `GET /admin/guides/{intent}` | `test_get_guide_markdown` | Mock S3 get_object with markdown bytes. Assert `GuideContent`. |
+| `PUT /admin/guides/{intent}` | `test_update_guide` | Mock S3 `put_object`. Assert 200 and content echo. |
+| `DELETE /admin/guides/{intent}` | `test_delete_guide` | Mock S3 `head_object` + `delete_object`. Assert 200. |
+| `GET /admin/config` | `test_get_config` | Patch `settings` proxy. Assert snapshot splits mutable/immutable. |
+| `PUT /admin/config` | `test_put_config_hot_reload` | Patch env + call `settings.reload()`. Assert new values returned. |
+| `GET /admin/logs` | `test_list_logs_filtered` | Mock S3 list + get under `conversations/`. Assert filters applied. |
+| `GET /admin/logs/{session_id}` | `test_get_log_detail` | Mock S3 objects for session. Assert sorted `List[ConversationLogEntry]`. |
+
+**Test Setup Requirements**:
+- `pytest` + `httpx` (for `TestClient`).
+- `moto` for mocked S3.
+- `monkeypatch.setenv("ADMIN_API_KEY", "test-admin-key")` before each test.
+- Reset `settings.reset()` and `session_manager` state in fixtures.
+
+### 5.2 Frontend Tests (Vitest + React Testing Library)
+
+| Module | Test Name | Scope |
+|--------|-----------|-------|
+| `LoginForm` | `renders and submits api key` | Unit: input change + button click triggers `setApiKey`. |
+| `AdminAuthProvider` | `redirects to login when api key missing` | Unit: unauthenticated render of protected layout redirects. |
+| `DataTable` | `renders rows and calls pagination` | Unit: TanStack Table integration with shadcn/ui components. |
+| `CatalogPage` | `loads and displays products` | Integration: MSW mocks `GET /admin/catalog`. Assert rows rendered. |
+| `CatalogPage` | `saves updated catalog on click` | Integration: MSW mocks `PUT /admin/catalog`. Assert mutation called. |
+| `S3Tree` | `expands folders and selects files` | Unit: click folder → children rendered; checkbox selects file. |
+| `MarkdownEditor` | `renders split pane with preview` | Unit: type markdown → preview renders heading. |
+| `ConfigPage` | `disables immutable fields` | Unit: immutable inputs have `disabled` attribute. |
+| `ConfigPage` | `submits mutable settings` | Integration: MSW mocks `PUT /admin/config`. Assert toast success. |
+
+**Test Stack**:
+- **Runner**: Vitest (Next.js 16 native support per docs).
+- **DOM**: `jsdom` + `@testing-library/react`.
+- **MSW**: Mock Service Worker for API interception.
+- **Coverage**: `v8` provider, threshold 70% for MVP.
+
+---
+
+## 6. User Flows (Gherkin)
+
+### Feature: Admin Authentication
+
+```gherkin
+Feature: Admin Authentication
+  Scenario: Login con API key válida
+    Given el admin navega a /admin/login
+    When ingresa una API key válida y hace clic en "Ingresar"
+    Then es redirigido a /admin/dashboard
+    And la API key se almacena en localStorage
+
+  Scenario: Acceso sin autenticar
+    Given el admin no ha iniciado sesión
+    When intenta acceder a /admin/catalog
+    Then es redirigido a /admin/login
+```
+
+### Feature: Dashboard
+
+```gherkin
+Feature: Dashboard
+  Scenario: Ver métricas en tiempo real
+    Given el admin ha iniciado sesión
+    When accede a /admin/dashboard
+    Then ve el conteo de sesiones activas, tokens totales, y tasa de escalamiento
+    And el gráfico de distribución de intenciones muestra datos
+```
+
+### Feature: S3 Explorer
+
+```gherkin
+Feature: S3 Explorer
+  Scenario: Navegar árbol de archivos y subir PDF
+    Given el admin ha iniciado sesión
+    And está en /admin/s3-explorer
+    When expande la carpeta "raw/paneles"
+    Then ve la lista de PDFs existentes
+    When selecciona "Subir archivo", elige un PDF y confirma
+    Then el archivo aparece en el árbol bajo "raw/paneles"
+    And recibe una notificación de éxito
+
+  Scenario: Eliminar objetos S3
+    Given el admin ha iniciado sesión
+    And ha seleccionado uno o más archivos en el árbol S3
+    When hace clic en "Eliminar seleccionados" y confirma
+    Then los archivos desaparecen del árbol
+    And recibe una notificación de éxito
+```
+
+### Feature: Catalog Editor
+
+```gherkin
+Feature: Catalog Editor
+  Scenario: Editar catálogo y guardar
+    Given el admin ha iniciado sesión
+    And está en /admin/catalog
+    When hace clic en "Añadir producto"
+    And completa los campos nombre_comercial, fabricante, categoría, ruta_s3
+    And hace clic en "Guardar catálogo"
+    Then el sistema persiste el nuevo catálogo en S3
+    And el chatbot utiliza el catálogo actualizado dentro de 30 segundos
+```
+
+### Feature: Guides Editor
+
+```gherkin
+Feature: Guides Editor
+  Scenario: Crear y editar guía markdown
+    Given el admin ha iniciado sesión
+    And navega a /admin/guides/nueva-intencion
+    When escribe contenido markdown en el editor
+    Then el panel de preview renderiza el markdown en tiempo real
+    When hace clic en "Guardar guía"
+    Then la guía se almacena en S3 como guides/nueva-intencion.md
+```
+
+### Feature: Config Editor
+
+```gherkin
+Feature: Config Editor
+  Scenario: Cambiar system prompt y verificar aplicación
+    Given el admin ha iniciado sesión
+    And está en /admin/config
+    When modifica el campo "System Prompt"
+    And hace clic en "Guardar configuración"
+    Then el backend recarga settings sin reiniciar el contenedor
+    And una nueva conversación en /chat utiliza el system prompt actualizado
+```
+
+### Feature: Escalation Thresholds
+
+```gherkin
+Feature: Escalation Thresholds
+  Scenario: Ajustar umbral de confianza
+    Given el admin ha iniciado sesión
+    And está en /admin/escalation
+    When desliza el slider de "Umbral de confianza" a 0.6
+    And hace clic en "Guardar"
+    Then el backend actualiza escalation_confidence_threshold a 0.6
+    And las próximas clasificaciones de intención respetan el nuevo umbral
+```
+
+### Feature: Conversation Logs
+
+```gherkin
+Feature: Conversation Logs
+  Scenario: Revisar logs de conversación
+    Given el admin ha iniciado sesión
+    And está en /admin/logs
+    When aplica un filtro por fecha "2026-05-01" a "2026-05-16"
+    Then la tabla muestra solo sesiones dentro del rango
+    When hace clic en una session_id
+    Then se abre el detalle con la transcripción completa turno por turno
+```
+
+---
+
+## 7. SDD Compliance
+
+### Requirements Summary
+
+| Domain | Type | Requirements | Scenarios |
+|--------|------|--------------|-----------|
+| admin-auth | New | 2 | 2 |
+| admin-dashboard | New | 1 | 1 |
+| admin-s3-explorer | New | 2 | 2 |
+| admin-catalog-editor | New | 1 | 1 |
+| admin-guides-editor | New | 1 | 1 |
+| admin-config-editor | New | 1 | 1 |
+| admin-escalation | New | 1 | 1 |
+| admin-conversation-logs | New | 2 | 2 |
+| **Total** | — | **11** | **11** |
+
+### Coverage
+
+- **Happy paths**: Covered for all 8 features.
+- **Edge cases**: Covered (401/403 redirects, 409 conflicts, empty catalog, missing guides).
+- **Error states**: Covered via explicit error handling tables and Gherkin preconditions.
+
+### Risks
+
+| Risk | Likelihood | Mitigation in Spec |
+|------|------------|--------------------|
+| Concurrent catalog edits corrupt JSON | Med | E7 specifies optimistic locking with ETag (`If-Match`). |
+| Large PDF uploads bloat backend | Med | E4 uses presigned POST; frontend uploads directly to S3. |
+| Settings reload race conditions | Low | E13 specifies atomic proxy swap via `settings.reload()`. |
+| CORS between panel and backend | Low | `allow_origins` in backend CORS MUST include admin panel origin. |
+| Admin key leakage | Med | Key stored only in env + localStorage (client). No cookies. |
+| Next.js 16 caching stale data | Low | TanStack Query `staleTime: 0` and manual invalidation on mutations. |
+
+### Next Recommended Phase
+
+Ready for **sdd-design** (technical design document) followed by **sdd-tasks** (implementation task breakdown). If design already exists, proceed directly to **sdd-tasks**.
+
+### Artifacts
+
+- `openspec/changes/admin-panel-mvp/proposal.md` (read)
+- `openspec/changes/admin-panel-mvp/spec.md` (this file)
+
+### Skill Resolution
+
+- **sdd-spec**: Executed. Complied with single-file artifact request despite default multi-domain structure.
+- **RFC 2119**: Applied (MUST, SHALL, SHOULD, MAY) in requirements and endpoint specs.
+- **Gherkin**: 11 scenarios across 8 features.
+- **Pydantic v2**: All schemas use v2 patterns (`model_validator`, `Field`).

--- a/openspec/changes/admin-panel-mvp/tasks.md
+++ b/openspec/changes/admin-panel-mvp/tasks.md
@@ -1,0 +1,333 @@
+# Tasks: Admin Panel MVP
+
+> **Artifact**: `openspec/changes/admin-panel-mvp/tasks.md`  
+> **Change**: admin-panel-mvp  
+> **Delivery Strategy**: `auto-chain`  
+> **Chain Strategy**: `feature-branch-chain`
+
+---
+
+## 1. Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | ~2,000 (backend ~700 + frontend ~1,000 + infra ~300) |
+| 400-line budget risk | High (without chaining) |
+| Chained PRs recommended | Yes |
+| Suggested split | 6 chained PRs (see slices below) |
+| Delivery strategy | `auto-chain` |
+| Chain strategy | `feature-branch-chain` |
+
+```
+Decision needed before apply: No
+Chained PRs recommended: Yes
+Chain strategy: feature-branch-chain
+400-line budget risk: High
+```
+
+**Tracker branch**: `feature/admin-panel`
+
+| Slice | PR | Base Branch | Est. Lines | Risk |
+|-------|----|-------------|------------|------|
+| Slice 1 | PR #1 | `feature/admin-panel` | ~320 | Low |
+| Slice 2 | PR #2 | `feature/admin-panel-slice-1` | ~350 | Low |
+| Slice 3 | PR #3 | `feature/admin-panel-slice-2` | ~380 | Low |
+| Slice 4 | PR #4 | `feature/admin-panel-slice-3` | ~340 | Low |
+| Slice 5 | PR #5 | `feature/admin-panel-slice-4` | ~360 | Low |
+| Slice 6 | PR #6 | `feature/admin-panel-slice-5` | ~300 | Low |
+
+---
+
+## 2. Slices (Chained PRs)
+
+### Slice 1: Backend Foundation — Auth + S3 + Config
+
+**Branch**: `feature/admin-panel-slice-1`  
+**Target PR**: `feature/admin-panel` (tracker)  
+**Est. Lines**: ~320  
+**Done When**: All admin endpoints reject invalid/missing keys; S3 extensions pass unit tests; settings reload works atomically.
+
+- [x] **1.1** Add `ADMIN_API_KEY_HEADER` and `verify_admin_key` dependency to `backend/app/auth.py`. Use `hmac.compare_digest` for timing-safe comparison. Return 401/403/503 as spec'd.
+- [x] **1.2** Add `admin_api_key: Optional[str]` to `backend/app/config.py` Settings model. Implement `_SettingsProxy.reload()` with atomic `_instance` swap.
+- [x] **1.3** Extend `backend/app/s3_client.py` with `list_objects()`, `head_object()`, `delete_object()`, `delete_objects()`, `generate_presigned_post()`. Raise custom S3 exceptions on failures.
+- [x] **1.4** Create `backend/app/admin_schemas.py` with all Pydantic v2 models: `CatalogIndex`, `GuideMeta`, `GuideContent`, `DashboardMetrics`, `MutableSettings`, `ImmutableSettings`, `CurrentSettingsSnapshot`, `S3TreeNode`, `PresignedUploadRequest`, `PresignedUploadResponse`, `DeleteS3ObjectsRequest`, `LogFilterParams`.
+- [x] **1.5** Create `backend/app/admin_router.py` with root `APIRouter(prefix="/admin")`. Mount `GET /admin/health` returning `{"status": "healthy", "service": "arte-chatbot-admin"}`.
+- [x] **1.6** Create `backend/app/admin_auth.py` wrapper re-exporting `verify_admin_key` for clean router imports.
+- [x] **1.7** Wire `admin_router` into `backend/main.py` via `app.include_router(admin_router, prefix="/admin")`. Add `http://localhost:3001` to `CORSMiddleware` `allow_origins`.
+- [x] **1.8** Write backend tests: `test_admin_health_authenticated`, `test_admin_health_missing_key`, `test_admin_health_invalid_key`, `test_s3_list_objects_mock`, `test_s3_presigned_post_mock`, `test_s3_delete_objects_mock`, `test_settings_reload_atomic`.
+
+**Files Created**: `backend/app/admin_schemas.py`, `backend/app/admin_router.py`, `backend/app/admin_auth.py`, `backend/app/tests/test_admin_slice1.py`  
+**Files Modified**: `backend/app/auth.py`, `backend/app/config.py`, `backend/app/s3_client.py`, `backend/main.py`
+
+---
+
+### Slice 2: Backend Domain — Catalog + Guides + Logs
+
+**Branch**: `feature/admin-panel-slice-2`  
+**Target PR**: `feature/admin-panel-slice-1`  
+**Est. Lines**: ~350  
+**Done When**: Catalog CRUD with optimistic locking passes tests; guides CRUD works; log filtering returns correct summaries.
+
+- [x] **2.1** Create `backend/app/admin_catalog.py`. Implement `GET /admin/catalog` (download `index/catalog_index.json`, validate `CatalogIndex`). Implement `PUT /admin/catalog` with `If-Match` ETag optimistic locking (409 on mismatch) and `get_catalog(force_reload=True)` cache invalidation.
+- [x] **2.2** Create `backend/app/admin_guides.py`. Implement `GET /admin/guides` (list `.md` under `guides/`), `GET /admin/guides/{intent}` (sanitize + download), `PUT /admin/guides/{intent}` (validate + upload), `DELETE /admin/guides/{intent}` (head + delete).
+- [x] **2.3** Create `backend/app/admin_logs.py`. Implement `GET /admin/logs` (list `conversations/`, filter in-memory by date/intent/escalated, paginate with limit/offset). Implement `GET /admin/logs/{session_id}` (download all JSON under prefix, sort by `turn_number`).
+- [x] **2.4** Modify `backend/app/catalog.py` to expose `save_catalog(index_data: dict, etag: Optional[str])` and `reload_catalog()` helpers.
+- [x] **2.5** Modify `backend/app/conversation_logger.py` to expose `list_logs(filters)` and `get_log(session_id)` for S3 prefix reads.
+- [x] **2.6** Wire catalog, guides, logs routers into `backend/app/admin_router.py` via `include_router`.
+- [x] **2.7** Write backend tests: `test_get_catalog`, `test_put_catalog_optimistic_lock`, `test_put_catalog_validation_error`, `test_list_guides`, `test_get_guide`, `test_update_guide`, `test_delete_guide`, `test_list_logs_filtered`, `test_get_log_detail`.
+
+**Files Created**: `backend/app/admin_catalog.py`, `backend/app/admin_guides.py`, `backend/app/admin_logs.py`, `backend/app/tests/test_admin_slice2.py`  
+**Files Modified**: `backend/app/catalog.py`, `backend/app/conversation_logger.py`, `backend/app/admin_router.py`
+
+---
+
+### Slice 3: Backend Dashboard + Frontend Bootstrap
+
+**Branch**: `feature/admin-panel-slice-3`  
+**Target PR**: `feature/admin-panel-slice-2`  
+**Est. Lines**: ~380  
+**Done When**: Dashboard endpoint returns real aggregated metrics; Next.js builds successfully; login page renders and stores key.
+
+- [ ] **3.1** Create `backend/app/admin_dashboard.py`. Implement `GET /admin/dashboard/metrics` aggregating `session_manager.get_session_count()`, `get_all_token_totals()`, and scanning S3 `conversations/` (last 24h) for escalation rate and intent distribution.
+- [ ] **3.2** Modify `backend/app/session.py` to expose `get_all_token_totals()`, `get_intent_distribution()`, `get_escalation_rate()` for metric aggregation.
+- [ ] **3.3** Create `backend/app/admin_config.py`. Implement `GET /admin/config` (snapshot mutable/immutable with secrets redacted as `***REDACTED***`). Implement `PUT /admin/config` (partial `MutableSettings` update + `settings.reload()`).
+- [ ] **3.4** Wire dashboard and config routers into `backend/app/admin_router.py`.
+- [ ] **3.5** Write backend tests: `test_dashboard_metrics`, `test_get_config_redacts_secrets`, `test_put_config_hot_reload`.
+- [ ] **3.6** Bootstrap `admin-panel/` with `create-next-app@latest` (Next.js 16, App Router, TypeScript, Tailwind CSS). Install dependencies: `shadcn/ui` init, `@tanstack/react-query`, `react-hook-form`, `zod`, `@hookform/resolvers`, `recharts`, `sonner`, `next-themes`.
+- [ ] **3.7** Configure `admin-panel/next.config.ts` with `output: "standalone"`, `images.unoptimized: true`, and `NEXT_PUBLIC_API_URL` env mapping.
+- [ ] **3.8** Configure `admin-panel/tailwind.config.ts` and `admin-panel/app/globals.css` for shadcn/ui base styles.
+- [ ] **3.9** Create `admin-panel/app/layout.tsx` with root providers (`QueryClientProvider`, `AdminAuthProvider`, `Sonner`).
+- [ ] **3.10** Create `admin-panel/app/admin/layout.tsx` with sidebar navigation, header, and auth guard (redirect to `/admin/login` if no key in `localStorage`).
+- [ ] **3.11** Create `admin-panel/app/admin/login/page.tsx` with API key input form. Store key in `localStorage` as `arte_admin_key`. Redirect to `/admin/dashboard` on save.
+- [ ] **3.12** Create `admin-panel/providers/admin-auth-provider.tsx` with context exposing `apiKey`, `setApiKey`, `logout`, `isAuthenticated`.
+- [ ] **3.13** Create `admin-panel/providers/query-client.tsx` with TanStack Query client setup (`staleTime: 30_000` default).
+- [ ] **3.14** Create `admin-panel/lib/utils.ts` with `cn()` helper. Create `admin-panel/lib/types.ts` with TypeScript interfaces mirroring Pydantic schemas.
+- [ ] **3.15** Write frontend tests: login form submits and stores key; auth guard redirects unauthenticated users.
+
+**Files Created**: `backend/app/admin_dashboard.py`, `backend/app/admin_config.py`, `backend/app/tests/test_admin_slice3.py`, `admin-panel/*` (bootstrap files)  
+**Files Modified**: `backend/app/session.py`, `backend/app/admin_router.py`
+
+---
+
+### Slice 4: Frontend Pages — Dashboard + Config + Escalation
+
+**Branch**: `feature/admin-panel-slice-4`  
+**Target PR**: `feature/admin-panel-slice-3`  
+**Est. Lines**: ~340  
+**Done When**: Dashboard renders charts with live data; config form saves and triggers toast; escalation slider updates threshold.
+
+- [ ] **4.1** Create `admin-panel/lib/api.ts` with TanStack Query hooks: `useDashboardMetrics`, `useConfig`, `useUpdateConfig`. Implement default `queryFn` injecting `X-Admin-API-Key` header from context/localStorage.
+- [ ] **4.2** Create `admin-panel/lib/schemas.ts` with Zod schemas mirroring Pydantic: `CatalogProductSchema`, `MutableSettingsSchema` (with `msg_delay_min/max` cross-field refinement).
+- [ ] **4.3** Create `admin-panel/app/admin/dashboard/page.tsx`. Render `StatsCards` (active sessions, total tokens, escalation rate). Render `IntentPieChart` (Recharts Pie) and `EscalationLineChart` (Recharts Line/Area).
+- [ ] **4.4** Create `admin-panel/components/dashboard-stats.tsx` with Recharts-based stat cards and chart wrappers.
+- [ ] **4.5** Create `admin-panel/app/admin/config/page.tsx`. Render `ConfigForm` with React Hook Form + Zod. Display mutable fields as editable inputs; immutable fields as read-only with `disabled`. Submit calls `useUpdateConfig`.
+- [ ] **4.6** Create `admin-panel/app/admin/escalation/page.tsx`. Render confidence threshold slider and forced keywords tag input. Submit via `useUpdateConfig`.
+- [ ] **4.7** Wire Sonner toasts for mutation success/error on config and escalation pages. Handle 422 errors by mapping to form fields via `form.setError`.
+- [ ] **4.8** Write frontend tests: dashboard renders stats cards; config form disables immutable fields; config form submits mutable settings and shows toast.
+
+**Files Created**: `admin-panel/lib/api.ts`, `admin-panel/lib/schemas.ts`, `admin-panel/app/admin/dashboard/page.tsx`, `admin-panel/app/admin/config/page.tsx`, `admin-panel/app/admin/escalation/page.tsx`, `admin-panel/components/dashboard-stats.tsx`, `admin-panel/components/config-form.tsx`, `admin-panel/components/escalation-form.tsx`, `admin-panel/__tests__/slice4.test.tsx`  
+**Files Modified**: `admin-panel/app/admin/layout.tsx` (add nav links)
+
+---
+
+### Slice 5: Frontend Pages — S3 Explorer + Catalog + Guides
+
+**Branch**: `feature/admin-panel-slice-5`  
+**Target PR**: `feature/admin-panel-slice-4`  
+**Est. Lines**: ~360  
+**Done When**: S3 tree expands/collapses; catalog table inline-edits and saves; markdown editor split-pane renders preview.
+
+- [ ] **5.1** Extend `admin-panel/lib/api.ts` with hooks: `useS3Tree`, `usePresignedUpload`, `useDeleteS3Objects`, `useCatalog`, `useUpdateCatalog`, `useGuides`, `useGuide`, `useUpdateGuide`, `useDeleteGuide`.
+- [ ] **5.2** Create `admin-panel/components/s3-tree.tsx`. Recursive tree using shadcn `Collapsible` + checkboxes. Fetches `GET /admin/s3/tree?prefix=raw/` or `guides/`.
+- [ ] **5.3** Create `admin-panel/components/upload-dialog.tsx`. File picker → calls `usePresignedUpload` → POSTs multipart directly to S3 presigned URL → invalidates S3 tree cache on success.
+- [ ] **5.4** Create `admin-panel/app/admin/s3-explorer/page.tsx`. Render `S3Tree`, upload button, delete-selected button with confirmation dialog.
+- [ ] **5.5** Create `admin-panel/components/data-table.tsx`. Reusable TanStack Table v8 wrapper with shadcn/ui `Table`, pagination, sorting, and column visibility.
+- [ ] **5.6** Create `admin-panel/app/admin/catalog/page.tsx`. Render `DataTable<CatalogProduct>`. Inline editing per row. "Add product" and "Remove selected" buttons. Save triggers `useUpdateCatalog` with current ETag.
+- [ ] **5.7** Create `admin-panel/app/admin/guides/page.tsx`. Render `DataTable<GuideMeta>` with links to `guides/[intent]`.
+- [ ] **5.8** Create `admin-panel/app/admin/guides/[intent]/page.tsx`. Split-pane layout: left `MarkdownEditor` (dynamic import `@uiw/react-md-editor` with `ssr: false`), right `MarkdownPreview` (`react-markdown`). Save/delete buttons.
+- [ ] **5.9** Create `admin-panel/components/markdown-editor.tsx` and `admin-panel/components/markdown-preview.tsx` wrappers.
+- [ ] **5.10** Write frontend tests: S3 tree expands folders; catalog page loads products; guide editor renders split pane.
+
+**Files Created**: `admin-panel/app/admin/s3-explorer/page.tsx`, `admin-panel/app/admin/catalog/page.tsx`, `admin-panel/app/admin/guides/page.tsx`, `admin-panel/app/admin/guides/[intent]/page.tsx`, `admin-panel/components/s3-tree.tsx`, `admin-panel/components/upload-dialog.tsx`, `admin-panel/components/data-table.tsx`, `admin-panel/components/markdown-editor.tsx`, `admin-panel/components/markdown-preview.tsx`, `admin-panel/__tests__/slice5.test.tsx`  
+**Files Modified**: `admin-panel/lib/api.ts`, `admin-panel/app/admin/layout.tsx` (add nav links)
+
+---
+
+### Slice 6: Frontend Pages — Logs + Docker + CI/CD
+
+**Branch**: `feature/admin-panel-slice-6`  
+**Target PR**: `feature/admin-panel-slice-5`  
+**Est. Lines**: ~300  
+**Done When**: Logs table filters and shows detail drawer; Docker compose spins up admin panel on port 3001; CI passes; all integration tests green.
+
+- [ ] **6.1** Extend `admin-panel/lib/api.ts` with hooks: `useLogs`, `useLogDetail`.
+- [ ] **6.2** Create `admin-panel/app/admin/logs/page.tsx`. Render `DataTable<ConversationLogSummary>` with `LogFilterBar` (date range, intent select, escalated checkbox). Click row opens detail drawer.
+- [ ] **6.3** Create `admin-panel/components/log-filter-bar.tsx` with date pickers, intent dropdown, and escalated toggle.
+- [ ] **6.4** Create `admin-panel/components/log-detail-drawer.tsx` (or page). Display full chronological transcript of `ConversationLogEntry` list with turn numbers, timestamps, and tokens.
+- [ ] **6.5** Create `admin-panel/Dockerfile` with multi-stage build (`deps` → `builder` → `runner`), `node:20-alpine`, standalone output, non-root `nextjs` user.
+- [ ] **6.6** Update root `docker-compose.yml` to add `admin-panel` service exposing port `3001:3000`, depending on `backend`, with `NEXT_PUBLIC_API_URL=http://backend:8000`.
+- [ ] **6.7** Create `.github/workflows/admin-panel.yml` with jobs: checkout → setup-node@20 → `npm ci` → `npm run lint` → `npm run typecheck` → `npm run test:unit` → `npm run build`.
+- [ ] **6.8** Update `admin-panel/package.json` scripts: `lint`, `typecheck`, `test:unit`, `build`.
+- [ ] **6.9** Run final integration tests: `docker compose up -d` → verify backend health (`/health`) → verify admin health (`/admin/health`) → verify login → verify catalog CRUD → verify config hot reload → verify S3 upload/delete.
+- [ ] **6.10** Verify existing `/chat` endpoint remains functional and unchanged post-integration.
+
+**Files Created**: `admin-panel/app/admin/logs/page.tsx`, `admin-panel/components/log-filter-bar.tsx`, `admin-panel/components/log-detail-drawer.tsx`, `admin-panel/Dockerfile`, `.github/workflows/admin-panel.yml`, `admin-panel/__tests__/slice6.test.tsx`  
+**Files Modified**: `docker-compose.yml`, `admin-panel/package.json`, `admin-panel/lib/api.ts`, `admin-panel/app/admin/layout.tsx` (add nav links)
+
+---
+
+## 3. Detailed Task List by Slice
+
+| Slice | Task | Files | Depends On | Definition of Done |
+|-------|------|-------|------------|-------------------|
+| 1 | 1.1 Admin auth dependency | `backend/app/auth.py` | — | `test_admin_health_missing_key` passes; 401/403/503 returned correctly |
+| 1 | 1.2 Settings reload | `backend/app/config.py` | — | `settings.reload()` swaps instance atomically; concurrent reads safe |
+| 1 | 1.3 S3 extensions | `backend/app/s3_client.py` | — | All 5 new methods unit-tested with mocked boto3 |
+| 1 | 1.4 Admin schemas | `backend/app/admin_schemas.py` | — | All Pydantic models validate correctly with sample data |
+| 1 | 1.5 Admin router + health | `backend/app/admin_router.py` | 1.1 | `GET /admin/health` returns 200 with correct JSON shape |
+| 1 | 1.6 Auth wrapper | `backend/app/admin_auth.py` | 1.1 | Clean import in router files |
+| 1 | 1.7 Wire router + CORS | `backend/main.py` | 1.5 | `/admin/*` routes resolve; CORS includes `:3001` |
+| 1 | 1.8 Slice 1 tests | `backend/app/tests/test_admin_slice1.py` | 1.1–1.7 | 100% of new auth/S3/config code covered |
+| 2 | 2.1 Catalog endpoints | `backend/app/admin_catalog.py` | 1.4, 1.3 | ETag optimistic locking works; 409 on mismatch |
+| 2 | 2.2 Guides endpoints | `backend/app/admin_guides.py` | 1.4, 1.3 | CRUD cycle passes; intent sanitized with regex |
+| 2 | 2.3 Logs endpoints | `backend/app/admin_logs.py` | 1.4, 1.3 | Filtering by date/intent/escalated returns correct subset |
+| 2 | 2.4 Catalog helpers | `backend/app/catalog.py` | 2.1 | `save_catalog` and `reload_catalog` exported and tested |
+| 2 | 2.5 Logger helpers | `backend/app/conversation_logger.py` | 2.3 | `list_logs` and `get_log` exported and tested |
+| 2 | 2.6 Wire domain routers | `backend/app/admin_router.py` | 2.1–2.3 | All `/admin/catalog`, `/admin/guides`, `/admin/logs` reachable |
+| 2 | 2.7 Slice 2 tests | `backend/app/tests/test_admin_slice2.py` | 2.1–2.6 | All CRUD scenarios pass including 409/404/422 |
+| 3 | 3.1 Dashboard endpoint | `backend/app/admin_dashboard.py` | 2.3 | Returns `DashboardMetrics` with real aggregated data |
+| 3 | 3.2 Session metrics | `backend/app/session.py` | 3.1 | `get_all_token_totals()`, `get_intent_distribution()` tested |
+| 3 | 3.3 Config endpoints | `backend/app/admin_config.py` | 1.2 | Secrets redacted; hot reload works without restart |
+| 3 | 3.4 Wire dashboard/config | `backend/app/admin_router.py` | 3.1, 3.3 | `/admin/dashboard/metrics` and `/admin/config` reachable |
+| 3 | 3.5 Slice 3 backend tests | `backend/app/tests/test_admin_slice3.py` | 3.1–3.4 | Metrics shape validated; config reload verified |
+| 3 | 3.6 Next.js bootstrap | `admin-panel/*` | — | `npm run build` succeeds with zero errors |
+| 3 | 3.7 next.config.ts | `admin-panel/next.config.ts` | 3.6 | `output: "standalone"` set; build produces `.next/standalone` |
+| 3 | 3.8 Tailwind + globals | `admin-panel/tailwind.config.ts`, `globals.css` | 3.6 | shadcn/ui components render with correct base styles |
+| 3 | 3.9 Root layout | `admin-panel/app/layout.tsx` | 3.6 | Providers wrap app; no hydration errors |
+| 3 | 3.10 Admin layout | `admin-panel/app/admin/layout.tsx` | 3.9 | Sidebar renders; unauthenticated redirect works |
+| 3 | 3.11 Login page | `admin-panel/app/admin/login/page.tsx` | 3.10 | Key stored in `localStorage`; redirect to dashboard |
+| 3 | 3.12 Auth provider | `admin-panel/providers/admin-auth-provider.tsx` | 3.9 | Context provides `apiKey`, `setApiKey`, `logout` |
+| 3 | 3.13 Query client | `admin-panel/providers/query-client.tsx` | 3.9 | Default `staleTime: 30_000`; devtools optional |
+| 3 | 3.14 Utils + types | `admin-panel/lib/utils.ts`, `lib/types.ts` | 3.6 | `cn()` works; TypeScript interfaces match Pydantic |
+| 3 | 3.15 Slice 3 frontend tests | `admin-panel/__tests__/slice3.test.tsx` | 3.10–3.12 | Login and auth guard tested with React Testing Library |
+| 4 | 4.1 API hooks (dash/config) | `admin-panel/lib/api.ts` | 3.14 | All dashboard/config hooks fetch and cache correctly |
+| 4 | 4.2 Zod schemas | `admin-panel/lib/schemas.ts` | 3.14 | `MutableSettingsSchema` cross-field refinement works |
+| 4 | 4.3 Dashboard page | `admin-panel/app/admin/dashboard/page.tsx` | 4.1 | Charts render with data from backend |
+| 4 | 4.4 Dashboard stats | `admin-panel/components/dashboard-stats.tsx` | 4.3 | Recharts Pie and Line display without errors |
+| 4 | 4.5 Config page | `admin-panel/app/admin/config/page.tsx` | 4.1, 4.2 | Form submits; 422 errors map to fields |
+| 4 | 4.6 Escalation page | `admin-panel/app/admin/escalation/page.tsx` | 4.1, 4.2 | Slider and keywords save successfully |
+| 4 | 4.7 Toast wiring | Various | 4.5, 4.6 | Sonner shows success on save; error on failure |
+| 4 | 4.8 Slice 4 tests | `admin-panel/__tests__/slice4.test.tsx` | 4.3–4.7 | Dashboard, config, escalation pages render and submit |
+| 5 | 5.1 API hooks (S3/catalog/guides) | `admin-panel/lib/api.ts` | 3.14 | All new hooks fetch/mutate with correct invalidation |
+| 5 | 5.2 S3 tree component | `admin-panel/components/s3-tree.tsx` | 5.1 | Recursive expansion; checkbox selection |
+| 5 | 5.3 Upload dialog | `admin-panel/components/upload-dialog.tsx` | 5.1 | File → presigned URL → S3 direct upload → cache invalidation |
+| 5 | 5.4 S3 explorer page | `admin-panel/app/admin/s3-explorer/page.tsx` | 5.2, 5.3 | Upload and delete buttons functional; tree refreshes |
+| 5 | 5.5 Data table | `admin-panel/components/data-table.tsx` | — | Reusable wrapper sorts, paginates, toggles columns |
+| 5 | 5.6 Catalog page | `admin-panel/app/admin/catalog/page.tsx` | 5.1, 5.5 | Inline edit + save with ETag; add/remove rows |
+| 5 | 5.7 Guides list page | `admin-panel/app/admin/guides/page.tsx` | 5.1, 5.5 | Table links to intent editor |
+| 5 | 5.8 Guide editor page | `admin-panel/app/admin/guides/[intent]/page.tsx` | 5.1 | Split-pane edit/preview; save/delete functional |
+| 5 | 5.9 Markdown components | `admin-panel/components/markdown-editor.tsx`, `markdown-preview.tsx` | 5.8 | Dynamic import avoids SSR issues |
+| 5 | 5.10 Slice 5 tests | `admin-panel/__tests__/slice5.test.tsx` | 5.2–5.9 | S3 tree, catalog, editor render and interact |
+| 6 | 6.1 API hooks (logs) | `admin-panel/lib/api.ts` | 3.14 | `useLogs` and `useLogDetail` fetch correctly |
+| 6 | 6.2 Logs page | `admin-panel/app/admin/logs/page.tsx` | 6.1 | Table renders with filters applied |
+| 6 | 6.3 Log filter bar | `admin-panel/components/log-filter-bar.tsx` | 6.2 | Date range, intent, escalated filters update table |
+| 6 | 6.4 Log detail drawer | `admin-panel/components/log-detail-drawer.tsx` | 6.1 | Full transcript displayed chronologically |
+| 6 | 6.5 Dockerfile | `admin-panel/Dockerfile` | 3.7 | Multi-stage build; non-root user; standalone output |
+| 6 | 6.6 docker-compose update | `docker-compose.yml` | 6.5 | `admin-panel` service starts on `:3001`; depends on backend |
+| 6 | 6.7 GitHub Actions | `.github/workflows/admin-panel.yml` | 6.5 | CI passes on push/PR to `admin-panel/**` |
+| 6 | 6.8 package.json scripts | `admin-panel/package.json` | 6.7 | `lint`, `typecheck`, `test:unit`, `build` defined |
+| 6 | 6.9 Integration tests | Manual / scripted | 1–6 | Full end-to-end flow passes in Docker |
+| 6 | 6.10 Chat regression | `backend/main.py` | 1–6 | `POST /chat` still returns 200 with valid `X-API-Key` |
+
+---
+
+## 4. Slice Dependencies
+
+```
+Slice 1 → Slice 2 → Slice 3 → Slice 4 → Slice 5 → Slice 6
+```
+
+**Why this order:**
+
+| Dependency | Explanation |
+|------------|-------------|
+| **Slice 1 → Slice 2** | Catalog, guides, and logs endpoints depend on `admin_schemas.py`, S3 extensions, auth dependency, and the admin router skeleton from Slice 1. |
+| **Slice 2 → Slice 3** | Dashboard metrics need session aggregation and conversation log queries (Slice 2). Config endpoint needs `settings.reload()` (Slice 1). Frontend bootstrap is independent of backend domain logic but we bundle it here to keep Slice 3 reviewable. |
+| **Slice 3 → Slice 4** | Dashboard, config, and escalation pages depend on the TanStack Query hooks and auth provider bootstrapped in Slice 3. |
+| **Slice 4 → Slice 5** | S3 explorer, catalog, and guides pages reuse the `DataTable`, `api.ts` patterns, and layout established in Slice 4. |
+| **Slice 5 → Slice 6** | Logs page reuses `DataTable` and filtering patterns from Slice 5. Docker/CI should come last to package the complete frontend. |
+
+**What CANNOT be parallelized:**
+- Backend routers cannot be implemented before auth, schemas, and S3 extensions exist.
+- Frontend pages cannot fetch data before backend endpoints exist.
+- Docker/CI cannot be finalized until all frontend pages and build scripts exist.
+
+---
+
+## 5. Testing Matrix
+
+| Slice | Backend Tests (pytest) | Frontend Tests (Vitest + RTL) | Integration Tests |
+|-------|------------------------|-------------------------------|-------------------|
+| 1 | Auth (401/403/503), S3 mocks (list/delete/presigned), config reload | — | — |
+| 2 | Catalog CRUD + ETag lock, guides CRUD, logs list/detail + filters | — | — |
+| 3 | Dashboard metrics, config snapshot + hot reload | Login form, auth guard redirect | — |
+| 4 | — | Dashboard render, config form submit, escalation slider | — |
+| 5 | — | S3 tree interaction, catalog inline edit, markdown editor split-pane | S3 presigned upload E2E |
+| 6 | — | Logs table + filters, log detail drawer | Docker compose health, `/chat` regression |
+
+**Coverage Targets (MVP):**
+- Backend: ≥80% on new admin modules.
+- Frontend: ≥70% overall; 100% on `api.ts` hooks and form submissions.
+
+---
+
+## 6. Environment Variables & Configuration
+
+| Variable | Scope | Required | Default | Where to Set |
+|----------|-------|----------|---------|--------------|
+| `ADMIN_API_KEY` | Backend | Yes | — | `.env`, Docker secrets, CI secrets |
+| `NEXT_PUBLIC_API_URL` | Frontend (build + runtime) | Yes | `http://localhost:8000` | `admin-panel/.env.local`, `docker-compose.yml` |
+| `ADMIN_PANEL_ORIGIN` | Backend CORS | No | `http://localhost:3001` | `.env` (production) |
+| `AWS_ACCESS_KEY_ID` | Backend | Yes | — | `.env` (existing) |
+| `AWS_SECRET_ACCESS_KEY` | Backend | Yes | — | `.env` (existing) |
+| `AWS_BUCKET_NAME` | Backend | Yes | — | `.env` (existing) |
+| `AWS_REGION` | Backend | Yes | — | `.env` (existing) |
+
+**Security Notes:**
+- `ADMIN_API_KEY` must be ≥32 cryptographically random characters.
+- `OPENAI_API_KEY`, `AWS_SECRET_ACCESS_KEY`, `CHAT_API_KEY` are NEVER exposed via `/admin/config`. They are redacted as `***REDACTED***`.
+- `ADMIN_API_KEY` is NOT embedded in the Next.js bundle. It is entered at runtime via login.
+
+---
+
+## 7. Pre-Deploy Checklist
+
+Before merging tracker branch `feature/admin-panel` into `main`:
+
+- [ ] All pytest tests pass: `pytest backend/app/tests/test_admin_slice*.py -v`
+- [ ] All Vitest tests pass: `cd admin-panel && npm run test:unit`
+- [ ] TypeScript type-check passes: `cd admin-panel && npm run typecheck`
+- [ ] ESLint passes: `cd admin-panel && npm run lint`
+- [ ] Docker Compose builds cleanly: `docker compose up -d --build`
+- [ ] Backend health: `curl http://localhost:8000/health` → `200 OK`
+- [ ] Admin health: `curl -H "X-Admin-API-Key: $ADMIN_API_KEY" http://localhost:8000/admin/health` → `200 OK`
+- [ ] Admin panel loads at `http://localhost:3001/admin/login`
+- [ ] Auth rejects requests without key: `curl http://localhost:8000/admin/dashboard/metrics` → `401`
+- [ ] Auth rejects invalid key: `curl -H "X-Admin-API-Key: bad" ...` → `403`
+- [ ] Existing chat endpoint unchanged: `curl -H "X-API-Key: $CHAT_API_KEY" -X POST http://localhost:8000/chat -d '{"message":"hola"}'` → `200 OK`
+- [ ] Config hot reload verified: change system prompt via admin → new chat uses updated prompt without restart
+- [ ] Rollback plan documented and tested: stopping `admin-panel` container and removing `/admin` router does not break chat
+- [ ] Secrets redaction verified: `GET /admin/config` never returns raw `openai_api_key` or `aws_secret_access_key`
+
+---
+
+## Summary
+
+| Field | Value |
+|-------|-------|
+| **status** | `tasks_complete` |
+| **executive_summary** | 6 chained slices covering backend auth/S3/config, domain endpoints (catalog/guides/logs), dashboard/metrics, Next.js bootstrap, all frontend pages (dashboard, config, escalation, S3 explorer, catalog, guides, logs), Docker/CI/CD, and integration verification. Each slice stays under 400 changed lines for reviewable diffs. |
+| **artifacts** | `openspec/changes/admin-panel-mvp/tasks.md` |
+| **next_recommended** | `sdd-apply` — begin implementation with Slice 1 (`feature/admin-panel-slice-1`) |
+| **risks** | 1. Slice 3 is the largest (~380 lines) due to Next.js bootstrap overhead. Mitigation: bootstrap is mostly generated code. 2. Concurrent catalog edits: mitigated by ETag optimistic locking in Slice 2. 3. S3 list performance: mitigated by prefix filtering and documented MVP limits. |
+| **skill_resolution** | `sdd-tasks` completed. Tasks organized into 6 chained PRs for `feature-branch-chain` strategy. Ready for `auto-chain` execution. |


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega endpoints backend de dominio para administrar catálogo, guías Markdown y logs de conversación. También incluye los artefactos SDD del Admin Panel MVP para dejar trazabilidad de proposal/spec/design/tasks.

## Issues relacionados

Closes #176
Part of #174

## Tipo de cambio

- [x] 🆕 Nueva funcionalidad (feature)
- [ ] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [x] 🧪 Tests
- [x] 📄 Documentación / configuración
- [ ] 🔧 Infra / CI

## Chain Context

| Field | Value |
|-------|-------|
| Chain | Admin Panel MVP |
| Tracker | #174 |
| Position | 2 of 6 |
| Base | `feature/admin-panel-slice-1` |
| Depends on | Slice 1 / #175 |
| Follow-up | US-17 / Slice 3 |
| Review budget | 3009 changed lines / 400 — `size:exception` requested |
| Starts at | admin backend foundation |
| Ends with | catalog/guides/logs backend endpoints available |

### Chain Overview

```text
main
 └── feature/admin-panel tracker (#174)
      └── Slice 1 (#175)
           └── 📍 Slice 2 (#176)
                └── Slice 3 (#177)
                     └── Slice 4 (#178)
                          └── Slice 5 (#179)
                               └── Slice 6 (#180)
```

## Checklist antes de pedir review

- [x] El código corre localmente sin errores (tests pasan; build no ejecutado por regla del proyecto)
- [x] Los criterios de aceptación del issue relacionado están cumplidos
- [x] No hay credenciales, API keys ni rutas absolutas hardcodeadas
- [x] Si agregué dependencias nuevas, actualicé `requirements.txt` / `pyproject.toml` (no aplica)
- [x] Si modifiqué el schema del endpoint, verifiqué que `/docs` refleja los cambios mediante FastAPI schemas
- [x] Si modifiqué el harness o el dataset, corrí `python evaluation/harness.py` (no aplica)

## Cómo probar este PR

1. `uv run pytest backend/app/tests/test_admin_slice1.py backend/app/tests/test_admin_slice2.py -v`
2. Probar `GET/PUT /admin/catalog` con `X-Admin-API-Key`.
3. Probar `GET/PUT/DELETE /admin/guides/{intent}` con key válida.

## Notas para el reviewer

- `size:exception` solicitado porque este slice incluye OpenSpec + endpoints + tests.
