### PR TITLE
fix(admin): address admin panel follow-up risks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,11 @@ STAGING_ID=pr-123
 STAGING_EXPIRES_AT=2026-06-05T12:00:00Z
 STAGING_AWS_BUCKET_NAME=arte-chatbot-staging-data
 
+# Optional. Persist /chat conversation turns to S3 for the admin Logs screen.
+# docker compose defaults this to true for local admin-panel runs unless explicitly set.
+CONVERSATION_LOGGING_ENABLED=true
+CONVERSATION_LOG_PREFIX=conversations
+
 # --- WhatsApp Conversational Features ---
 # All flags default to false (zero-risk deployment). Enable individually.
 WHATSAPP_FORMATTER_ENABLED=false

--- a/admin-panel/lib/schemas.ts
+++ b/admin-panel/lib/schemas.ts
@@ -34,7 +34,16 @@ export const CatalogProductSchema = z.object({
   descripcion: z.string().max(2000).optional(),
   ruta_s3: z
     .string()
-    .regex(/^[a-zA-Z0-9_\-/]+\.[a-zA-Z0-9]+$/, "Ruta S3 inválida"),
+    .min(1, "Ruta S3 requerida")
+    .refine(
+      (value) =>
+        !value.startsWith("/") &&
+        !value.includes("//") &&
+        !value.split("/").includes("..") &&
+        !/[\u0000-\u001F\u007F]/.test(value) &&
+        /^raw\/.+\.[^/.]+$/.test(value),
+      "Ruta S3 inválida",
+    ),
   variantes: z.array(ProductVariantSchema).default([]),
   parametros_comunes: z.record(z.string(), z.unknown()).default({}),
 });

--- a/backend/app/admin_s3.py
+++ b/backend/app/admin_s3.py
@@ -5,7 +5,6 @@ the chatbot knowledge-base bucket without exposing AWS credentials to the
 browser.
 """
 
-import re
 from datetime import datetime
 from typing import Annotated, Any, Literal
 
@@ -33,7 +32,6 @@ s3_client = S3Client()
 ALLOWED_READ_PREFIXES = ("", "raw/", "guides/", "index/")
 ALLOWED_WRITE_PREFIXES = ("raw/", "guides/", "index/")
 ALLOWED_DOWNLOAD_PREFIXES = ("raw/",)
-KEY_PATTERN = re.compile(r"^[a-zA-Z0-9_\-/.]+$")
 PRESIGNED_DOWNLOAD_EXPIRES_SECONDS = 300
 
 
@@ -47,7 +45,16 @@ def _validate_s3_key(key: str, allowed_prefixes: tuple[str, ...]) -> None:
     Raises:
         HTTPException: If the key is unsafe or outside allowed prefixes.
     """
-    if key.startswith("/") or ".." in key or not KEY_PATTERN.match(key):
+    # S3 keys commonly contain spaces, parentheses, plus signs and accented
+    # product names. Validate path safety and allowed prefixes instead of using
+    # an ASCII-only regex that rejects valid S3 object names.
+    if (
+        not key
+        or key.startswith("/")
+        or "//" in key
+        or any(part == ".." for part in key.split("/"))
+        or any(ord(char) < 32 or ord(char) == 127 for char in key)
+    ):
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="Invalid S3 key",

--- a/backend/app/llm_client.py
+++ b/backend/app/llm_client.py
@@ -34,8 +34,6 @@ def expand_query_with_context(message: str, history: list) -> str:
     return message
 
 
-DEFAULT_MODEL = settings.llm_model
-
 ARTE_SYSTEM_PROMPT = (
     "Eres un asistente técnico de Arte Soluciones Energéticas, una empresa B2B "
     "de energía solar. Tu rol es ayudar a clientes con consultas sobre productos "
@@ -140,12 +138,12 @@ class LLMClient:
     def __init__(
         self,
         api_key: Optional[str] = None,
-        model: str = DEFAULT_MODEL,
+        model: Optional[str] = None,
     ) -> None:
         self.api_key = (
             api_key if api_key is not None else os.getenv("OPENAI_API_KEY", "")
         )
-        self.model = model
+        self._model_override = model
 
         # Build system prompt: base + WhatsApp formatting when enabled
         whatsapp_enabled = os.getenv(
@@ -164,6 +162,16 @@ class LLMClient:
 
         # OpenAI SDK client
         self._openai_client: Optional[OpenAI] = None
+
+    @property
+    def model(self) -> str:
+        """Return the effective model, honoring runtime config reloads."""
+        return self._model_override or settings.llm_model
+
+    @model.setter
+    def model(self, value: str) -> None:
+        """Allow tests and explicit callers to pin a model on this client."""
+        self._model_override = value
 
     @property
     def openai_client(self) -> OpenAI:

--- a/backend/app/tests/test_admin_s3.py
+++ b/backend/app/tests/test_admin_s3.py
@@ -99,6 +99,30 @@ def test_presigned_upload_success(client: TestClient) -> None:
     assert data["key"] == "raw/paneles/a.pdf"
 
 
+def test_presigned_upload_accepts_real_s3_product_key(client: TestClient) -> None:
+    """POST /admin/s3/presigned-upload accepts valid S3 keys with spaces."""
+    key = "raw/paneles/Jinko Tiger Pro 460W (Ficha Técnica).pdf"
+    with patch("backend.app.admin_s3.s3_client") as mock_s3:
+        mock_s3.head_object = AsyncMock(
+            side_effect=S3ObjectNotFoundError("not found")
+        )
+        mock_s3.generate_presigned_post = AsyncMock(
+            return_value={
+                "url": "https://bucket.s3.amazonaws.com/",
+                "fields": {"key": key},
+            }
+        )
+
+        response = client.post(
+            "/admin/s3/presigned-upload",
+            headers={"X-Admin-API-Key": "test-admin-key"},
+            json={"key": key, "content_type": "application/pdf"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["key"] == key
+
+
 def test_presigned_upload_conflict(client: TestClient) -> None:
     """POST /admin/s3/presigned-upload returns 409 when object exists."""
     with patch("backend.app.admin_s3.s3_client") as mock_s3:

--- a/backend/app/tests/test_admin_s3.py
+++ b/backend/app/tests/test_admin_s3.py
@@ -103,9 +103,7 @@ def test_presigned_upload_accepts_real_s3_product_key(client: TestClient) -> Non
     """POST /admin/s3/presigned-upload accepts valid S3 keys with spaces."""
     key = "raw/paneles/Jinko Tiger Pro 460W (Ficha Técnica).pdf"
     with patch("backend.app.admin_s3.s3_client") as mock_s3:
-        mock_s3.head_object = AsyncMock(
-            side_effect=S3ObjectNotFoundError("not found")
-        )
+        mock_s3.head_object = AsyncMock(side_effect=S3ObjectNotFoundError("not found"))
         mock_s3.generate_presigned_post = AsyncMock(
             return_value={
                 "url": "https://bucket.s3.amazonaws.com/",

--- a/backend/app/tests/test_admin_slice3.py
+++ b/backend/app/tests/test_admin_slice3.py
@@ -170,6 +170,29 @@ def test_put_config_hot_reload(
     assert settings.conversation_logging_enabled is True
 
 
+def test_put_config_enables_runtime_conversation_logger(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Conversation logger is created lazily after Config enables logging."""
+    import backend.main as main
+
+    monkeypatch.setenv("CONVERSATION_LOGGING_ENABLED", "false")
+    settings.reload()
+    main.conversation_logger = None
+
+    response = client.put(
+        "/admin/config",
+        headers={"X-Admin-API-Key": "test-admin-key"},
+        json={"conversation_logging_enabled": True},
+    )
+
+    assert response.status_code == 200
+    logger = main._get_conversation_logger()
+    assert logger is not None
+    assert logger._prefix == settings.conversation_log_prefix
+
+
 def test_put_config_ignores_redacted_admin_key(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/backend/main.py
+++ b/backend/main.py
@@ -229,6 +229,31 @@ if settings.conversation_logging_enabled:
     )
 
 
+def _get_conversation_logger() -> Optional[ConversationLogger]:
+    """Return a logger that follows runtime config changes.
+
+    Admin Config can toggle conversation logging without restarting the API.
+    Keep the module-level variable for test patching/backward compatibility, but
+    create or clear the concrete logger lazily based on the current settings.
+    """
+    global conversation_logger
+    if conversation_logger is not None and not isinstance(
+        conversation_logger,
+        ConversationLogger,
+    ):
+        return conversation_logger
+    if not settings.conversation_logging_enabled:
+        conversation_logger = None
+        return None
+    if conversation_logger is None:
+        conversation_logger = ConversationLogger(
+            s3_client=s3_client,
+            bucket=settings.aws_bucket_name,
+            prefix=settings.conversation_log_prefix,
+        )
+    return conversation_logger
+
+
 def get_llm_client() -> LLMClient:
     """Dependency that provides a LLMClient instance."""
     return llm_client
@@ -273,7 +298,8 @@ def _fire_conversation_log(
     user_profile: Optional[str] = None,
 ) -> None:
     """Fire-and-forget conversation log. Never blocks or raises."""
-    if conversation_logger is None:
+    logger_instance = _get_conversation_logger()
+    if logger_instance is None:
         return
     turn_number = len(session_manager.get_history(session_id))
     entry = ConversationLogEntry(
@@ -293,7 +319,7 @@ def _fire_conversation_log(
         git_commit_hash=settings.git_commit_hash,
         user_profile=user_profile,
     )
-    asyncio.create_task(conversation_logger.log_turn(entry))
+    asyncio.create_task(logger_instance.log_turn(entry))
 
 
 class ChatRequest(BaseModel):

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -160,9 +160,10 @@ class TestLLMClientWithTools:
 
     @patch("backend.app.llm_client.OpenAI")
     def test_get_llm_response_with_tools_uses_instructions(
-        self, mock_openai_class: MagicMock
+        self, mock_openai_class: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test get_llm_response_with_tools passes instructions parameter."""
+        monkeypatch.setenv("WHATSAPP_FORMATTER_ENABLED", "false")
         mock_client = MagicMock()
         mock_openai_class.return_value = mock_client
 

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -5,8 +5,11 @@ Tests the LLM client for OpenAI Responses API integration with tool calling supp
 """
 
 import os
-import pytest
 from unittest.mock import patch, MagicMock
+
+import pytest
+
+from backend.app.config import settings
 from backend.app.llm_client import (
     LLMClient,
     LLMServiceError,
@@ -34,8 +37,21 @@ class TestLLMClientInitialization:
 
     def test_llm_client_default_model(self) -> None:
         """Test LLMClient uses default model."""
+        settings.reset()
         client = LLMClient()
-        assert client.model == "gpt-5.4-nano"
+        assert client.model == settings.llm_model
+
+    def test_llm_client_default_model_follows_settings_reload(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Default LLMClient model follows runtime settings reloads."""
+        client = LLMClient()
+        monkeypatch.setenv("LLM_MODEL", "gpt-runtime")
+        settings.reload()
+
+        assert client.model == "gpt-runtime"
+
+        settings.reset()
 
     def test_llm_client_custom_model(self) -> None:
         """Test LLMClient accepts custom model."""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,9 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
       - PORT=8000
+      # Local Docker runs include the admin Logs screen, so persist chat turns
+      # unless explicitly disabled in the shell/.env with CONVERSATION_LOGGING_ENABLED=false.
+      - CONVERSATION_LOGGING_ENABLED=${CONVERSATION_LOGGING_ENABLED:-true}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s


### PR DESCRIPTION
Closes #180
Part of #207

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Allows valid real-world S3 product keys while preserving path-safety validation for admin S3 uploads/downloads.
- Makes runtime admin config changes affect conversation logging and the default LLM model without restarting the process.
- Documents local conversation logging defaults and adds regression coverage for the updated admin/runtime behavior.

## Changes
| File | Change |
|------|--------|
| `.env.example` | Documents conversation logging environment variables for the admin Logs screen. |
| `admin-panel/lib/schemas.ts` | Aligns frontend S3 path validation with backend path-safety rules and real product filenames. |
| `backend/app/admin_s3.py` | Replaces ASCII-only key validation with safer path validation that accepts spaces/accents/common filename characters. |
| `backend/app/llm_client.py` | Makes the default model follow runtime `settings.reload()` unless explicitly overridden. |
| `backend/main.py` | Creates/clears the conversation logger lazily so enabling logging via admin config takes effect at runtime. |
| `backend/app/tests/test_admin_s3.py` | Covers product keys containing spaces and parentheses. |
| `backend/app/tests/test_admin_slice3.py` | Covers runtime creation of the conversation logger after config changes. |
| `backend/tests/test_llm_client.py` | Covers runtime model reload and isolates prompt configuration in tests. |
| `docker-compose.yml` | Enables local compose conversation logging by default for the admin Logs screen. |

## Test Plan
- [x] `uv run pytest backend/app/tests/test_admin_s3.py backend/app/tests/test_admin_slice3.py backend/tests/test_llm_client.py -v` — 42 passed, 2 warnings
- [x] `npm run typecheck` from `admin-panel/`
- [x] No shell scripts changed; shellcheck not applicable

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts / not applicable: no shell scripts changed
- [x] Skills tested in at least one agent / not applicable: application code change
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Notes for reviewer
This PR targets `feature/admin-panel` as a follow-up patch before the tracker PR merges to `main`.