### PR TITLE
fix(evaluation): report real harness metrics

### DIFF
--- a/evaluation/harness/run.py
+++ b/evaluation/harness/run.py
@@ -18,6 +18,7 @@ import logging
 import getpass
 import os
 import sys
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -149,7 +150,7 @@ async def run_single_query(
     }
 
     try:
-        start_time = datetime.now(timezone.utc)
+        start_time = time.perf_counter()
         headers = {}
         if CHAT_API_KEY:
             headers["X-API-Key"] = CHAT_API_KEY
@@ -159,14 +160,14 @@ async def run_single_query(
             headers=headers,
             timeout=30.0,
         )
-        end_time = datetime.now(timezone.utc)
+        elapsed_ms = (time.perf_counter() - start_time) * 1000
 
         if response.status_code == 200:
             data = response.json()
             result["response"] = data.get("response", "")
             result["session_id"] = data.get("session_id", "")
-            result["latency_ms"] = data.get("latency_ms", 0.0)
-            result["escalated"] = data.get("escalated", False)
+            result["latency_ms"] = data.get("latency_ms") or elapsed_ms
+            result["escalated"] = data.get("escalated", data.get("escalate", False))
             result["source_documents"] = data.get("source_documents", [])
             result["num_sources"] = data.get("num_sources", 0)
         else:

--- a/evaluation/harness/tests/test_run.py
+++ b/evaluation/harness/tests/test_run.py
@@ -1,0 +1,89 @@
+import httpx
+import pytest
+
+from evaluation.harness.run import run_single_query
+
+
+@pytest.mark.asyncio
+async def test_run_single_query_maps_backend_escalate_field() -> None:
+    """The backend returns `escalate`; the harness reports `escalated`."""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "response": "Escalation response",
+                "session_id": "session-1",
+                "escalate": True,
+                "source_documents": [],
+                "num_sources": 0,
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        result = await run_single_query(
+            client,
+            {
+                "id": "q001",
+                "query": "Necesito una cotización",
+                "should_escalate": True,
+            },
+        )
+
+    assert result["error"] == ""
+    assert result["escalated"] is True
+
+
+@pytest.mark.asyncio
+async def test_run_single_query_uses_measured_latency_when_api_omits_it() -> None:
+    """CI results should not report zero latency when the backend omits latency_ms."""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "response": "OK",
+                "session_id": "session-1",
+                "escalate": False,
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        result = await run_single_query(
+            client,
+            {
+                "id": "q001",
+                "query": "Hola",
+            },
+        )
+
+    assert result["error"] == ""
+    assert result["latency_ms"] > 0
+
+
+@pytest.mark.asyncio
+async def test_run_single_query_preserves_explicit_api_latency() -> None:
+    """If an API starts returning latency_ms, preserve that value."""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "response": "OK",
+                "session_id": "session-1",
+                "latency_ms": 123.45,
+                "escalated": True,
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        result = await run_single_query(
+            client,
+            {
+                "id": "q001",
+                "query": "Hola",
+            },
+        )
+
+    assert result["latency_ms"] == 123.45
+    assert result["escalated"] is True

--- a/evaluation/harness/tests/test_s3_upload.py
+++ b/evaluation/harness/tests/test_s3_upload.py
@@ -81,7 +81,14 @@ class TestUploadResults:
         assert "results.csv" in keys[1]
         assert mock_s3.upload_file.call_count == 2
 
-    @patch.dict("os.environ", {"AWS_ACCESS_KEY_ID": "", "AWS_SECRET_ACCESS_KEY": ""})
+    @patch.dict(
+        "os.environ",
+        {
+            "AWS_ACCESS_KEY_ID": "",
+            "AWS_SECRET_ACCESS_KEY": "",
+            "AWS_REGION": "us-east-1",
+        },
+    )
     @patch("evaluation.harness.s3_upload.boto3.client")
     def test_uses_default_credential_chain_when_no_static_credentials(
         self, mock_boto: MagicMock, tmp_path: Path
@@ -136,7 +143,11 @@ class TestUploadResultsWithMetadata:
 
         with patch.dict(
             "os.environ",
-            {"AWS_ACCESS_KEY_ID": "", "AWS_SECRET_ACCESS_KEY": ""},
+            {
+                "AWS_ACCESS_KEY_ID": "",
+                "AWS_SECRET_ACCESS_KEY": "",
+                "AWS_REGION": "us-east-1",
+            },
         ):
             keys = upload_results_with_metadata(
                 tmp_path, "evaluation/manual/testuser/", "manual", "testuser"


### PR DESCRIPTION
Closes #214

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Normalize backend `escalate` into harness `escalated` so escalation metrics are real.
- Measure local request latency when the API omits `latency_ms`.
- Add unit coverage for escalation mapping, latency fallback, and deterministic AWS region expectations in S3 upload tests.

## Changes
| File | Change |
|------|--------|
| `evaluation/harness/run.py` | Maps `escalate`/`escalated` and records measured latency fallback. |
| `evaluation/harness/tests/test_run.py` | Adds unit tests for harness response normalization. |
| `evaluation/harness/tests/test_s3_upload.py` | Pins `AWS_REGION` in env-sensitive assertions. |

## Test Plan
- [x] `uv run pytest evaluation/harness/tests/test_run.py evaluation/harness/tests/test_s3_upload.py`

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts / not applicable: no shell scripts changed
- [x] Skills tested in at least one agent / not applicable: no skills changed
- [x] Docs updated if behavior changed / not applicable: test-covered bug fix
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers