### PR TITLE
fix(chat): expose classification metadata

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -956,9 +956,7 @@ async def _process_chat_message(
 
             if not tool_calls:
                 content = llm_response.text
-                intent_type, confidence, cleaned_content = _extract_intent_type(
-                    content
-                )
+                intent_type, confidence, cleaned_content = _extract_intent_type(content)
                 intent_for_behavior = intent_type or "FAQ"
 
                 if intent_for_behavior in ESCALATE_INTENTS:
@@ -1320,9 +1318,7 @@ async def _process_chat_message(
             session_id,
             iteration,
         )
-        intent_type, confidence, cleaned_text = _extract_intent_type(
-            last_output_text
-        )
+        intent_type, confidence, cleaned_text = _extract_intent_type(last_output_text)
         intent_for_behavior = intent_type or "FAQ"
 
         if intent_for_behavior in ESCALATE_INTENTS:

--- a/backend/main.py
+++ b/backend/main.py
@@ -104,27 +104,40 @@ OUT_OF_DOMAIN_MESSAGE = (
 
 
 INTENT_MARKER_RE = re.compile(r"\[INTENT:\s*(\w+)\]")
+CONFIDENCE_MARKER_RE = re.compile(r"\[CONFIDENCE:\s*([0-9]+(?:\.[0-9]+)?)\]")
 
 
-def _extract_intent_type(text: str) -> tuple[str, str]:
-    """Extract intent_type from LLM output text.
+def _extract_intent_type(text: str) -> tuple[Optional[str], Optional[float], str]:
+    """Extract intent_type and confidence from LLM output text.
 
-    The LLM is instructed to prefix responses with [INTENT: <type>].
-    This function parses the marker and returns the cleaned response.
+    The LLM is instructed to prefix responses with [INTENT: <type>] and
+    [CONFIDENCE: <score>]. This function parses both markers and returns
+    the cleaned response.
 
     Args:
         text: Raw LLM output text.
 
     Returns:
-        Tuple of (intent_type, cleaned_response_text).
+        Tuple of (intent_type, confidence, cleaned_response_text). intent_type is
+        None when the LLM does not provide a valid [INTENT] marker.
     """
-    match = INTENT_MARKER_RE.search(text)
-    if match:
-        intent = match.group(1)
+    intent_type: Optional[str] = None
+    intent_match = INTENT_MARKER_RE.search(text)
+    if intent_match:
+        intent = intent_match.group(1)
         if intent in INTENT_TYPES:
-            cleaned = INTENT_MARKER_RE.sub("", text).strip()
-            return intent, cleaned
-    return "FAQ", text
+            intent_type = intent
+
+    confidence: Optional[float] = None
+    confidence_match = CONFIDENCE_MARKER_RE.search(text)
+    if confidence_match:
+        confidence_value = float(confidence_match.group(1))
+        if 0.0 <= confidence_value <= 1.0:
+            confidence = confidence_value
+
+    cleaned = INTENT_MARKER_RE.sub("", text)
+    cleaned = CONFIDENCE_MARKER_RE.sub("", cleaned).strip()
+    return intent_type, confidence, cleaned
 
 
 ESCALATE_INTENTS = {"escalate_quote", "escalate_technical", "escalate_order"}
@@ -277,7 +290,8 @@ class ChatResponse(BaseModel):
 
     response: str
     escalate: bool = False
-    intent_type: str = "FAQ"
+    intent_type: Optional[str] = None
+    confidence: Optional[float] = None
     reason: Optional[str] = None
     session_id: str
     source_documents: list[SourceDocument] = Field(default_factory=list)
@@ -942,9 +956,12 @@ async def _process_chat_message(
 
             if not tool_calls:
                 content = llm_response.text
-                intent_type, cleaned_content = _extract_intent_type(content)
+                intent_type, confidence, cleaned_content = _extract_intent_type(
+                    content
+                )
+                intent_for_behavior = intent_type or "FAQ"
 
-                if intent_type in ESCALATE_INTENTS:
+                if intent_for_behavior in ESCALATE_INTENTS:
                     session_manager.add_turn(
                         session_id=session_id,
                         question=message,
@@ -962,7 +979,7 @@ async def _process_chat_message(
                         session_id=session_id,
                         user_message=message,
                         bot_response=DEFAULT_ESCALATION_MESSAGE,
-                        intent_type=intent_type,
+                        intent_type=intent_for_behavior,
                         escalate=True,
                         source_documents=[s.ruta for s in source_docs],
                         input_tokens=acc_input_tokens,
@@ -975,7 +992,8 @@ async def _process_chat_message(
                         response=DEFAULT_ESCALATION_MESSAGE,
                         escalate=True,
                         intent_type=intent_type,
-                        reason=f"Intent classified as {intent_type}",
+                        confidence=confidence,
+                        reason=f"Intent classified as {intent_for_behavior}",
                         session_id=session_id,
                         source_documents=source_docs,
                         num_sources=len(source_docs),
@@ -984,7 +1002,7 @@ async def _process_chat_message(
                         total_tokens=acc_total_tokens,
                     )
 
-                if intent_type == "fuera_de_dominio":
+                if intent_for_behavior == "fuera_de_dominio":
                     session_manager.add_turn(
                         session_id=session_id,
                         question=message,
@@ -1002,7 +1020,7 @@ async def _process_chat_message(
                         session_id=session_id,
                         user_message=message,
                         bot_response=OUT_OF_DOMAIN_MESSAGE,
-                        intent_type=intent_type,
+                        intent_type=intent_for_behavior,
                         escalate=False,
                         source_documents=[],
                         input_tokens=acc_input_tokens,
@@ -1015,6 +1033,7 @@ async def _process_chat_message(
                         response=OUT_OF_DOMAIN_MESSAGE,
                         escalate=False,
                         intent_type=intent_type,
+                        confidence=confidence,
                         session_id=session_id,
                         source_documents=source_docs,
                         num_sources=len(source_docs),
@@ -1030,16 +1049,16 @@ async def _process_chat_message(
 
                 split_messages, split_delays = process_split_messages(
                     text=response_text,
-                    intent_type=intent_type,
+                    intent_type=intent_for_behavior,
                     llm_regenerate_fn=None,
                 )
 
-                escalate = intent_type in ESCALATE_INTENTS
+                escalate = intent_for_behavior in ESCALATE_INTENTS
                 if split_messages:
                     split_messages[0] = maybe_prepend_greeting(
                         session_id=session_id,
                         response_text=split_messages[0],
-                        intent_type=intent_type,
+                        intent_type=intent_for_behavior,
                         escalate=escalate,
                     )
                     response_text = "\n\n".join(split_messages)
@@ -1047,7 +1066,7 @@ async def _process_chat_message(
                     response_text = maybe_prepend_greeting(
                         session_id=session_id,
                         response_text=response_text,
-                        intent_type=intent_type,
+                        intent_type=intent_for_behavior,
                         escalate=escalate,
                     )
 
@@ -1065,7 +1084,7 @@ async def _process_chat_message(
                     session_id=session_id,
                     user_message=message,
                     bot_response=response_text,
-                    intent_type=intent_type,
+                    intent_type=intent_for_behavior,
                     escalate=False,
                     source_documents=[s.ruta for s in source_docs],
                     input_tokens=acc_input_tokens,
@@ -1078,6 +1097,7 @@ async def _process_chat_message(
                     response=response_text,
                     escalate=False,
                     intent_type=intent_type,
+                    confidence=confidence,
                     session_id=session_id,
                     source_documents=source_docs,
                     num_sources=len(source_docs),
@@ -1300,9 +1320,12 @@ async def _process_chat_message(
             session_id,
             iteration,
         )
-        intent_type, cleaned_text = _extract_intent_type(last_output_text)
+        intent_type, confidence, cleaned_text = _extract_intent_type(
+            last_output_text
+        )
+        intent_for_behavior = intent_type or "FAQ"
 
-        if intent_type in ESCALATE_INTENTS:
+        if intent_for_behavior in ESCALATE_INTENTS:
             session_manager.add_turn(
                 session_id=session_id,
                 question=message,
@@ -1317,7 +1340,7 @@ async def _process_chat_message(
                 session_id=session_id,
                 user_message=message,
                 bot_response=DEFAULT_ESCALATION_MESSAGE,
-                intent_type=intent_type,
+                intent_type=intent_for_behavior,
                 escalate=True,
                 source_documents=[s.ruta for s in source_docs],
                 input_tokens=acc_input_tokens,
@@ -1330,7 +1353,8 @@ async def _process_chat_message(
                 response=DEFAULT_ESCALATION_MESSAGE,
                 escalate=True,
                 intent_type=intent_type,
-                reason=f"Intent classified as {intent_type}",
+                confidence=confidence,
+                reason=f"Intent classified as {intent_for_behavior}",
                 session_id=session_id,
                 source_documents=source_docs,
                 num_sources=len(source_docs),
@@ -1350,7 +1374,7 @@ async def _process_chat_message(
                 "Se alcanzó el límite de iteraciones. Por favor, reformula "
                 "tu pregunta o contacta al equipo de ventas."
             ),
-            intent_type=intent_type,
+            intent_type=intent_for_behavior,
             escalate=False,
             source_documents=[s.ruta for s in source_docs],
             input_tokens=acc_input_tokens,
@@ -1366,6 +1390,7 @@ async def _process_chat_message(
             ),
             escalate=False,
             intent_type=intent_type,
+            confidence=confidence,
             session_id=session_id,
             source_documents=source_docs,
             num_sources=len(source_docs),

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -289,21 +289,29 @@ class TestChatEndpointUnit:
     def test_chat_intent_marker_stripped_from_response(self, mock_llm) -> None:
         """Test that [INTENT: ...] marker is stripped from response text."""
         mock_llm.return_value = make_llm_response(
-            text="[INTENT: FAQ] Los paneles monocristalinos son más eficientes.",
+            text=(
+                "[INTENT: FAQ][CONFIDENCE: 0.92] "
+                "Los paneles monocristalinos son más eficientes."
+            ),
         )
         response = client.post(
-            "/chat", json={"message": "¿Qué tipo de panel me conviene?"}
+            "/chat",
+            json={"message": "¿Qué tipo de panel me conviene?", "is_final": True},
         )
         data = response.json()
         assert "[INTENT:" not in data["response"]
+        assert "[CONFIDENCE:" not in data["response"]
+        assert data["intent_type"] == "FAQ"
+        assert data["confidence"] == 0.92
         assert "monocristalinos" in data["response"]
 
     def test_chat_response_schema_includes_intent_type(self) -> None:
-        """Test that ChatResponse schema includes intent_type field."""
+        """Test that ChatResponse schema includes optional intent fields."""
         from backend.main import ChatResponse
 
         schema = ChatResponse.model_json_schema()
         assert "intent_type" in schema["properties"]
+        assert "confidence" in schema["properties"]
 
     def test_chat_response_schema_includes_token_fields(self) -> None:
         """Test that ChatResponse schema includes optional token fields."""
@@ -323,6 +331,8 @@ class TestChatEndpointUnit:
             response="test",
             session_id="s1",
         )
+        assert resp.intent_type is None
+        assert resp.confidence is None
         assert resp.input_tokens is None
         assert resp.output_tokens is None
         assert resp.total_tokens is None
@@ -334,10 +344,14 @@ class TestChatEndpointUnit:
         resp = ChatResponse(
             response="test",
             session_id="s1",
+            intent_type="FAQ",
+            confidence=0.87,
             input_tokens=100,
             output_tokens=50,
             total_tokens=150,
         )
+        assert resp.intent_type == "FAQ"
+        assert resp.confidence == 0.87
         assert resp.input_tokens == 100
         assert resp.output_tokens == 50
         assert resp.total_tokens == 150
@@ -935,7 +949,7 @@ class TestTokenAccumulation:
 
         response = client.post(
             "/chat",
-            json={"message": "¿Qué es un panel solar?", "session_id": "tok-s1"},
+            json={"message": "¿Qué es un panel solar?", "is_final": True},
         )
 
         assert response.status_code == 200

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -185,6 +185,20 @@
       background: var(--text-secondary);
     }
 
+    .message-meta-tag {
+      display: inline-flex;
+      align-items: center;
+      padding: 2px 7px;
+      border: 1px solid var(--border-color);
+      border-radius: 999px;
+      background: #f8fafc;
+      color: var(--text-secondary);
+      font-size: 10px;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      text-transform: uppercase;
+    }
+
     /* Typing indicator */
     .typing-indicator {
       display: none;
@@ -667,6 +681,11 @@
         return `${(ms / 1000).toFixed(1)}s`;
       }
 
+      function formatConfidence(value) {
+        if (typeof value !== "number" || Number.isNaN(value)) return null;
+        return `${Math.round(value * 100)}%`;
+      }
+
       function scrollToBottom() {
         messagesEl.scrollTop = messagesEl.scrollHeight;
       }
@@ -694,6 +713,17 @@
           if (meta.time) parts.push(escapeHtml(meta.time));
           if (meta.duration) parts.push(escapeHtml(meta.duration));
           if (meta.model) parts.push(escapeHtml(meta.model));
+          if (meta.intentType) {
+            parts.push(
+              `<span class="message-meta-tag">Intención: ${escapeHtml(meta.intentType)}</span>`
+            );
+          }
+          const confidence = formatConfidence(meta.confidence);
+          if (confidence) {
+            parts.push(
+              `<span class="message-meta-tag">Confianza: ${escapeHtml(confidence)}</span>`
+            );
+          }
           if (meta.inputTokens != null && meta.outputTokens != null) {
             parts.push(`${meta.inputTokens}\u2192${meta.outputTokens} tok`);
           }
@@ -791,6 +821,8 @@
               addMessage(chatResponse.response, "bot", {
                 time: responseTimeStr,
                 model: MODEL,
+                intentType: chatResponse.intent_type,
+                confidence: chatResponse.confidence,
                 escalate: chatResponse.escalate,
                 reason: chatResponse.reason,
                 inputTokens: chatResponse.input_tokens,
@@ -924,6 +956,8 @@
             time: responseTimeStr,
             duration: formatTime(elapsed),
             model: MODEL,
+            intentType: data.intent_type,
+            confidence: data.confidence,
             escalate: data.escalate,
             reason: data.reason,
             inputTokens: data.input_tokens,


### PR DESCRIPTION
Closes #204

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Moves `[INTENT]` and `[CONFIDENCE]` out of the visible chat response and into structured `/chat` response fields.
- Keeps backend behavior stable when intent is omitted by using `FAQ` internally while exposing `intent_type` as optional.
- Updates the frontend to display intent and confidence as metadata chips under bot messages.

## Changes
| File | Change |
|------|--------|
| `backend/main.py` | Parses classification markers, strips them from `response`, and exposes optional `intent_type`/`confidence`. |
| `backend/tests/test_chat.py` | Adds contract coverage for marker stripping, optional defaults, and explicit metadata values. |
| `frontend/index.html` | Renders intent and confidence metadata for normal and buffered bot responses. |

## Test Plan
- [x] `uv run pytest backend/tests/test_chat.py::TestChatEndpointUnit::test_chat_intent_marker_stripped_from_response backend/tests/test_chat.py::TestChatEndpointUnit::test_chat_response_schema_includes_intent_type backend/tests/test_chat.py::TestChatEndpointUnit::test_chat_response_token_fields_default_to_none backend/tests/test_chat.py::TestChatEndpointUnit::test_chat_response_token_fields_accept_values backend/tests/test_chat.py::TestTokenAccumulation::test_single_call_tokens_in_chat_response`
- [x] Inline frontend JavaScript parsed successfully with Node VM script extraction.
- [x] Shell scripts not modified; shellcheck not applicable.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts, or confirmed no scripts changed
- [x] Skills tested in at least one agent, or not applicable
- [x] Docs updated if behavior changed, or not applicable
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers