### PR TITLE
fix(chat): greet direct quote escalations

### DIFF
--- a/backend/app/greeting.py
+++ b/backend/app/greeting.py
@@ -66,7 +66,7 @@ def maybe_prepend_greeting(
 
     The greeting is prepended ONLY when ALL of the following are true:
     - greeting_enabled setting is True
-    - escalate is False
+    - escalate is False, except first-contact quote escalation
     - intent_type is not "fuera_de_dominio"
     - This is the first contact for the session
 
@@ -81,7 +81,9 @@ def maybe_prepend_greeting(
     """
     if not settings.greeting_enabled:
         return response_text
-    if escalate or intent_type == "fuera_de_dominio":
+    if intent_type == "fuera_de_dominio":
+        return response_text
+    if escalate and intent_type != "escalate_quote":
         return response_text
     if not is_first_contact(session_id):
         return response_text

--- a/backend/app/tests/test_greeting.py
+++ b/backend/app/tests/test_greeting.py
@@ -191,6 +191,27 @@ class TestMaybePrependGreeting:
 
     @patch("backend.app.greeting.settings")
     @patch("backend.app.greeting.session_manager")
+    @patch("backend.app.greeting._get_time_greeting")
+    def test_greeting_prepended_on_first_contact_quote_escalation(
+        self,
+        mock_greeting: MagicMock,
+        mock_sm: MagicMock,
+        mock_settings: MagicMock,
+    ) -> None:
+        """Quote escalation still greets first-contact users."""
+        mock_settings.greeting_enabled = True
+        mock_settings.greeting_timezone = "America/Bogota"
+        mock_sm.get_history.return_value = []
+        mock_greeting.return_value = "Buenos días"
+
+        result = maybe_prepend_greeting(
+            "s1", "Respuesta", "escalate_quote", True
+        )
+        assert "Buenos días" in result
+        assert "Respuesta" in result
+
+    @patch("backend.app.greeting.settings")
+    @patch("backend.app.greeting.session_manager")
     def test_greeting_not_prepended_on_fuera_de_dominio(
         self,
         mock_sm: MagicMock,

--- a/backend/app/tests/test_greeting.py
+++ b/backend/app/tests/test_greeting.py
@@ -204,9 +204,7 @@ class TestMaybePrependGreeting:
         mock_sm.get_history.return_value = []
         mock_greeting.return_value = "Buenos días"
 
-        result = maybe_prepend_greeting(
-            "s1", "Respuesta", "escalate_quote", True
-        )
+        result = maybe_prepend_greeting("s1", "Respuesta", "escalate_quote", True)
         assert "Buenos días" in result
         assert "Respuesta" in result
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -128,6 +128,18 @@ def _extract_intent_type(text: str) -> tuple[str, str]:
 
 
 ESCALATE_INTENTS = {"escalate_quote", "escalate_technical", "escalate_order"}
+QUOTE_ESCALATION_KEYWORDS = {"cotización", "presupuesto"}
+
+
+def _intent_type_for_escalation_keyword(matched_keyword: Optional[str]) -> str:
+    """Map rule-based escalation keywords to public intent types."""
+    if matched_keyword is None:
+        return "escalate_technical"
+    if matched_keyword.lower() in QUOTE_ESCALATION_KEYWORDS:
+        return "escalate_quote"
+    if matched_keyword.lower() == "pedido":
+        return "escalate_order"
+    return "escalate_technical"
 
 
 app = FastAPI(title="ARTE Chatbot Backend")
@@ -830,6 +842,15 @@ async def _process_chat_message(
     escalation_result = default_detector.detect(message)
 
     if escalation_result.escalate:
+        intent_type = _intent_type_for_escalation_keyword(
+            escalation_result.matched_keyword
+        )
+        response_text = maybe_prepend_greeting(
+            session_id=session_id,
+            response_text=DEFAULT_ESCALATION_MESSAGE,
+            intent_type=intent_type,
+            escalate=True,
+        )
         logger.info(
             "Escalation detected: request_id=%s, session_id=%s, reason=%s",
             request_id,
@@ -839,15 +860,15 @@ async def _process_chat_message(
         session_manager.add_turn(
             session_id=session_id,
             question=message,
-            answer=DEFAULT_ESCALATION_MESSAGE,
+            answer=response_text,
             source_documents=[],
         )
         response_time_ms = (time.time() - request_start) * 1000
         _fire_conversation_log(
             session_id=session_id,
             user_message=message,
-            bot_response=DEFAULT_ESCALATION_MESSAGE,
-            intent_type="escalate_technical",
+            bot_response=response_text,
+            intent_type=intent_type,
             escalate=True,
             source_documents=[],
             input_tokens=0,
@@ -857,9 +878,9 @@ async def _process_chat_message(
             user_profile=inferred_profile,
         )
         return ChatResponse(
-            response=DEFAULT_ESCALATION_MESSAGE,
+            response=response_text,
             escalate=True,
-            intent_type="escalate_technical",
+            intent_type=intent_type,
             reason=escalation_result.reason,
             session_id=session_id,
             source_documents=[],
@@ -945,10 +966,16 @@ async def _process_chat_message(
                 intent_type, cleaned_content = _extract_intent_type(content)
 
                 if intent_type in ESCALATE_INTENTS:
+                    response_text = maybe_prepend_greeting(
+                        session_id=session_id,
+                        response_text=DEFAULT_ESCALATION_MESSAGE,
+                        intent_type=intent_type,
+                        escalate=True,
+                    )
                     session_manager.add_turn(
                         session_id=session_id,
                         question=message,
-                        answer=DEFAULT_ESCALATION_MESSAGE,
+                        answer=response_text,
                         source_documents=[],
                     )
                     session_manager.add_token_usage(
@@ -961,7 +988,7 @@ async def _process_chat_message(
                     _fire_conversation_log(
                         session_id=session_id,
                         user_message=message,
-                        bot_response=DEFAULT_ESCALATION_MESSAGE,
+                        bot_response=response_text,
                         intent_type=intent_type,
                         escalate=True,
                         source_documents=[s.ruta for s in source_docs],
@@ -972,7 +999,7 @@ async def _process_chat_message(
                         user_profile=inferred_profile,
                     )
                     return ChatResponse(
-                        response=DEFAULT_ESCALATION_MESSAGE,
+                        response=response_text,
                         escalate=True,
                         intent_type=intent_type,
                         reason=f"Intent classified as {intent_type}",
@@ -1303,10 +1330,16 @@ async def _process_chat_message(
         intent_type, cleaned_text = _extract_intent_type(last_output_text)
 
         if intent_type in ESCALATE_INTENTS:
+            response_text = maybe_prepend_greeting(
+                session_id=session_id,
+                response_text=DEFAULT_ESCALATION_MESSAGE,
+                intent_type=intent_type,
+                escalate=True,
+            )
             session_manager.add_turn(
                 session_id=session_id,
                 question=message,
-                answer=DEFAULT_ESCALATION_MESSAGE,
+                answer=response_text,
                 source_documents=[],
             )
             session_manager.add_token_usage(
@@ -1316,7 +1349,7 @@ async def _process_chat_message(
             _fire_conversation_log(
                 session_id=session_id,
                 user_message=message,
-                bot_response=DEFAULT_ESCALATION_MESSAGE,
+                bot_response=response_text,
                 intent_type=intent_type,
                 escalate=True,
                 source_documents=[s.ruta for s in source_docs],
@@ -1327,7 +1360,7 @@ async def _process_chat_message(
                 user_profile=inferred_profile,
             )
             return ChatResponse(
-                response=DEFAULT_ESCALATION_MESSAGE,
+                response=response_text,
                 escalate=True,
                 intent_type=intent_type,
                 reason=f"Intent classified as {intent_type}",

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -99,13 +99,18 @@ class TestChatEndpointUnit:
             text="[INTENT: escalate_quote] Un agente de ventas te contactará pronto.",
         )
         response = client.post(
-            "/chat", json={"message": "Necesito una cotización de paneles"}
+            "/chat",
+            json={
+                "message": "Necesito una cotización de paneles",
+                "is_final": True,
+            },
         )
         assert response.status_code == 200
         data = response.json()
         assert data["escalate"] is True
         assert data["intent_type"] == "escalate_quote"
         assert data["session_id"] is not None
+        assert "asistente virtual de Arte Soluciones Energéticas" in data["response"]
 
     @patch("backend.main.llm_client.get_llm_response_with_tools")
     def test_chat_returns_escalate_for_pedido(self, mock_llm) -> None:


### PR DESCRIPTION
## ¿Qué hace este PR?

Corrige el flujo donde una cotización enviada como primer mensaje se escalaba antes de agregar el saludo inicial. Ahora las escalaciones de cotización conservan el saludo de primer contacto y mantienen el mensaje de derivación a ventas.

## Issues relacionados

Closes #203

## Tipo de cambio

- [ ] 🆕 Nueva funcionalidad (feature)
- [x] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [ ] 🧪 Tests
- [ ] 📄 Documentación / configuración
- [ ] 🔧 Infra / CI

## Summary

- Permite saludo inicial para `escalate_quote` sin habilitarlo para otras escalaciones.
- Mapea las keywords directas `cotización` y `presupuesto` a `escalate_quote` antes de responder.
- Agrega cobertura para saludo en cotizaciones directas.

## Changes

| File | Change |
|------|--------|
| `backend/app/greeting.py` | Permite saludo en escalaciones de cotización de primer contacto. |
| `backend/main.py` | Clasifica keywords directas de cotización como `escalate_quote` y aplica saludo antes de guardar/loggear la respuesta. |
| `backend/app/tests/test_greeting.py` | Agrega test unitario para saludo en `escalate_quote`. |
| `backend/tests/test_chat.py` | Verifica que `/chat` responda con saludo en cotización directa. |

## Cómo probar este PR

1. Ejecutar `uv run pytest backend/app/tests/test_greeting.py backend/tests/test_chat.py::TestChatEndpointUnit::test_chat_returns_escalate_for_cotizacion`.
2. Iniciar una sesión nueva y enviar `Necesito una cotización de paneles`.
3. Confirmar que la respuesta empieza con el saludo del asistente y luego deriva a ventas.

## Test Plan

- [x] `uv run pytest backend/app/tests/test_greeting.py backend/tests/test_chat.py::TestChatEndpointUnit::test_chat_returns_escalate_for_cotizacion`
- [x] No se modificaron scripts shell; shellcheck no aplica.
- [x] No se agregaron dependencias.

## Checklist antes de pedir review

- [x] El código corre localmente sin errores (`uvicorn` levanta, tests pasan)
- [x] Los criterios de aceptación del issue relacionado están cumplidos
- [x] No hay credenciales, API keys ni rutas absolutas hardcodeadas
- [x] Si agregué dependencias nuevas, actualicé `requirements.txt` / `pyproject.toml`
- [x] Si modifiqué el schema del endpoint, verifiqué que `/docs` refleja los cambios
- [x] Si modifiqué el harness o el dataset, corrí `python evaluation/harness.py` y el output es el esperado

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts, or no shell scripts changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Notas para el reviewer

El endpoint puede devolver `202` si el buffer multi-mensaje está activo; por eso el test del endpoint usa `is_final=True` para ejecutar directamente el flujo de chat.