### PR TITLE
fix(admin): integrate chat UI into admin panel

### DIFF
--- a/.github/workflows/admin-panel.yml
+++ b/.github/workflows/admin-panel.yml
@@ -11,7 +11,7 @@ on:
       - ".github/workflows/admin-panel.yml"
 
 jobs:
-  frontend:
+  admin-panel:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,16 +60,12 @@ jobs:
       - name: Build backend image
         run: docker build --build-arg GIT_COMMIT_HASH=${{ github.sha }} -t arte-chatbot-backend -f backend/Dockerfile .
 
-      - name: Build frontend image
-        run: docker build --build-arg GIT_COMMIT_HASH=${{ github.sha }} -t arte-chatbot-frontend -f frontend/Dockerfile .
-
       - name: Build admin image
-        run: docker build --build-arg GIT_COMMIT_HASH=${{ github.sha }} -t arte-chatbot-admin -f admin/Dockerfile .
+        run: docker build --build-arg GIT_COMMIT_HASH=${{ github.sha }} -t arte-chatbot-admin -f admin-panel/Dockerfile admin-panel
 
       - name: Export Docker images
         run: |
           docker save arte-chatbot-backend -o backend-image.tar
-          docker save arte-chatbot-frontend -o frontend-image.tar
           docker save arte-chatbot-admin -o admin-image.tar
 
       - name: Upload backend image artifact
@@ -77,13 +73,6 @@ jobs:
         with:
           name: backend-image
           path: backend-image.tar
-          retention-days: 1
-
-      - name: Upload frontend image artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: frontend-image
-          path: frontend-image.tar
           retention-days: 1
 
       - name: Upload admin image artifact
@@ -267,12 +256,6 @@ jobs:
           name: backend-image
           path: ./artifact
 
-      - name: Download frontend image artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: frontend-image
-          path: ./artifact
-
       - name: Download admin image artifact
         uses: actions/download-artifact@v4
         with:
@@ -282,7 +265,6 @@ jobs:
       - name: Load built images
         run: |
           docker load -i ./artifact/backend-image.tar
-          docker load -i ./artifact/frontend-image.tar
           docker load -i ./artifact/admin-image.tar
 
       - name: Configure AWS credentials through OIDC
@@ -311,10 +293,8 @@ jobs:
           }
 
           push_if_missing arte-chatbot-backend "${{ vars.BACKEND_ECR_REPOSITORY_URL }}" "${CANDIDATE_TAG}"
-          push_if_missing arte-chatbot-frontend "${{ vars.FRONTEND_ECR_REPOSITORY_URL }}" "${CANDIDATE_TAG}"
           push_if_missing arte-chatbot-admin "${{ vars.ADMIN_ECR_REPOSITORY_URL }}" "${CANDIDATE_TAG}"
           push_if_missing arte-chatbot-backend "${{ vars.BACKEND_ECR_REPOSITORY_URL }}" "${SHA_TAG}"
-          push_if_missing arte-chatbot-frontend "${{ vars.FRONTEND_ECR_REPOSITORY_URL }}" "${SHA_TAG}"
           push_if_missing arte-chatbot-admin "${{ vars.ADMIN_ECR_REPOSITORY_URL }}" "${SHA_TAG}"
 
   publish-release-images:
@@ -334,12 +314,6 @@ jobs:
           name: backend-image
           path: ./artifact
 
-      - name: Download frontend image artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: frontend-image
-          path: ./artifact
-
       - name: Download admin image artifact
         uses: actions/download-artifact@v4
         with:
@@ -349,7 +323,6 @@ jobs:
       - name: Load built images
         run: |
           docker load -i ./artifact/backend-image.tar
-          docker load -i ./artifact/frontend-image.tar
           docker load -i ./artifact/admin-image.tar
 
       - name: Configure AWS credentials through OIDC
@@ -378,7 +351,6 @@ jobs:
           }
 
           push_if_missing arte-chatbot-backend "${{ vars.BACKEND_ECR_REPOSITORY_URL }}" "${SHA_TAG}"
-          push_if_missing arte-chatbot-frontend "${{ vars.FRONTEND_ECR_REPOSITORY_URL }}" "${SHA_TAG}"
           push_if_missing arte-chatbot-admin "${{ vars.ADMIN_ECR_REPOSITORY_URL }}" "${SHA_TAG}"
 
   deploy-production:
@@ -400,7 +372,6 @@ jobs:
       TF_VAR_cloudflare_account_id: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
       TF_VAR_cloudflare_zone_id: ${{ vars.CLOUDFLARE_ZONE_ID }}
       TF_VAR_backend_tunnel_secret: ${{ secrets.PROD_BACKEND_TUNNEL_SECRET }}
-      TF_VAR_frontend_tunnel_secret: ${{ secrets.PROD_FRONTEND_TUNNEL_SECRET }}
       TF_VAR_admin_tunnel_secret: ${{ secrets.PROD_ADMIN_TUNNEL_SECRET }}
       TF_VAR_backend_runtime_secret_arns: ${{ secrets.PROD_BACKEND_RUNTIME_SECRET_ARNS_JSON }}
       TF_VAR_aws_bucket_name: ${{ secrets.AWS_BUCKET_NAME }}
@@ -427,7 +398,6 @@ jobs:
         run: |
           terraform -chdir=infra/terraform/envs/prod apply -auto-approve \
             -var="backend_image_tag=${SHA_TAG}" \
-            -var="frontend_image_tag=${SHA_TAG}" \
             -var="admin_image_tag=${SHA_TAG}"
 
   cleanup:

--- a/admin-panel/__tests__/admin-chat.test.tsx
+++ b/admin-panel/__tests__/admin-chat.test.tsx
@@ -1,0 +1,230 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import AdminChatPage from "@/app/admin/chat/page";
+import AdminLayout from "@/app/admin/layout";
+import { ADMIN_CHAT_HISTORY_KEY } from "@/components/chat/chat-history";
+import { STORAGE_KEY, AdminAuthProvider } from "@/providers/admin-auth-provider";
+
+const replaceMock = vi.fn();
+let pathname = "/admin/chat";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => pathname,
+  useRouter: () => ({ replace: replaceMock, push: vi.fn() }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function renderWithProviders(ui: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AdminAuthProvider>{ui}</AdminAuthProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("Admin chat workbench", () => {
+  beforeEach(() => {
+    pathname = "/admin/chat";
+    replaceMock.mockClear();
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("blocks unauthenticated access through the admin layout", async () => {
+    renderWithProviders(
+      <AdminLayout>
+        <AdminChatPage />
+      </AdminLayout>,
+    );
+
+    expect(await screen.findByText(/verificando credenciales/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/admin/login");
+    });
+  });
+
+  it("renders the chat route inside the existing admin navigation", async () => {
+    window.localStorage.setItem(STORAGE_KEY, "admin-key");
+
+    renderWithProviders(
+      <AdminLayout>
+        <AdminChatPage />
+      </AdminLayout>,
+    );
+
+    expect(await screen.findByRole("heading", { name: /chat ui de pruebas/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /chat/i })).toHaveAttribute(
+      "href",
+      "/admin/chat",
+    );
+    expect(screen.getByRole("link", { name: /dashboard/i })).toHaveAttribute(
+      "href",
+      "/admin/dashboard",
+    );
+    expect(screen.getByRole("link", { name: /config/i })).toHaveAttribute(
+      "href",
+      "/admin/config",
+    );
+    expect(screen.getByRole("link", { name: /logs/i })).toHaveAttribute(
+      "href",
+      "/admin/logs",
+    );
+  });
+
+  it("restores saved recent conversation history when selected", async () => {
+    window.localStorage.setItem(STORAGE_KEY, "admin-key");
+    window.localStorage.setItem(
+      ADMIN_CHAT_HISTORY_KEY,
+      JSON.stringify([
+        {
+          id: "conversation-a",
+          sessionId: "session-a",
+          title: "Consulta panel Tiger",
+          createdAt: "2026-06-01T12:00:00.000Z",
+          updatedAt: "2026-06-01T12:01:00.000Z",
+          messages: [
+            { id: "u1", role: "user", content: "Necesito ficha Tiger" },
+            { id: "a1", role: "assistant", content: "La ficha Tiger está disponible." },
+          ],
+        },
+      ]),
+    );
+
+    renderWithProviders(<AdminChatPage />);
+
+    await userEvent.click(await screen.findByRole("button", { name: /consulta panel tiger/i }));
+
+    expect(screen.getByText("Necesito ficha Tiger")).toBeInTheDocument();
+    expect(screen.getByText("La ficha Tiger está disponible.")).toBeInTheDocument();
+  });
+
+  it("sends chat through admin auth, renders split bubbles, and never stores CHAT_API_KEY", async () => {
+    window.localStorage.setItem(STORAGE_KEY, "admin-key");
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        response: "fallback ignored",
+        session_id: "session-split",
+        source_documents: [],
+        messages: ["Primera parte técnica", "Segunda parte técnica"],
+        delays_ms: [100, 200],
+        escalate: false,
+        input_tokens: 10,
+        output_tokens: 20,
+        total_tokens: 30,
+      }),
+    );
+
+    renderWithProviders(<AdminChatPage />);
+
+    await userEvent.type(
+      screen.getByLabelText(/mensaje para probar el chatbot/i),
+      "Compará paneles de 550W",
+    );
+    await userEvent.click(screen.getByRole("button", { name: /enviar mensaje/i }));
+
+    expect(await screen.findByText("Primera parte técnica")).toBeInTheDocument();
+    expect(screen.getByText("Segunda parte técnica")).toBeInTheDocument();
+    expect(screen.getAllByText("Entrada: 10")).toHaveLength(2);
+    expect(screen.getAllByText("Salida: 20")).toHaveLength(2);
+    expect(screen.queryByText("fallback ignored")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Compará paneles de 550W").length).toBeGreaterThan(0);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/admin/chat"),
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.any(Headers),
+        }),
+      );
+    });
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init?.headers as Headers).get("X-Admin-API-Key")).toBe("admin-key");
+    expect(window.localStorage.getItem("CHAT_API_KEY")).toBeNull();
+  });
+
+  it("shows deduplicated datasheet sources in a modal with admin download flow", async () => {
+    window.localStorage.setItem(STORAGE_KEY, "admin-key");
+    const openMock = vi.spyOn(window, "open").mockImplementation(() => null);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === "POST" && String(init.body).includes("presigned")) {
+          return jsonResponse({
+            url: "https://signed.example/raw/paneles/tiger.pdf",
+            key: "raw/paneles/tiger.pdf",
+            expires_in: 300,
+          });
+        }
+
+        if (String(_input).includes("/admin/s3/presigned-download")) {
+          return jsonResponse({
+            url: "https://signed.example/raw/paneles/tiger.pdf",
+            key: "raw/paneles/tiger.pdf",
+            expires_in: 300,
+          });
+        }
+
+        return jsonResponse({
+          response: "Usé una ficha técnica.",
+          session_id: "session-source",
+          source_documents: [
+            { ruta: "raw/paneles/tiger.pdf", contenido_relevante: "Potencia 550W" },
+            { ruta: "raw/paneles/tiger.pdf", contenido_relevante: "Potencia 550W" },
+          ],
+          messages: [],
+          delays_ms: [],
+          escalate: false,
+        });
+      },
+    );
+
+    renderWithProviders(<AdminChatPage />);
+
+    await userEvent.type(screen.getByLabelText(/mensaje para probar el chatbot/i), "Ficha Tiger");
+    await userEvent.click(screen.getByRole("button", { name: /enviar mensaje/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /ver fichas técnicas/i }));
+
+    expect(screen.getByRole("dialog", { name: /fichas técnicas usadas/i })).toBeInTheDocument();
+    expect(screen.getAllByText("tiger.pdf")).toHaveLength(1);
+    expect(screen.getByText("raw/paneles/tiger.pdf")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /abrir tiger.pdf/i }));
+
+    await waitFor(() => {
+      const presignedCall = fetchMock.mock.calls.find(([input]) =>
+        String(input).includes("/admin/s3/presigned-download"),
+      );
+      expect(presignedCall).toBeTruthy();
+      expect(JSON.parse(presignedCall?.[1]?.body as string)).toEqual({
+        key: "raw/paneles/tiger.pdf",
+        disposition: "inline",
+      });
+      expect(openMock).toHaveBeenCalledWith(
+        "https://signed.example/raw/paneles/tiger.pdf",
+        "_blank",
+        "noopener,noreferrer",
+      );
+    });
+  });
+});

--- a/admin-panel/__tests__/admin-chat.test.tsx
+++ b/admin-panel/__tests__/admin-chat.test.tsx
@@ -164,6 +164,35 @@ describe("Admin chat workbench", () => {
     expect(window.localStorage.getItem("CHAT_API_KEY")).toBeNull();
   });
 
+  it("renders markdown and preserves split responses when only delays metadata is present", async () => {
+    window.localStorage.setItem(STORAGE_KEY, "admin-key");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        response: "*Primera parte*\n• Punto técnico\n\nSistema _on grid_",
+        session_id: "session-split-fallback",
+        source_documents: [],
+        messages: [],
+        delays_ms: [100, 200],
+        escalate: false,
+      }),
+    );
+
+    const { container } = renderWithProviders(<AdminChatPage />);
+
+    await userEvent.type(
+      screen.getByLabelText(/mensaje para probar el chatbot/i),
+      "Compará paneles con markdown",
+    );
+    await userEvent.click(screen.getByRole("button", { name: /enviar mensaje/i }));
+
+    expect(await screen.findByText("Primera parte")).toBeInTheDocument();
+    expect(screen.getByText("Punto técnico")).toBeInTheDocument();
+    expect(screen.getByText("Sistema", { exact: false })).toBeInTheDocument();
+    expect(container.querySelector("strong")?.textContent).toBe("Primera parte");
+    expect(container.querySelector("em")?.textContent).toBe("on grid");
+    expect(container.querySelector("li")?.textContent).toBe("Punto técnico");
+  });
+
   it("shows deduplicated datasheet sources in a modal with admin download flow", async () => {
     window.localStorage.setItem(STORAGE_KEY, "admin-key");
     const openMock = vi.spyOn(window, "open").mockImplementation(() => null);

--- a/admin-panel/app/admin/chat/page.tsx
+++ b/admin-panel/app/admin/chat/page.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { ChatComposer } from "@/components/chat/chat-composer";
+import {
+  createAssistantMessages,
+  createEmptyConversation,
+  createUserMessage,
+  readChatHistory,
+  titleFromPrompt,
+  upsertConversation,
+  writeChatHistory,
+} from "@/components/chat/chat-history";
+import { ChatSidebar } from "@/components/chat/chat-sidebar";
+import { ChatThread } from "@/components/chat/chat-thread";
+import { SourceModal } from "@/components/chat/source-modal";
+import { useSendAdminChatMessage } from "@/lib/api";
+import type { AdminChatConversation, SourceDocument } from "@/lib/types";
+
+export default function AdminChatPage() {
+  const [conversations, setConversations] = useState<AdminChatConversation[]>([]);
+  const [activeConversation, setActiveConversation] = useState<AdminChatConversation>(() =>
+    createEmptyConversation(),
+  );
+  const [modalSources, setModalSources] = useState<SourceDocument[] | null>(null);
+  const sendMessage = useSendAdminChatMessage();
+
+  useEffect(() => {
+    const stored = readChatHistory();
+    setConversations(stored);
+  }, []);
+
+  const persistedConversations = useMemo(
+    () => upsertConversation(conversations, activeConversation),
+    [activeConversation, conversations],
+  );
+
+  const persistConversation = (conversation: AdminChatConversation) => {
+    const next = upsertConversation(conversations, conversation);
+    setConversations(next);
+    writeChatHistory(next);
+  };
+
+  const startNewConversation = () => {
+    setActiveConversation(createEmptyConversation());
+  };
+
+  const selectConversation = (conversation: AdminChatConversation) => {
+    setActiveConversation(conversation);
+  };
+
+  const handleSend = async (message: string) => {
+    const userMessage = createUserMessage(message);
+    const title = activeConversation.messages.length
+      ? activeConversation.title
+      : titleFromPrompt(message);
+    const optimisticConversation = {
+      ...activeConversation,
+      title,
+      messages: [...activeConversation.messages, userMessage],
+    };
+    setActiveConversation(optimisticConversation);
+
+    const response = await sendMessage.mutateAsync({
+      message,
+      session_id: activeConversation.sessionId,
+      is_final: true,
+    });
+    const assistantMessages = createAssistantMessages(response);
+    const nextConversation = {
+      ...optimisticConversation,
+      sessionId: response.session_id,
+      messages: [...optimisticConversation.messages, ...assistantMessages],
+    };
+    setActiveConversation(nextConversation);
+    persistConversation(nextConversation);
+  };
+
+  return (
+    <div className="admin-chat-shell">
+      <section className="chat-main-panel">
+        <header className="chat-hero">
+          <div>
+            <p className="chat-sidebar-kicker">Arte Chatbot</p>
+            <h1>Chat UI de pruebas</h1>
+            <p>
+              Consola administrativa para probar respuestas, revisar fuentes y validar
+              conversaciones sin exponer credenciales del endpoint público.
+            </p>
+          </div>
+          <button className="chat-new-button" type="button" onClick={startNewConversation}>
+            Nueva conversación
+          </button>
+        </header>
+        <div className="chat-workspace">
+          <ChatSidebar
+            conversations={persistedConversations}
+            selectedId={activeConversation.id}
+            onSelect={selectConversation}
+          />
+          <div className="chat-conversation-panel">
+            <ChatThread
+              messages={activeConversation.messages}
+              isSending={sendMessage.isPending}
+              onOpenSources={setModalSources}
+            />
+            <ChatComposer isSending={sendMessage.isPending} onSend={handleSend} />
+          </div>
+        </div>
+      </section>
+      {modalSources ? (
+        <SourceModal sources={modalSources} onClose={() => setModalSources(null)} />
+      ) : null}
+    </div>
+  );
+}

--- a/admin-panel/app/admin/layout.tsx
+++ b/admin-panel/app/admin/layout.tsx
@@ -11,6 +11,7 @@ import {
   FileText,
   GitBranch,
   LogOut,
+  MessageSquareText,
   Settings,
 } from "lucide-react";
 
@@ -19,6 +20,7 @@ import { useAdminAuth } from "@/providers/admin-auth-provider";
 
 const navItems = [
   { href: "/admin/dashboard", label: "Dashboard", icon: BarChart3 },
+  { href: "/admin/chat", label: "Chat", icon: MessageSquareText },
   { href: "/admin/config", label: "Config", icon: Settings },
   { href: "/admin/escalation", label: "Escalamiento", icon: GitBranch },
   { href: "/admin/s3-explorer", label: "S3 Explorer", icon: Cloud },
@@ -108,7 +110,9 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
             </Button>
           </div>
         </header>
-        <main className="p-6">{children}</main>
+        <main className={pathname.startsWith("/admin/chat") ? "p-0" : "p-6"}>
+          {children}
+        </main>
       </div>
     </div>
   );

--- a/admin-panel/app/globals.css
+++ b/admin-panel/app/globals.css
@@ -200,6 +200,35 @@
     box-shadow: 0 12px 32px rgba(15, 15, 15, 0.08);
   }
 
+  .chat-plain-text {
+    white-space: pre-wrap;
+  }
+
+  .chat-markdown {
+    display: grid;
+    gap: 0.55rem;
+    white-space: normal;
+  }
+
+  .chat-markdown :where(p, ul, ol, h1, h2, h3) {
+    margin: 0;
+  }
+
+  .chat-markdown :where(ul, ol) {
+    padding-left: 1.15rem;
+  }
+
+  .chat-markdown li {
+    margin: 0.2rem 0;
+  }
+
+  .chat-markdown code {
+    border-radius: 0.35rem;
+    background: rgba(15, 15, 15, 0.08);
+    padding: 0.05rem 0.28rem;
+    font-size: 0.9em;
+  }
+
   .chat-message-user .chat-message-card {
     border-color: rgba(255, 194, 0, 0.76);
     background: linear-gradient(135deg, var(--chat-amber), #ffe28a);

--- a/admin-panel/app/globals.css
+++ b/admin-panel/app/globals.css
@@ -4,23 +4,23 @@
 
 @layer base {
   :root {
-    --background: 44 45% 95%;
-    --foreground: 170 23% 12%;
-    --card: 48 42% 98%;
-    --card-foreground: 170 23% 12%;
-    --primary: 168 75% 18%;
-    --primary-foreground: 42 64% 96%;
-    --secondary: 42 80% 88%;
-    --secondary-foreground: 168 75% 18%;
-    --muted: 42 28% 88%;
-    --muted-foreground: 172 12% 38%;
-    --accent: 28 92% 54%;
-    --accent-foreground: 44 45% 95%;
+    --background: 190 8% 86%;
+    --foreground: 0 0% 6%;
+    --card: 0 0% 100%;
+    --card-foreground: 0 0% 6%;
+    --primary: 0 0% 6%;
+    --primary-foreground: 190 8% 86%;
+    --secondary: 46 100% 50%;
+    --secondary-foreground: 0 0% 6%;
+    --muted: 190 8% 92%;
+    --muted-foreground: 315 2% 44%;
+    --accent: 46 100% 50%;
+    --accent-foreground: 0 0% 6%;
     --destructive: 0 70% 45%;
-    --destructive-foreground: 44 45% 95%;
-    --border: 168 18% 78%;
-    --input: 168 18% 78%;
-    --ring: 28 92% 54%;
+    --destructive-foreground: 190 8% 96%;
+    --border: 315 2% 72%;
+    --input: 315 2% 72%;
+    --ring: 46 100% 50%;
     --radius: 0.9rem;
     --font-display: "Fraunces", "Georgia", serif;
     --font-body: "Aptos", "Segoe UI", sans-serif;
@@ -39,9 +39,285 @@
 @layer utilities {
   .solar-grid {
     background-image:
-      linear-gradient(rgba(16, 83, 73, 0.08) 1px, transparent 1px),
-      linear-gradient(90deg, rgba(16, 83, 73, 0.08) 1px, transparent 1px),
-      radial-gradient(circle at top right, rgba(241, 121, 35, 0.22), transparent 38rem);
+      linear-gradient(rgba(15, 15, 15, 0.035) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(15, 15, 15, 0.035) 1px, transparent 1px),
+      radial-gradient(circle at top right, rgba(255, 194, 0, 0.24), transparent 34rem);
     background-size: 48px 48px, 48px 48px, auto;
+  }
+
+  .admin-chat-shell {
+    --chat-smoky-black: #0f0f0f;
+    --chat-amber: #ffc200;
+    --chat-dark-silver: #736f72;
+    --chat-platinum: #d8ddde;
+    --chat-green: #09bc8a;
+    min-height: calc(100vh - 5.5rem);
+    background:
+      linear-gradient(135deg, rgba(255, 194, 0, 0.18), transparent 24rem),
+      var(--chat-platinum);
+    color: var(--chat-smoky-black);
+  }
+
+  .chat-main-panel {
+    display: flex;
+    min-height: calc(100vh - 5.5rem);
+    flex-direction: column;
+  }
+
+  .chat-hero {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid rgba(115, 111, 114, 0.32);
+    background: rgba(255, 255, 255, 0.72);
+    padding: 1.25rem 1.5rem;
+    backdrop-filter: blur(16px);
+  }
+
+  .chat-hero h1,
+  .chat-empty-state h2,
+  .chat-modal h2 {
+    color: var(--chat-smoky-black);
+    font-family: var(--font-display);
+    font-size: clamp(1.8rem, 3.4vw, 3.1rem);
+    font-weight: 950;
+    letter-spacing: -0.04em;
+  }
+
+  .chat-sidebar-kicker {
+    color: var(--chat-dark-silver);
+    font-size: 0.72rem;
+    font-weight: 900;
+    letter-spacing: 0.24em;
+    text-transform: uppercase;
+  }
+
+  .chat-empty-note,
+  .chat-hero p,
+  .chat-empty-state p {
+    color: var(--chat-dark-silver);
+  }
+
+  .chat-new-button,
+  .chat-composer button {
+    border-radius: 999px;
+    background: var(--chat-smoky-black);
+    color: var(--chat-amber);
+    font-weight: 900;
+    padding: 0.8rem 1rem;
+    box-shadow: 0 10px 24px rgba(15, 15, 15, 0.16);
+  }
+
+  .chat-workspace {
+    display: grid;
+    flex: 1;
+    grid-template-columns: minmax(14rem, 17rem) minmax(0, 1fr);
+    min-height: 0;
+  }
+
+  .chat-sidebar {
+    border-right: 1px solid rgba(115, 111, 114, 0.24);
+    background: rgba(255, 255, 255, 0.44);
+    padding: 1rem;
+  }
+
+  .chat-recent-section {
+    margin-top: 0.25rem;
+  }
+
+  .chat-recent-list {
+    margin-top: 0.75rem;
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .chat-recent-item {
+    border-radius: 1rem;
+    border: 1px solid rgba(115, 111, 114, 0.24);
+    background: rgba(255, 255, 255, 0.58);
+    padding: 0.75rem;
+    text-align: left;
+    transition: background 160ms ease, border-color 160ms ease, transform 160ms ease;
+  }
+
+  .chat-recent-item:hover,
+  .chat-recent-item-active {
+    background: rgba(255, 194, 0, 0.22);
+    border-color: var(--chat-amber);
+    transform: translateY(-1px);
+  }
+
+  .chat-recent-item span,
+  .chat-source-card h3 {
+    display: block;
+    color: var(--chat-smoky-black);
+    font-weight: 800;
+  }
+
+  .chat-recent-item small,
+  .chat-source-card p,
+  .chat-source-card small {
+    color: var(--chat-dark-silver);
+  }
+
+  .chat-conversation-panel {
+    display: flex;
+    min-height: 0;
+    flex-direction: column;
+  }
+
+  .chat-thread {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: 1rem;
+    overflow-y: auto;
+    padding: 1.5rem;
+  }
+
+  .chat-empty-state {
+    margin: auto;
+    max-width: 42rem;
+    padding: 2rem;
+    text-align: center;
+  }
+
+  .chat-message {
+    max-width: min(44rem, 86%);
+  }
+
+  .chat-message-user {
+    align-self: flex-end;
+  }
+
+  .chat-message-card {
+    border: 1px solid rgba(115, 111, 114, 0.22);
+    border-radius: 1.4rem;
+    background: rgba(255, 255, 255, 0.72);
+    padding: 1rem 1.15rem;
+    line-height: 1.7;
+    box-shadow: 0 12px 32px rgba(15, 15, 15, 0.08);
+  }
+
+  .chat-message-user .chat-message-card {
+    border-color: rgba(255, 194, 0, 0.76);
+    background: linear-gradient(135deg, var(--chat-amber), #ffe28a);
+    color: var(--chat-smoky-black);
+    font-weight: 750;
+  }
+
+  .chat-badge-row {
+    margin-top: 0.75rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    color: var(--chat-green);
+    font-size: 0.78rem;
+    font-weight: 800;
+  }
+
+  .chat-badge-alert {
+    color: var(--chat-amber);
+  }
+
+  .chat-sources-button,
+  .chat-modal-close,
+  .chat-source-card button {
+    margin-top: 0.55rem;
+    border-radius: 999px;
+    border: 1px solid rgba(15, 15, 15, 0.16);
+    background: rgba(255, 255, 255, 0.65);
+    color: var(--chat-smoky-black);
+    padding: 0.45rem 0.8rem;
+    font-weight: 850;
+  }
+
+  .chat-typing {
+    color: var(--chat-green);
+    font-weight: 800;
+  }
+
+  .chat-composer {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.75rem;
+    border-top: 1px solid rgba(115, 111, 114, 0.24);
+    background: rgba(255, 255, 255, 0.72);
+    padding: 1rem;
+    backdrop-filter: blur(16px);
+  }
+
+  .chat-composer textarea {
+    resize: none;
+    border-radius: 1.3rem;
+    border: 1px solid rgba(115, 111, 114, 0.28);
+    background: rgba(255, 255, 255, 0.82);
+    padding: 0.9rem 1rem;
+    color: var(--chat-smoky-black);
+    outline: none;
+  }
+
+  .chat-composer button {
+    width: auto;
+  }
+
+  .chat-composer button:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+  }
+
+  .chat-modal-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 50;
+    display: grid;
+    place-items: center;
+    background: rgba(15, 15, 15, 0.38);
+    padding: 1rem;
+  }
+
+  .chat-modal {
+    width: min(42rem, 100%);
+    border-radius: 1.5rem;
+    border: 1px solid rgba(115, 111, 114, 0.24);
+    background: var(--chat-platinum);
+    padding: 1.25rem;
+    box-shadow: 0 28px 80px rgba(15, 15, 15, 0.22);
+  }
+
+  .chat-modal-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .chat-source-list {
+    margin-top: 1rem;
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .chat-source-card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-radius: 1rem;
+    border: 1px solid rgba(115, 111, 114, 0.24);
+    background: rgba(255, 255, 255, 0.58);
+    padding: 1rem;
+  }
+
+  @media (max-width: 900px) {
+    .chat-workspace {
+      grid-template-columns: 1fr;
+    }
+
+    .chat-sidebar {
+      border-right: 0;
+      border-bottom: 1px solid rgba(115, 111, 114, 0.24);
+    }
   }
 }

--- a/admin-panel/components/chat/chat-composer.tsx
+++ b/admin-panel/components/chat/chat-composer.tsx
@@ -1,0 +1,38 @@
+import { type FormEvent, useState } from "react";
+
+interface ChatComposerProps {
+  isSending: boolean;
+  onSend: (message: string) => void;
+}
+
+export function ChatComposer({ isSending, onSend }: ChatComposerProps) {
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = message.trim();
+    if (!trimmed || isSending) {
+      return;
+    }
+    onSend(trimmed);
+    setMessage("");
+  };
+
+  return (
+    <form className="chat-composer" onSubmit={handleSubmit}>
+      <label className="sr-only" htmlFor="admin-chat-message">
+        Mensaje para probar el chatbot
+      </label>
+      <textarea
+        id="admin-chat-message"
+        value={message}
+        onChange={(event) => setMessage(event.target.value)}
+        placeholder="Escribí una consulta técnica para simular una conversación…"
+        rows={2}
+      />
+      <button disabled={isSending || !message.trim()} type="submit">
+        Enviar mensaje
+      </button>
+    </form>
+  );
+}

--- a/admin-panel/components/chat/chat-history.ts
+++ b/admin-panel/components/chat/chat-history.ts
@@ -1,0 +1,127 @@
+import type {
+  AdminChatConversation,
+  AdminChatMessage,
+  ChatResponse,
+  SourceDocument,
+} from "@/lib/types";
+
+export const ADMIN_CHAT_HISTORY_KEY = "arte_admin_chat_history";
+const MAX_CONVERSATIONS = 12;
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function createId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function getSourceKey(source: SourceDocument): string {
+  return source.ruta.trim();
+}
+
+export function getSourceName(source: SourceDocument): string {
+  const key = getSourceKey(source);
+  return key.split("/").filter(Boolean).at(-1) ?? key;
+}
+
+export function dedupeSources(sources: SourceDocument[] = []): SourceDocument[] {
+  const seen = new Set<string>();
+  return sources.filter((source) => {
+    const key = getSourceKey(source);
+    if (!key || seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+export function assistantPartsFromResponse(response: ChatResponse): string[] {
+  const splitParts = response.messages?.filter((message) => message.trim()) ?? [];
+  if (splitParts.length > 0) {
+    return splitParts;
+  }
+
+  return response.response.trim() ? [response.response] : [];
+}
+
+export function readChatHistory(): AdminChatConversation[] {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const raw = window.localStorage.getItem(ADMIN_CHAT_HISTORY_KEY);
+    const parsed: unknown = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? (parsed as AdminChatConversation[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function writeChatHistory(conversations: AdminChatConversation[]): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.localStorage.setItem(
+    ADMIN_CHAT_HISTORY_KEY,
+    JSON.stringify(conversations.slice(0, MAX_CONVERSATIONS)),
+  );
+}
+
+export function createEmptyConversation(): AdminChatConversation {
+  const timestamp = nowIso();
+  return {
+    id: createId("conversation"),
+    sessionId: createId("admin-session"),
+    title: "Nueva conversación",
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    messages: [],
+  };
+}
+
+export function createUserMessage(content: string): AdminChatMessage {
+  return {
+    id: createId("user"),
+    role: "user",
+    content,
+    createdAt: nowIso(),
+  };
+}
+
+export function createAssistantMessages(response: ChatResponse): AdminChatMessage[] {
+  const sources = dedupeSources(response.source_documents);
+  return assistantPartsFromResponse(response).map((content, index) => ({
+    id: createId(`assistant-${index}`),
+    role: "assistant",
+    content,
+    sources,
+    inputTokens: response.input_tokens,
+    outputTokens: response.output_tokens,
+    totalTokens: response.total_tokens,
+    escalate: response.escalate,
+    createdAt: nowIso(),
+  }));
+}
+
+export function upsertConversation(
+  conversations: AdminChatConversation[],
+  conversation: AdminChatConversation,
+): AdminChatConversation[] {
+  const next = [
+    { ...conversation, updatedAt: nowIso() },
+    ...conversations.filter((item) => item.id !== conversation.id),
+  ];
+  return next.slice(0, MAX_CONVERSATIONS);
+}
+
+export function titleFromPrompt(prompt: string): string {
+  const normalized = prompt.trim().replace(/\s+/g, " ");
+  if (!normalized) {
+    return "Nueva conversación";
+  }
+  return normalized.length > 42 ? `${normalized.slice(0, 39)}…` : normalized;
+}

--- a/admin-panel/components/chat/chat-history.ts
+++ b/admin-panel/components/chat/chat-history.ts
@@ -43,6 +43,17 @@ export function assistantPartsFromResponse(response: ChatResponse): string[] {
     return splitParts;
   }
 
+  if ((response.delays_ms?.length ?? 0) > 0) {
+    const responseSplitParts = response.response
+      .split(/\n{2,}/)
+      .map((message) => message.trim())
+      .filter(Boolean);
+
+    if (responseSplitParts.length > 0) {
+      return responseSplitParts;
+    }
+  }
+
   return response.response.trim() ? [response.response] : [];
 }
 

--- a/admin-panel/components/chat/chat-message-bubble.tsx
+++ b/admin-panel/components/chat/chat-message-bubble.tsx
@@ -1,3 +1,4 @@
+import { MarkdownPreview } from "@/components/markdown-preview";
 import type { AdminChatMessage, SourceDocument } from "@/lib/types";
 
 interface ChatMessageBubbleProps {
@@ -19,7 +20,11 @@ export function ChatMessageBubble({ message, onOpenSources }: ChatMessageBubbleP
       className={message.role === "user" ? "chat-message chat-message-user" : "chat-message"}
     >
       <div className="chat-message-card">
-        <p>{message.content}</p>
+        {message.role === "assistant" ? (
+          <MarkdownPreview content={message.content} className="chat-markdown" />
+        ) : (
+          <p className="chat-plain-text">{message.content}</p>
+        )}
         {hasTokenMetrics ? (
           <div className="chat-badge-row" aria-label="Métricas de tokens">
             {message.inputTokens != null ? <span>Entrada: {message.inputTokens}</span> : null}

--- a/admin-panel/components/chat/chat-message-bubble.tsx
+++ b/admin-panel/components/chat/chat-message-bubble.tsx
@@ -1,0 +1,43 @@
+import type { AdminChatMessage, SourceDocument } from "@/lib/types";
+
+interface ChatMessageBubbleProps {
+  message: AdminChatMessage;
+  onOpenSources: (sources: SourceDocument[]) => void;
+}
+
+export function ChatMessageBubble({ message, onOpenSources }: ChatMessageBubbleProps) {
+  const sources = message.sources ?? [];
+  const hasSources = message.role === "assistant" && sources.length > 0;
+  const hasTokenMetrics =
+    message.role === "assistant" &&
+    (message.inputTokens != null ||
+      message.outputTokens != null ||
+      message.totalTokens != null);
+
+  return (
+    <article
+      className={message.role === "user" ? "chat-message chat-message-user" : "chat-message"}
+    >
+      <div className="chat-message-card">
+        <p>{message.content}</p>
+        {hasTokenMetrics ? (
+          <div className="chat-badge-row" aria-label="Métricas de tokens">
+            {message.inputTokens != null ? <span>Entrada: {message.inputTokens}</span> : null}
+            {message.outputTokens != null ? <span>Salida: {message.outputTokens}</span> : null}
+            {message.totalTokens != null ? <span>Total: {message.totalTokens}</span> : null}
+            {message.escalate ? <span className="chat-badge-alert">Escalar</span> : null}
+          </div>
+        ) : null}
+      </div>
+      {hasSources ? (
+        <button
+          className="chat-sources-button"
+          type="button"
+          onClick={() => onOpenSources(sources)}
+        >
+          Ver fichas técnicas
+        </button>
+      ) : null}
+    </article>
+  );
+}

--- a/admin-panel/components/chat/chat-sidebar.tsx
+++ b/admin-panel/components/chat/chat-sidebar.tsx
@@ -1,0 +1,44 @@
+import type { AdminChatConversation } from "@/lib/types";
+
+interface ChatSidebarProps {
+  conversations: AdminChatConversation[];
+  selectedId: string;
+  onSelect: (conversation: AdminChatConversation) => void;
+}
+
+export function ChatSidebar({
+  conversations,
+  selectedId,
+  onSelect,
+}: ChatSidebarProps) {
+  return (
+    <aside className="chat-sidebar">
+      <section aria-labelledby="recent-chat-heading" className="chat-recent-section">
+        <p id="recent-chat-heading" className="chat-sidebar-kicker">
+          Recientes
+        </p>
+        {conversations.length === 0 ? (
+          <p className="chat-empty-note">Todavía no hay conversaciones guardadas.</p>
+        ) : (
+          <div className="chat-recent-list">
+            {conversations.map((conversation) => (
+              <button
+                key={conversation.id}
+                type="button"
+                className={
+                  conversation.id === selectedId
+                    ? "chat-recent-item chat-recent-item-active"
+                    : "chat-recent-item"
+                }
+                onClick={() => onSelect(conversation)}
+              >
+                <span>{conversation.title}</span>
+                <small>{conversation.messages.length} mensajes</small>
+              </button>
+            ))}
+          </div>
+        )}
+      </section>
+    </aside>
+  );
+}

--- a/admin-panel/components/chat/chat-thread.tsx
+++ b/admin-panel/components/chat/chat-thread.tsx
@@ -1,0 +1,37 @@
+import type { AdminChatMessage, SourceDocument } from "@/lib/types";
+
+import { ChatMessageBubble } from "./chat-message-bubble";
+
+interface ChatThreadProps {
+  messages: AdminChatMessage[];
+  isSending: boolean;
+  onOpenSources: (sources: SourceDocument[]) => void;
+}
+
+export function ChatThread({ messages, isSending, onOpenSources }: ChatThreadProps) {
+  if (messages.length === 0) {
+    return (
+      <section className="chat-empty-state" aria-label="Conversación vacía">
+        <p className="chat-sidebar-kicker">Workbench</p>
+        <h2>Probá conversaciones B2B con fichas técnicas reales.</h2>
+        <p>
+          Las respuestas usan el proxy administrativo y quedan guardadas como
+          historial local sin almacenar secretos del chatbot.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section aria-label="Historial de conversación" className="chat-thread">
+      {messages.map((message) => (
+        <ChatMessageBubble
+          key={message.id}
+          message={message}
+          onOpenSources={onOpenSources}
+        />
+      ))}
+      {isSending ? <p className="chat-typing">Generando respuesta…</p> : null}
+    </section>
+  );
+}

--- a/admin-panel/components/chat/source-modal.tsx
+++ b/admin-panel/components/chat/source-modal.tsx
@@ -1,0 +1,61 @@
+import { usePresignedDownload } from "@/lib/api";
+import type { SourceDocument } from "@/lib/types";
+
+import { getSourceKey, getSourceName } from "./chat-history";
+
+interface SourceModalProps {
+  sources: SourceDocument[];
+  onClose: () => void;
+}
+
+export function SourceModal({ sources, onClose }: SourceModalProps) {
+  const presignedDownload = usePresignedDownload();
+
+  const openSource = async (source: SourceDocument) => {
+    const result = await presignedDownload.mutateAsync({
+      key: getSourceKey(source),
+      disposition: "inline",
+    });
+    window.open(result.url, "_blank", "noopener,noreferrer");
+  };
+
+  return (
+    <div className="chat-modal-backdrop" role="presentation">
+      <section
+        aria-label="Fichas técnicas usadas"
+        aria-modal="true"
+        className="chat-modal"
+        role="dialog"
+      >
+        <div className="chat-modal-header">
+          <div>
+            <p className="chat-sidebar-kicker">Fuentes</p>
+            <h2>Fichas técnicas usadas</h2>
+          </div>
+          <button className="chat-modal-close" type="button" onClick={onClose}>
+            Cerrar
+          </button>
+        </div>
+        <div className="chat-source-list">
+          {sources.map((source) => {
+            const name = getSourceName(source);
+            return (
+              <article className="chat-source-card" key={getSourceKey(source)}>
+                <div>
+                  <h3>{name}</h3>
+                  <p>{getSourceKey(source)}</p>
+                  {source.contenido_relevante ? (
+                    <small>{source.contenido_relevante}</small>
+                  ) : null}
+                </div>
+                <button type="button" onClick={() => openSource(source)}>
+                  Abrir {name}
+                </button>
+              </article>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/admin-panel/components/markdown-preview.tsx
+++ b/admin-panel/components/markdown-preview.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 
 interface MarkdownPreviewProps {
   content: string;
+  className?: string;
 }
 
 function escapeHtml(value: string): string {
@@ -18,16 +19,18 @@ function escapeHtml(value: string): string {
 function renderInline(value: string): string {
   return escapeHtml(value)
     .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/\*(.+?)\*/g, "<strong>$1</strong>")
+    .replace(/(^|\s)_(.+?)_(?=\s|$|[.,;:!?])/g, "$1<em>$2</em>")
     .replace(/`(.+?)`/g, "<code>$1</code>");
 }
 
-function renderMarkdown(content: string): string {
+export function renderMarkdown(content: string): string {
   const lines = content.split("\n");
   const html: string[] = [];
   let listOpen = false;
 
   for (const line of lines) {
-    if (line.startsWith("- ")) {
+    if (line.startsWith("- ") || line.startsWith("• ")) {
       if (!listOpen) {
         html.push("<ul>");
         listOpen = true;
@@ -59,12 +62,15 @@ function renderMarkdown(content: string): string {
   return html.join("\n");
 }
 
-export function MarkdownPreview({ content }: MarkdownPreviewProps) {
+export function MarkdownPreview({ content, className }: MarkdownPreviewProps) {
   const html = useMemo(() => renderMarkdown(content), [content]);
 
   return (
     <article
-      className="prose prose-sm max-w-none rounded-2xl border bg-card p-4 text-foreground shadow-sm [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_h1]:text-2xl [&_h1]:font-black [&_h2]:text-xl [&_h2]:font-bold [&_h3]:text-lg [&_h3]:font-bold [&_li]:ml-5 [&_li]:list-disc [&_p]:my-2"
+      className={
+        className ??
+        "prose prose-sm max-w-none rounded-2xl border bg-card p-4 text-foreground shadow-sm [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_h1]:text-2xl [&_h1]:font-black [&_h2]:text-xl [&_h2]:font-bold [&_h3]:text-lg [&_h3]:font-bold [&_li]:ml-5 [&_li]:list-disc [&_p]:my-2"
+      }
       data-testid="markdown-preview"
       dangerouslySetInnerHTML={{ __html: html || "<p>Sin contenido.</p>" }}
     />

--- a/admin-panel/lib/api.ts
+++ b/admin-panel/lib/api.ts
@@ -3,7 +3,10 @@ import { toast } from "sonner";
 
 import { STORAGE_KEY } from "@/providers/admin-auth-provider";
 import type {
+  BufferResultResponse,
   CatalogIndex,
+  ChatRequest,
+  ChatResponse,
   ConversationLogEntry,
   ConversationLogsResponse,
   ConversationLogSummary,
@@ -376,6 +379,32 @@ export function useLogs(filters: LogFilterParams = {}) {
 
       return response;
     },
+    staleTime: 0,
+  });
+}
+
+export function useSendAdminChatMessage() {
+  return useMutation({
+    mutationFn: (data: ChatRequest) =>
+      adminFetch<ChatResponse>("/admin/chat", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+    onError: (error) => {
+      const message = error instanceof Error ? error.message : "Error inesperado";
+      toast.error(message);
+    },
+  });
+}
+
+export function useAdminChatBufferResult(sessionId: string | null) {
+  return useQuery({
+    queryKey: ["admin", "chat", "buffer", sessionId],
+    queryFn: () =>
+      adminFetch<BufferResultResponse>(
+        `/admin/chat/buffer-result/${encodeURIComponent(sessionId ?? "")}`,
+      ),
+    enabled: Boolean(sessionId),
     staleTime: 0,
   });
 }

--- a/admin-panel/lib/types.ts
+++ b/admin-panel/lib/types.ts
@@ -147,3 +147,55 @@ export interface ConversationLogEntry {
   git_commit_hash: string;
   user_profile?: string | null;
 }
+
+export interface ChatRequest {
+  message: string;
+  session_id?: string;
+  is_final?: boolean;
+}
+
+export interface SourceDocument {
+  ruta: string;
+  contenido_relevante?: string | null;
+}
+
+export interface ChatResponse {
+  response: string;
+  session_id: string;
+  source_documents: SourceDocument[];
+  messages?: string[] | null;
+  delays_ms?: number[] | null;
+  escalate: boolean;
+  input_tokens?: number | null;
+  output_tokens?: number | null;
+  total_tokens?: number | null;
+}
+
+export interface BufferResultResponse {
+  status: "pending" | "ready" | "not_found";
+  session_id: string;
+  result?: string | null;
+}
+
+export type AdminChatRole = "user" | "assistant";
+
+export interface AdminChatMessage {
+  id: string;
+  role: AdminChatRole;
+  content: string;
+  sources?: SourceDocument[];
+  inputTokens?: number | null;
+  outputTokens?: number | null;
+  totalTokens?: number | null;
+  escalate?: boolean;
+  createdAt?: string;
+}
+
+export interface AdminChatConversation {
+  id: string;
+  sessionId: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+  messages: AdminChatMessage[];
+}

--- a/backend/app/admin_chat.py
+++ b/backend/app/admin_chat.py
@@ -1,0 +1,186 @@
+"""Admin-authenticated chat proxy endpoints."""
+
+import uuid
+from typing import Annotated, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+from backend.app.admin_auth import verify_admin_key
+from backend.app.auth import api_key_principal
+from backend.app.config import settings
+from backend.app.message_buffer import (
+    add_to_buffer,
+    clear_pending_chat_response,
+    clear_processing,
+    flush_buffer,
+    get_buffer_count,
+    is_buffering,
+    is_processing,
+    pop_pending_chat_response,
+    schedule_flush,
+)
+from backend.app.security import (
+    check_rate_limit,
+    validate_session_id,
+)
+from backend.app.session import session_manager
+
+chat_router = APIRouter(tags=["admin-chat"])
+
+
+class AdminChatRequest(BaseModel):
+    """Request model for the admin chat proxy endpoint."""
+
+    message: str = Field(..., min_length=1, max_length=4000)
+    session_id: Optional[str] = Field(
+        default=None,
+        max_length=128,
+        pattern=r"^[A-Za-z0-9._:-]+$",
+    )
+    is_final: Optional[bool] = Field(
+        default=None,
+        description="Hint to flush multi-message buffer immediately",
+    )
+
+
+class AdminBufferingResponse(BaseModel):
+    """Response returned while admin multi-message buffering is active."""
+
+    status: str = "buffering"
+    session_id: str
+    poll_url: Optional[str] = Field(default=None)
+
+
+class AdminBufferResultResponse(BaseModel):
+    """Response returned when polling an admin buffered chat result."""
+
+    status: str = Field(default="pending")
+    session_id: str
+    result: Optional[str] = Field(default=None)
+
+
+def _admin_principal(admin_key: str) -> str:
+    """Return a stable principal namespace for admin chat sessions."""
+    return f"admin:{api_key_principal(admin_key)}"
+
+
+def _bind_or_validate_admin_session(session_id: str, principal: str) -> None:
+    """Bind unknown admin chat sessions or validate existing ownership."""
+    if not session_manager.has_session_owner(session_id):
+        session_manager.bind_session(session_id, principal)
+        return
+
+    if not session_manager.is_session_owner(session_id, principal):
+        raise HTTPException(status_code=403, detail="Forbidden session_id")
+
+
+async def _process_admin_buffer_expiry(
+    session_id: str,
+    joined_message: str,
+) -> None:
+    """Delegate admin buffer expiry processing to the existing chat callback."""
+    from backend.main import _on_buffer_window_expired
+
+    await _on_buffer_window_expired(session_id, joined_message)
+
+
+@chat_router.post("/chat")
+async def admin_chat_endpoint(
+    request: AdminChatRequest,
+    admin_key: Annotated[str, Depends(verify_admin_key)],
+) -> object:
+    """Process chat messages through the admin-authenticated proxy."""
+    from backend.app.llm_client import LLMServiceError
+    from backend.main import (
+        _process_chat_message,
+        file_inputs_client,
+        llm_client,
+        s3_client,
+    )
+
+    principal = _admin_principal(admin_key)
+    check_rate_limit(principal)
+
+    session_id = request.session_id or str(uuid.uuid4())
+    validate_session_id(session_id)
+    _bind_or_validate_admin_session(session_id, principal)
+    request_id = str(uuid.uuid4())
+
+    if settings.multi_message_buffer_enabled:
+        current_count = get_buffer_count(session_id)
+
+        if request.is_final or current_count >= 4:
+            overflow_result = await add_to_buffer(session_id, request.message)
+            joined = overflow_result or await flush_buffer(session_id)
+            if joined:
+                if len(joined) > settings.max_chat_message_chars:
+                    raise HTTPException(
+                        status_code=413,
+                        detail="Buffered message too large",
+                    )
+                request = AdminChatRequest(
+                    message=joined,
+                    session_id=session_id,
+                    is_final=request.is_final,
+                )
+        else:
+            clear_pending_chat_response(session_id)
+            clear_processing(session_id)
+            await add_to_buffer(session_id, request.message)
+            schedule_flush(
+                session_id,
+                settings.buffer_window_seconds,
+                _process_admin_buffer_expiry,
+            )
+            return JSONResponse(
+                status_code=202,
+                content=AdminBufferingResponse(
+                    session_id=session_id,
+                    poll_url=f"/admin/chat/buffer-result/{session_id}",
+                ).model_dump(),
+            )
+
+    try:
+        return await _process_chat_message(
+            session_id=session_id,
+            message=request.message,
+            llm_client=llm_client,
+            s3_client=s3_client,
+            file_inputs_client=file_inputs_client,
+            request_id=request_id,
+        )
+    except LLMServiceError as exc:
+        raise HTTPException(status_code=503, detail="LLM service unavailable") from exc
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail="Internal server error") from exc
+
+
+@chat_router.get(
+    "/chat/buffer-result/{session_id}",
+    response_model=AdminBufferResultResponse,
+)
+async def get_admin_buffer_result(
+    session_id: str,
+    admin_key: Annotated[str, Depends(verify_admin_key)],
+) -> AdminBufferResultResponse:
+    """Poll for an admin buffered chat response."""
+    validate_session_id(session_id)
+
+    principal = _admin_principal(admin_key)
+    check_rate_limit(principal)
+    _bind_or_validate_admin_session(session_id, principal)
+
+    chat_response_json = pop_pending_chat_response(session_id)
+    if chat_response_json:
+        return AdminBufferResultResponse(
+            status="ready",
+            session_id=session_id,
+            result=chat_response_json,
+        )
+
+    if is_buffering(session_id) or is_processing(session_id):
+        return AdminBufferResultResponse(status="pending", session_id=session_id)
+
+    return AdminBufferResultResponse(status="not_found", session_id=session_id)

--- a/backend/app/admin_router.py
+++ b/backend/app/admin_router.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends
 
 from backend.app.admin_auth import verify_admin_key
 from backend.app.admin_catalog import catalog_router
+from backend.app.admin_chat import chat_router
 from backend.app.admin_config import config_router
 from backend.app.admin_dashboard import dashboard_router
 from backend.app.admin_guides import guides_router
@@ -18,6 +19,7 @@ from backend.app.admin_s3 import s3_router
 admin_router = APIRouter(prefix="/admin")
 
 admin_router.include_router(catalog_router)
+admin_router.include_router(chat_router)
 admin_router.include_router(config_router)
 admin_router.include_router(dashboard_router)
 admin_router.include_router(guides_router)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -17,8 +17,10 @@ from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 LOCAL_CORS_ORIGINS = [
     "http://localhost:3000",
+    "http://localhost:3001",
     "http://localhost:5173",
     "http://127.0.0.1:3000",
+    "http://127.0.0.1:3001",
     "http://127.0.0.1:5173",
 ]
 

--- a/backend/app/tests/test_admin_chat.py
+++ b/backend/app/tests/test_admin_chat.py
@@ -1,0 +1,175 @@
+"""Tests for admin-authenticated chat proxy endpoints."""
+
+import json
+from typing import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.app.config import settings
+from backend.app.message_buffer import set_pending_chat_response, set_processing
+from backend.tests.conftest import make_llm_response
+
+
+def _reset_settings() -> None:
+    """Reset settings proxy so each test reads patched environment values."""
+    settings.reset()
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, None, None]:
+    """FastAPI TestClient with only admin auth configured."""
+    monkeypatch.setenv("ADMIN_API_KEY", "test-admin-key")
+    monkeypatch.setenv("CHAT_API_KEY", "")
+    monkeypatch.setenv("GREETING_ENABLED", "false")
+    monkeypatch.setenv("MULTI_MESSAGE_BUFFER_ENABLED", "false")
+    _reset_settings()
+
+    from backend.main import app
+
+    with TestClient(app) as test_client:
+        yield test_client
+
+    _reset_settings()
+
+
+def _admin_headers() -> dict[str, str]:
+    """Return valid admin auth headers for tests."""
+    return {"X-Admin-API-Key": "test-admin-key"}
+
+
+class TestAdminChatAuth:
+    """Admin chat access requires admin authentication only."""
+
+    def test_admin_chat_requires_admin_key(self, client: TestClient) -> None:
+        """POST /admin/chat without admin key returns 401."""
+        response = client.post("/admin/chat", json={"message": "Hola"})
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Missing admin API key"
+
+    def test_admin_chat_rejects_invalid_admin_key(self, client: TestClient) -> None:
+        """POST /admin/chat with wrong admin key returns 403."""
+        response = client.post(
+            "/admin/chat",
+            headers={"X-Admin-API-Key": "wrong"},
+            json={"message": "Hola"},
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Invalid admin API key"
+
+    @patch("backend.main.llm_client.get_llm_response_with_tools")
+    def test_admin_chat_does_not_require_chat_api_key(
+        self,
+        mock_llm: AsyncMock,
+        client: TestClient,
+    ) -> None:
+        """Admin-authenticated chat succeeds when CHAT_API_KEY is not configured."""
+        mock_llm.return_value = make_llm_response(text="[INTENT: FAQ] Hola admin")
+
+        response = client.post(
+            "/admin/chat",
+            headers=_admin_headers(),
+            json={"message": "Hola", "session_id": "admin-chat-no-chat-key"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["response"] == "Hola admin"
+        assert data["session_id"] == "admin-chat-no-chat-key"
+
+
+class TestAdminChatContract:
+    """Admin chat proxy preserves existing chat response contracts."""
+
+    @patch("backend.main.process_split_messages")
+    @patch("backend.main.llm_client.get_llm_response_with_tools")
+    def test_admin_chat_preserves_split_fields(
+        self,
+        mock_llm: AsyncMock,
+        mock_split_messages: AsyncMock,
+        client: TestClient,
+    ) -> None:
+        """Split assistant fields are returned unchanged through admin proxy."""
+        mock_llm.return_value = make_llm_response(
+            text="[INTENT: FAQ] Primera parte\n---\nSegunda parte",
+            input_tokens=11,
+            output_tokens=7,
+            total_tokens=18,
+        )
+        mock_split_messages.return_value = (
+            ["Primera parte", "Segunda parte"],
+            [1200],
+        )
+
+        response = client.post(
+            "/admin/chat",
+            headers=_admin_headers(),
+            json={"message": "Separá", "session_id": "admin-chat-split"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["messages"] == ["Primera parte", "Segunda parte"]
+        assert data["delays_ms"] == [1200]
+        assert data["input_tokens"] == 11
+        assert data["output_tokens"] == 7
+        assert data["total_tokens"] == 18
+
+    def test_admin_buffer_result_returns_ready_chat_response(
+        self,
+        client: TestClient,
+    ) -> None:
+        """Admin buffer polling returns the same ready JSON payload contract."""
+        session_id = "admin-buffer-ready"
+        chat_response = {
+            "response": "Respuesta lista",
+            "escalate": False,
+            "intent_type": "FAQ",
+            "confidence": None,
+            "reason": None,
+            "session_id": session_id,
+            "source_documents": [],
+            "num_sources": 0,
+            "user_profile": "intermedio",
+            "messages": ["Respuesta lista"],
+            "delays_ms": [1200],
+            "input_tokens": 3,
+            "output_tokens": 4,
+            "total_tokens": 7,
+        }
+        set_pending_chat_response(session_id, json.dumps(chat_response))
+
+        response = client.get(
+            f"/admin/chat/buffer-result/{session_id}",
+            headers=_admin_headers(),
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ready"
+        assert data["session_id"] == session_id
+        assert json.loads(data["result"]) == chat_response
+
+    def test_admin_buffer_result_pending_while_processing(
+        self,
+        client: TestClient,
+    ) -> None:
+        """Admin buffer polling reports pending while background processing runs."""
+        session_id = "admin-buffer-pending"
+        set_processing(session_id)
+
+        response = client.get(
+            f"/admin/chat/buffer-result/{session_id}",
+            headers=_admin_headers(),
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data == {
+            "status": "pending",
+            "session_id": session_id,
+            "result": None,
+        }

--- a/backend/main.py
+++ b/backend/main.py
@@ -1108,12 +1108,8 @@ async def _process_chat_message(
                         total_tokens=acc_total_tokens,
                     )
 
-                response_text = cleaned_content
-                if settings.whatsapp_formatter_enabled:
-                    response_text = format_for_whatsapp(cleaned_content)
-
                 split_messages, split_delays = process_split_messages(
-                    text=response_text,
+                    text=cleaned_content,
                     intent_type=intent_for_behavior,
                     llm_regenerate_fn=None,
                 )
@@ -1128,6 +1124,10 @@ async def _process_chat_message(
                     )
                     response_text = "\n\n".join(split_messages)
                 else:
+                    response_text = cleaned_content
+                    if settings.whatsapp_formatter_enabled:
+                        response_text = format_for_whatsapp(cleaned_content)
+
                     response_text = maybe_prepend_greeting(
                         session_id=session_id,
                         response_text=response_text,

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -70,8 +70,10 @@ class TestRuntimeCorsConfig:
             settings = Settings()
             assert settings.allowed_cors_origins == [
                 "http://localhost:3000",
+                "http://localhost:3001",
                 "http://localhost:5173",
                 "http://127.0.0.1:3000",
+                "http://127.0.0.1:3001",
                 "http://127.0.0.1:5173",
             ]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
       - PORT=8000
+      - ALLOWED_CORS_ORIGINS=http://localhost:3001,http://127.0.0.1:3001,http://localhost:3000,http://127.0.0.1:3000,http://localhost:5173,http://127.0.0.1:5173
       # Local Docker runs include the admin Logs screen, so persist chat turns
       # unless explicitly disabled in the shell/.env with CONVERSATION_LOGGING_ENABLED=false.
       - CONVERSATION_LOGGING_ENABLED=${CONVERSATION_LOGGING_ENABLED:-true}
@@ -24,24 +25,6 @@ services:
       timeout: 3s
       retries: 3
       start_period: 10s
-    restart: unless-stopped
-
-  frontend:
-    build:
-      context: .
-      dockerfile: frontend/Dockerfile
-      args:
-        - GIT_COMMIT_HASH=${GIT_COMMIT_HASH:-unknown}
-    container_name: arte-chatbot-frontend
-    ports:
-      - "3000:3000"
-    env_file:
-      - .env
-    environment:
-      - API_URL=http://localhost:8000
-      - GIT_COMMIT_HASH=${GIT_COMMIT_HASH:-unknown}
-    depends_on:
-      - backend
     restart: unless-stopped
 
   admin-panel:

--- a/infra/terraform/envs/local-staging/main.tf
+++ b/infra/terraform/envs/local-staging/main.tf
@@ -4,13 +4,11 @@ locals {
 
   hostname_labels = {
     api   = "staging-chatbot-api-${var.staging_id}"
-    app   = "staging-chatbot-${var.staging_id}"
     admin = "staging-chatbot-admin-${var.staging_id}"
   }
 
-  backend_hostname  = "${local.hostname_labels.api}.${var.domain_name}"
-  frontend_hostname = "${local.hostname_labels.app}.${var.domain_name}"
-  admin_hostname    = "${local.hostname_labels.admin}.${var.domain_name}"
+  backend_hostname = "${local.hostname_labels.api}.${var.domain_name}"
+  admin_hostname   = "${local.hostname_labels.admin}.${var.domain_name}"
 
   production_hostnames = [
     "api.${var.domain_name}",
@@ -18,12 +16,10 @@ locals {
     "admin.${var.domain_name}",
   ]
 
-  public_api_url      = "https://${local.backend_hostname}"
-  public_frontend_url = "https://${local.frontend_hostname}"
-  public_admin_url    = "https://${local.admin_hostname}"
+  public_api_url   = "https://${local.backend_hostname}"
+  public_admin_url = "https://${local.admin_hostname}"
 
   allowed_cors_origins = join(",", [
-    local.public_frontend_url,
     local.public_admin_url,
   ])
 
@@ -43,7 +39,7 @@ resource "terraform_data" "production_hostname_guard" {
   lifecycle {
     precondition {
       condition = alltrue([
-        for hostname in [local.backend_hostname, local.frontend_hostname, local.admin_hostname] : !contains(local.production_hostnames, hostname)
+        for hostname in [local.backend_hostname, local.admin_hostname] : !contains(local.production_hostnames, hostname)
       ])
       error_message = "Local staging hostnames must not equal production api/app/admin hostnames."
     }
@@ -79,24 +75,6 @@ module "backend_cloudflare_tunnel" {
   tags = ["project:arte-chatbot", "environment:local-staging", "staging_id:${var.staging_id}", "service:backend"]
 }
 
-module "frontend_cloudflare_tunnel" {
-  source = "../../modules/cloudflare_tunnel"
-
-  account_id    = var.cloudflare_account_id
-  zone_id       = var.cloudflare_zone_id
-  tunnel_name   = "${local.name_prefix}-frontend"
-  tunnel_secret = var.frontend_tunnel_secret
-
-  public_hostnames = [
-    {
-      hostname         = local.frontend_hostname
-      local_origin_url = "http://localhost:3000"
-    }
-  ]
-
-  tags = ["project:arte-chatbot", "environment:local-staging", "staging_id:${var.staging_id}", "service:frontend"]
-}
-
 module "admin_cloudflare_tunnel" {
   source = "../../modules/cloudflare_tunnel"
 
@@ -126,10 +104,6 @@ module "cloudflare_tunnel_secrets" {
       description = "cloudflared connector token for backend local staging service"
       value       = module.backend_cloudflare_tunnel.tunnel_token
     }
-    frontend_cloudflare_tunnel_token = {
-      description = "cloudflared connector token for frontend local staging service"
-      value       = module.frontend_cloudflare_tunnel.tunnel_token
-    }
     admin_cloudflare_tunnel_token = {
       description = "cloudflared connector token for admin local staging service"
       value       = module.admin_cloudflare_tunnel.tunnel_token
@@ -145,11 +119,6 @@ module "cloudflare_tunnel_secrets" {
     "/local-staging/${var.staging_id}/backend_image_tag" = {
       description = "Backend ECR tag deployed to local staging."
       value       = var.backend_image_tag
-      secure      = false
-    }
-    "/local-staging/${var.staging_id}/frontend_image_tag" = {
-      description = "Frontend ECR tag deployed to local staging."
-      value       = var.frontend_image_tag
       secure      = false
     }
     "/local-staging/${var.staging_id}/admin_image_tag" = {
@@ -205,7 +174,6 @@ module "backend_service" {
     AWS_BUCKET_NAME      = var.aws_bucket_name
     AWS_REGION           = var.aws_region
     PUBLIC_API_URL       = local.public_api_url
-    PUBLIC_FRONTEND_URL  = local.public_frontend_url
     PUBLIC_ADMIN_URL     = local.public_admin_url
     ALLOWED_CORS_ORIGINS = local.allowed_cors_origins
     PORT                 = "8000"
@@ -232,48 +200,6 @@ module "backend_service" {
   task_role_policy_json = data.aws_iam_policy_document.backend_task_s3.json
   ecr_repository_arns   = [var.backend_ecr_repository_arn]
   tags                  = merge(local.common_tags, { Service = "backend" })
-}
-
-module "frontend_service" {
-  source = "../../modules/ecs_service"
-
-  name             = "${local.name_prefix}-frontend"
-  environment      = local.environment
-  cluster_arn      = aws_ecs_cluster.this.arn
-  cluster_name     = aws_ecs_cluster.this.name
-  vpc_id           = var.vpc_id
-  subnet_ids       = var.private_subnet_ids
-  assign_public_ip = var.assign_public_ip
-  desired_count    = var.desired_count
-  cpu              = var.task_cpu
-  memory           = var.task_memory
-
-  image_uri      = "${var.frontend_ecr_repository_url}:${var.frontend_image_tag}"
-  container_name = "frontend"
-  container_port = 3000
-
-  environment_variables = {
-    API_URL = local.public_api_url
-  }
-
-  sidecar_containers = [
-    {
-      name      = "cloudflared"
-      image     = var.cloudflared_image
-      essential = true
-      command   = ["tunnel", "--no-autoupdate", "run"]
-      environment = {
-        TUNNEL_ORIGIN_URL = "http://localhost:3000"
-      }
-      secrets = {
-        TUNNEL_TOKEN = local.tunnel_token_secret_arns["frontend_cloudflare_tunnel_token"]
-      }
-    }
-  ]
-
-  health_check_command = ["CMD-SHELL", "wget -qO- http://localhost:3000/ >/dev/null || exit 1"]
-  ecr_repository_arns  = [var.frontend_ecr_repository_arn]
-  tags                 = merge(local.common_tags, { Service = "frontend" })
 }
 
 module "admin_service" {

--- a/infra/terraform/envs/local-staging/outputs.tf
+++ b/infra/terraform/envs/local-staging/outputs.tf
@@ -7,7 +7,6 @@ output "public_urls" {
   description = "Unique local staging Cloudflare public URLs."
   value = {
     api   = local.public_api_url
-    app   = local.public_frontend_url
     admin = local.public_admin_url
   }
 }
@@ -20,8 +19,7 @@ output "expiration_at" {
 output "ecs_services" {
   description = "Local staging ECS service names."
   value = {
-    backend  = module.backend_service.service_name
-    frontend = module.frontend_service.service_name
-    admin    = module.admin_service.service_name
+    backend = module.backend_service.service_name
+    admin   = module.admin_service.service_name
   }
 }

--- a/infra/terraform/envs/local-staging/terraform.tfvars.example
+++ b/infra/terraform/envs/local-staging/terraform.tfvars.example
@@ -12,18 +12,14 @@ assign_public_ip = false
 cloudflare_account_id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 cloudflare_zone_id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 backend_tunnel_secret = "local-staging-backend-secret"
-frontend_tunnel_secret = "local-staging-frontend-secret"
 admin_tunnel_secret = "local-staging-admin-secret"
 
 backend_ecr_repository_url = "521170872319.dkr.ecr.us-east-2.amazonaws.com/arte-chatbot-prod-backend"
-frontend_ecr_repository_url = "521170872319.dkr.ecr.us-east-2.amazonaws.com/arte-chatbot-prod-frontend"
 admin_ecr_repository_url = "521170872319.dkr.ecr.us-east-2.amazonaws.com/arte-chatbot-prod-admin"
 backend_ecr_repository_arn = "arn:aws:ecr:us-east-2:521170872319:repository/arte-chatbot-prod-backend"
-frontend_ecr_repository_arn = "arn:aws:ecr:us-east-2:521170872319:repository/arte-chatbot-prod-frontend"
 admin_ecr_repository_arn = "arn:aws:ecr:us-east-2:521170872319:repository/arte-chatbot-prod-admin"
 
 backend_image_tag = "pr-123-sha-abcdef1"
-frontend_image_tag = "pr-123-sha-abcdef1"
 admin_image_tag = "pr-123-sha-abcdef1"
 expiration_at = "2026-06-05T12:00:00Z"
 

--- a/infra/terraform/envs/local-staging/variables.tf
+++ b/infra/terraform/envs/local-staging/variables.tf
@@ -69,12 +69,6 @@ variable "backend_tunnel_secret" {
   sensitive   = true
 }
 
-variable "frontend_tunnel_secret" {
-  description = "Local-staging-only frontend tunnel secret. Do not reuse production tunnel material."
-  type        = string
-  sensitive   = true
-}
-
 variable "admin_tunnel_secret" {
   description = "Local-staging-only admin tunnel secret. Do not reuse production tunnel material."
   type        = string
@@ -86,11 +80,6 @@ variable "backend_ecr_repository_url" {
   type        = string
 }
 
-variable "frontend_ecr_repository_url" {
-  description = "Existing frontend ECR repository URL that contains the explicit candidate tag."
-  type        = string
-}
-
 variable "admin_ecr_repository_url" {
   description = "Existing admin ECR repository URL that contains the explicit candidate tag."
   type        = string
@@ -98,11 +87,6 @@ variable "admin_ecr_repository_url" {
 
 variable "backend_ecr_repository_arn" {
   description = "Backend ECR repository ARN allowed for task execution pulls."
-  type        = string
-}
-
-variable "frontend_ecr_repository_arn" {
-  description = "Frontend ECR repository ARN allowed for task execution pulls."
   type        = string
 }
 
@@ -118,16 +102,6 @@ variable "backend_image_tag" {
   validation {
     condition     = can(regex("^(sha-[0-9a-fA-F]{7,40}|pr-[0-9]+-sha-[0-9a-fA-F]{7,40}|local-[a-zA-Z0-9._-]+)$", var.backend_image_tag))
     error_message = "backend_image_tag must be an explicit immutable candidate tag."
-  }
-}
-
-variable "frontend_image_tag" {
-  description = "Explicit immutable frontend ECR tag for this local staging environment."
-  type        = string
-
-  validation {
-    condition     = can(regex("^(sha-[0-9a-fA-F]{7,40}|pr-[0-9]+-sha-[0-9a-fA-F]{7,40}|local-[a-zA-Z0-9._-]+)$", var.frontend_image_tag))
-    error_message = "frontend_image_tag must be an explicit immutable candidate tag."
   }
 }
 

--- a/infra/terraform/envs/prod/main.tf
+++ b/infra/terraform/envs/prod/main.tf
@@ -3,20 +3,16 @@ locals {
 
   hostname_labels = {
     api   = "chatbot"
-    app   = "app"
     admin = "admin"
   }
 
-  backend_hostname  = "${local.hostname_labels.api}.${var.domain_name}"
-  frontend_hostname = "${local.hostname_labels.app}.${var.domain_name}"
-  admin_hostname    = "${local.hostname_labels.admin}.${var.domain_name}"
+  backend_hostname = "${local.hostname_labels.api}.${var.domain_name}"
+  admin_hostname   = "${local.hostname_labels.admin}.${var.domain_name}"
 
-  public_api_url      = "https://${local.backend_hostname}"
-  public_frontend_url = "https://${local.frontend_hostname}"
-  public_admin_url    = "https://${local.admin_hostname}"
+  public_api_url   = "https://${local.backend_hostname}"
+  public_admin_url = "https://${local.admin_hostname}"
 
   allowed_cors_origins = join(",", [
-    local.public_frontend_url,
     local.public_admin_url,
   ])
 
@@ -45,13 +41,6 @@ module "backend_ecr" {
   tags            = local.common_tags
 }
 
-module "frontend_ecr" {
-  source = "../../modules/ecr"
-
-  repository_name = "${var.name_prefix}-frontend"
-  tags            = local.common_tags
-}
-
 module "admin_ecr" {
   source = "../../modules/ecr"
 
@@ -75,24 +64,6 @@ module "backend_cloudflare_tunnel" {
   ]
 
   tags = ["project:arte-chatbot", "environment:prod", "service:backend"]
-}
-
-module "frontend_cloudflare_tunnel" {
-  source = "../../modules/cloudflare_tunnel"
-
-  account_id    = var.cloudflare_account_id
-  zone_id       = var.cloudflare_zone_id
-  tunnel_name   = "${var.name_prefix}-frontend"
-  tunnel_secret = var.frontend_tunnel_secret
-
-  public_hostnames = [
-    {
-      hostname         = local.frontend_hostname
-      local_origin_url = "http://localhost:3000"
-    }
-  ]
-
-  tags = ["project:arte-chatbot", "environment:prod", "service:frontend"]
 }
 
 module "admin_cloudflare_tunnel" {
@@ -123,10 +94,6 @@ module "cloudflare_tunnel_secrets" {
     backend_cloudflare_tunnel_token = {
       description = "cloudflared connector token for backend production service"
       value       = module.backend_cloudflare_tunnel.tunnel_token
-    }
-    frontend_cloudflare_tunnel_token = {
-      description = "cloudflared connector token for frontend production service"
-      value       = module.frontend_cloudflare_tunnel.tunnel_token
     }
     admin_cloudflare_tunnel_token = {
       description = "cloudflared connector token for admin production service"
@@ -180,7 +147,6 @@ module "backend_service" {
     AWS_BUCKET_NAME      = var.aws_bucket_name
     AWS_REGION           = var.aws_region
     PUBLIC_API_URL       = local.public_api_url
-    PUBLIC_FRONTEND_URL  = local.public_frontend_url
     PUBLIC_ADMIN_URL     = local.public_admin_url
     ALLOWED_CORS_ORIGINS = local.allowed_cors_origins
     PORT                 = "8000"
@@ -207,48 +173,6 @@ module "backend_service" {
   task_role_policy_json = data.aws_iam_policy_document.backend_task_s3.json
   ecr_repository_arns   = [module.backend_ecr.repository_arn]
   tags                  = merge(local.common_tags, { Service = "backend" })
-}
-
-module "frontend_service" {
-  source = "../../modules/ecs_service"
-
-  name             = "${var.name_prefix}-frontend"
-  environment      = local.environment
-  cluster_arn      = aws_ecs_cluster.this.arn
-  cluster_name     = aws_ecs_cluster.this.name
-  vpc_id           = var.vpc_id
-  subnet_ids       = var.private_subnet_ids
-  assign_public_ip = var.assign_public_ip
-  desired_count    = var.desired_count
-  cpu              = var.task_cpu
-  memory           = var.task_memory
-
-  image_uri      = "${module.frontend_ecr.repository_url}:${var.frontend_image_tag}"
-  container_name = "frontend"
-  container_port = 3000
-
-  environment_variables = {
-    API_URL = local.public_api_url
-  }
-
-  sidecar_containers = [
-    {
-      name      = "cloudflared"
-      image     = var.cloudflared_image
-      essential = true
-      command   = ["tunnel", "--no-autoupdate", "run"]
-      environment = {
-        TUNNEL_ORIGIN_URL = "http://localhost:3000"
-      }
-      secrets = {
-        TUNNEL_TOKEN = local.tunnel_token_secret_arns["frontend_cloudflare_tunnel_token"]
-      }
-    }
-  ]
-
-  health_check_command = ["CMD-SHELL", "wget -qO- http://localhost:3000/ >/dev/null || exit 1"]
-  ecr_repository_arns  = [module.frontend_ecr.repository_arn]
-  tags                 = merge(local.common_tags, { Service = "frontend" })
 }
 
 module "admin_service" {
@@ -304,20 +228,16 @@ module "github_oidc" {
 
   ecr_repository_arns = [
     module.backend_ecr.repository_arn,
-    module.frontend_ecr.repository_arn,
     module.admin_ecr.repository_arn,
   ]
   ecs_cluster_arn = aws_ecs_cluster.this.arn
   ecs_service_arns = [
     module.backend_service.service_arn,
-    module.frontend_service.service_arn,
     module.admin_service.service_arn,
   ]
   pass_role_arns = [
     module.backend_service.task_role_arn,
     module.backend_service.execution_role_arn,
-    module.frontend_service.task_role_arn,
-    module.frontend_service.execution_role_arn,
     module.admin_service.task_role_arn,
     module.admin_service.execution_role_arn,
   ]

--- a/infra/terraform/envs/prod/outputs.tf
+++ b/infra/terraform/envs/prod/outputs.tf
@@ -7,7 +7,6 @@ output "public_urls" {
   description = "Production Cloudflare public URLs."
   value = {
     api   = local.public_api_url
-    app   = local.public_frontend_url
     admin = local.public_admin_url
   }
 }
@@ -15,18 +14,16 @@ output "public_urls" {
 output "ecr_repository_urls" {
   description = "ECR repositories for independently built service images."
   value = {
-    backend  = module.backend_ecr.repository_url
-    frontend = module.frontend_ecr.repository_url
-    admin    = module.admin_ecr.repository_url
+    backend = module.backend_ecr.repository_url
+    admin   = module.admin_ecr.repository_url
   }
 }
 
 output "ecs_services" {
   description = "ECS service names."
   value = {
-    backend  = module.backend_service.service_name
-    frontend = module.frontend_service.service_name
-    admin    = module.admin_service.service_name
+    backend = module.backend_service.service_name
+    admin   = module.admin_service.service_name
   }
 }
 

--- a/infra/terraform/envs/prod/variables.tf
+++ b/infra/terraform/envs/prod/variables.tf
@@ -56,12 +56,6 @@ variable "backend_tunnel_secret" {
   sensitive   = true
 }
 
-variable "frontend_tunnel_secret" {
-  description = "Secure base64 tunnel secret for the frontend Cloudflare tunnel."
-  type        = string
-  sensitive   = true
-}
-
 variable "admin_tunnel_secret" {
   description = "Secure base64 tunnel secret for the admin Cloudflare tunnel."
   type        = string
@@ -76,12 +70,6 @@ variable "aws_bucket_name" {
 
 variable "backend_image_tag" {
   description = "Immutable backend image tag to deploy."
-  type        = string
-  default     = "bootstrap"
-}
-
-variable "frontend_image_tag" {
-  description = "Immutable frontend image tag to deploy."
   type        = string
   default     = "bootstrap"
 }

--- a/openspec/changes/admin-panel-chat-ui-integration/design.md
+++ b/openspec/changes/admin-panel-chat-ui-integration/design.md
@@ -1,0 +1,67 @@
+# Design: Admin Panel Chat UI Integration
+
+## Technical Approach
+
+Add an authenticated `/admin/chat` workbench inside the existing Next.js admin panel, keeping `app/admin/layout.tsx` as the protected shell and adding only a sidebar item plus a new route. The browser will call admin-authenticated backend proxy endpoints, not `/chat` with `CHAT_API_KEY`. The UI ports the useful standalone behavior—session id, buffering, escalation lock, token metadata—but upgrades it to a ChatGPT-like admin layout with recent conversations, source datasheet modal, split assistant bubbles, and local, secret-free history.
+
+## Architecture Decisions
+
+| Decision | Choice | Alternatives considered | Rationale |
+|---|---|---|---|
+| Secure chat access | Add `/admin/chat` and `/admin/chat/buffer-result/{session_id}` under `admin_router`, protected by `verify_admin_key`, reusing `main._process_chat_message` and buffer helpers. | Browser calls `/chat` with stored `CHAT_API_KEY`. | Prevents chat secret exposure and keeps admin auth as the single browser access gate. |
+| Admin UI shape | New `admin-panel/app/admin/chat/page.tsx` with feature components under `components/chat/`. | Rewrite admin layout or keep standalone `frontend/`. | Preserves all current admin routes and makes chat additive. |
+| Conversation history | Persist capped conversations in `localStorage` under an admin-scoped key; store session id, title, timestamps, messages, sources, tokens, escalation state. | Use S3 logs for UI state. | Local history is immediate and works while logs are async/configurable; no secrets are persisted. |
+| Visual system | Route-scoped dark workbench using Smoky Black `#0F0F0F`, Amber `#FFC200`, Dark Silver, Platinum, and Caribbean Green CSS variables/classes. | Replace global admin theme. | Delivers the requested production Chat UI without destabilizing existing admin screens. |
+| Datasheets | Dedupe `source_documents` by `ruta`; show `Ver fichas técnicas` only when sources exist; call existing `/admin/s3/presigned-download`. | Backend enrichment before modal. | Current contract only guarantees paths and optional snippets, so modal must not depend on rich metadata. |
+
+## Data Flow
+
+```text
+Admin user ─→ /admin/chat page ─→ adminFetch("/admin/chat")
+                               └→ localStorage capped history
+Backend /admin/chat ─→ verify_admin_key ─→ existing chat processing ─→ ChatResponse
+Buffered response ─→ /admin/chat/buffer-result/{session_id} ─→ parsed ChatResponse
+Sources button ─→ /admin/s3/presigned-download ─→ S3 PDF URL
+```
+
+## File Changes
+
+| File | Action | Description |
+|---|---|---|
+| `backend/app/admin_chat.py` | Create | Admin proxy endpoints, schemas/imports, buffer polling wrapper, no `CHAT_API_KEY` browser dependency. |
+| `backend/app/admin_router.py` | Modify | Include `chat_router`. |
+| `backend/main.py` | Modify | Extract reusable chat/buffer helpers if needed; keep public `/chat` behavior unchanged. |
+| `admin-panel/app/admin/layout.tsx` | Modify | Add Chat nav item; preserve existing items/routes. |
+| `admin-panel/app/admin/chat/page.tsx` | Create | Authenticated chat workbench route. |
+| `admin-panel/components/chat/*` | Create | Sidebar, thread, composer, message bubble, source modal, token/status badges. |
+| `admin-panel/lib/types.ts` | Modify | Add `ChatRequest`, `ChatResponse`, `SourceDocument`, `BufferResultResponse`, local history types. |
+| `admin-panel/lib/api.ts` | Modify | Export chat mutations/polling helpers via existing `adminFetch`. |
+| `admin-panel/app/globals.css` or route module | Modify | Add route-scoped chat palette tokens/utilities. |
+| `frontend/`, `docker-compose.yml` | Modify/Delete | Retire standalone Chat UI service/access path. |
+
+## Interfaces / Contracts
+
+```ts
+type ChatRequest = { message: string; session_id?: string; is_final?: boolean };
+type SourceDocument = { ruta: string; contenido_relevante?: string | null };
+type ChatResponse = { response: string; session_id: string; source_documents: SourceDocument[]; messages: string[]; delays_ms: number[]; escalate: boolean; input_tokens?: number | null; output_tokens?: number | null; total_tokens?: number | null };
+type BufferResultResponse = { status: "pending" | "ready" | "not_found"; session_id: string; result?: string | null };
+```
+
+Render assistant parts from `messages.length ? messages : [response]` for both direct and buffered responses.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|---|---|---|
+| Backend unit/integration | Admin proxy auth, no chat key header required, buffering result contract, split fields preserved. | Extend `backend/app/tests` or `backend/tests/test_chat.py` with FastAPI client tests. |
+| Frontend unit | Route renders layout, history restore, split bubbles, source modal dedupe/download, escalation lock. | Add Vitest/RTL chat tests with fetch mocks and localStorage assertions. |
+| Regression | Existing Dashboard, Config, Escalamiento, S3, Catálogo, Guías, Logs remain reachable. | Extend layout/nav tests and keep current slice tests passing. |
+
+## Migration / Rollout
+
+No data migration required. Roll out by deploying backend proxy plus admin route, then remove the `frontend` service from Compose/deployment references. Rollback restores the standalone service and removes `/admin/chat` additions.
+
+## Open Questions
+
+- [ ] Whether deployment IaC still references `PUBLIC_FRONTEND_URL` or a separate frontend image promotion path.

--- a/openspec/changes/admin-panel-chat-ui-integration/exploration.md
+++ b/openspec/changes/admin-panel-chat-ui-integration/exploration.md
@@ -1,0 +1,65 @@
+## Exploration: Move standalone Chat UI into the admin panel
+
+### Current State
+The test Chat UI currently lives as a standalone static app in `frontend/`, served by an Nginx container on port `3000`. It stores the `CHAT_API_KEY` in `sessionStorage`, calls `POST /chat` with `X-API-Key`, keeps only the active session in memory, ignores `ChatResponse.messages`, and renders `ChatResponse.response` as a single bot bubble.
+
+The admin panel is a Next.js 16 app in `admin-panel/`, served separately on local port `3001`, authenticated with `ADMIN_API_KEY` stored in `localStorage`, and protected by `app/admin/layout.tsx`. Existing admin features are Dashboard, Config, Escalamiento, S3 Explorer, Catálogo, Guías, Logs, and Login. These must remain intact; the safe integration point is a new authenticated route such as `/admin/chat` plus a new sidebar item, not a rewrite of existing routes.
+
+Backend support already exists for the requested chat metadata:
+
+- `POST /chat` returns `source_documents: [{ ruta, contenido_relevante }]`, `num_sources`, `messages`, `delays_ms`, token counts, intent metadata, escalation metadata, and `session_id`.
+- `source_documents` is populated when `leer_ficha_tecnica` is used; multiple tool calls can produce multiple paths.
+- `SPLIT_MESSAGES_ENABLED` causes the backend to populate `messages` and `delays_ms` when the response is split on `---`; the current static UI does not use those fields.
+- Admin already has `POST /admin/s3/presigned-download`, so a Chat UI inside the admin panel can show source datasheets and open/download them using the admin key.
+
+### Affected Areas
+- `frontend/index.html` — source behavior to port: API key modal, session id handling, polling `/buffer-result/{session_id}`, escalation locking, token badge, typing state.
+- `frontend/Dockerfile`, `frontend/nginx.conf`, `frontend/entrypoint.sh` — standalone service packaging that should no longer be the access path once the admin route exists.
+- `docker-compose.yml` — currently exposes both `frontend` and `admin-panel`; removing the standalone Chat UI access means dropping or disabling the `frontend` service and ensuring admin remains exposed.
+- `admin-panel/app/admin/layout.tsx` — add `/admin/chat` navigation without removing current admin items.
+- `admin-panel/lib/api.ts` — existing `adminFetch` only sends `X-Admin-API-Key`; chat calls need either a dedicated chat client or an admin-authenticated backend proxy.
+- `admin-panel/lib/types.ts` — add `ChatRequest`, `ChatResponse`, `SourceDocument`, and buffer result types mirroring backend response shapes.
+- `admin-panel/components/*` or new chat feature folder — likely home for conversation list, chat thread, datasheet modal, and message bubble components.
+- `backend/main.py` — `/chat` already has the needed response fields, but it requires `CHAT_API_KEY`; direct browser use from admin would either require a separate chat key prompt or a safer admin proxy.
+- `backend/app/admin_s3.py` — existing presigned download endpoint can power the datasheet modal.
+- `admin-panel/__tests__/*.test.tsx` — add React Testing Library coverage for the new route while preserving existing slice tests.
+- `backend/tests/test_chat.py` — already covers `source_documents`; add/extend split-message response tests if backend contract needs to be locked before frontend work.
+
+### Approaches
+1. **Client-only port with separate CHAT_API_KEY prompt** — Rebuild the static UI as React components under `/admin/chat`, still calling `/chat` directly with `X-API-Key` from a Chat API key stored in browser storage.
+   - Pros: Lowest backend impact; closest to current static behavior.
+   - Cons: Admin users still need a second secret; leaks/stores the chat key in the browser; weakens the goal that admin is the single controlled access path.
+   - Effort: Medium
+
+2. **Admin-authenticated chat proxy** — Add admin-protected backend endpoints, for example `POST /admin/chat` and `GET /admin/chat/buffer-result/{session_id}`, that validate `X-Admin-API-Key` and internally call existing chat processing without exposing `CHAT_API_KEY` to the browser.
+   - Pros: Best match for “only access through admin panel”; uses one admin credential; keeps Chat UI access governed by admin auth; unlocks presigned datasheet modal with the same key.
+   - Cons: Requires backend route work and careful reuse of existing `/chat` logic to avoid behavior drift.
+   - Effort: Medium
+
+3. **Server-persisted chat history via conversation logs** — Build `/admin/chat` history from existing S3 conversation logs and `GET /admin/logs/{session_id}`.
+   - Pros: Reuses persistent admin audit data; history survives devices and browser clearing when logging is enabled.
+   - Cons: Conversation logging is configurable and async; logs are redacted; not ideal for immediate in-progress Chat UI state; S3 list/read latency can make the Chat UI feel heavy.
+   - Effort: Medium-High
+
+4. **Browser-persisted chat workbench history** — Persist Chat UI sessions, messages, metadata, `source_documents`, `messages`, `delays_ms`, and token totals in `localStorage` under an admin-scoped key.
+   - Pros: Immediate UX, simple restore across reloads, independent of S3 logging, matches the “frontend de pruebas” nature.
+   - Cons: Per-browser only; storage can be cleared; must avoid persisting secrets and cap history size.
+   - Effort: Medium
+
+### Recommendation
+Use **Approach 2 + Approach 4**: implement `/admin/chat` in Next.js with browser-local conversation history, and route chat requests through admin-authenticated backend proxy endpoints. This preserves all current admin functionality, removes the standalone frontend as an access path, avoids exposing `CHAT_API_KEY` to the browser, and still uses existing backend behavior for source documents, buffering, splitting, escalation, and token accounting.
+
+For the datasheet modal, render `Ver fichas técnicas` only when `source_documents.length > 0`; dedupe by `ruta`; show filename/path and use existing `POST /admin/s3/presigned-download` for “Ver” or “Descargar”. `contenido_relevante` is currently optional and usually null, so do not design the modal as if extracted snippets are guaranteed.
+
+For split responses, render `data.messages` as individual bot bubbles when non-empty and fall back to `[data.response]`. If UX should simulate WhatsApp timing, apply `delays_ms` between bubbles; otherwise render immediately but preserve visual separation. The same parsing must be used for immediate `/chat` responses and parsed `/buffer-result` responses.
+
+### Risks
+- Current local CORS defaults and `.env.example` include `localhost:3000`/`5173` but not the compose admin origin `localhost:3001`; direct browser calls from admin may fail unless CORS is updated or proxied server-side.
+- A direct client-only port would keep requiring `CHAT_API_KEY` in browser storage, which conflicts with admin-only access control.
+- Conversation history via existing S3 logs is not a complete Chat UI persistence mechanism because logging can be disabled and writes are async.
+- Removing the `frontend` service changes local operator habits and any deployment/runtime references to `PUBLIC_FRONTEND_URL`.
+- `source_documents` currently exposes paths, not friendly names or guaranteed snippets; richer modal content would need catalog lookup or backend enrichment.
+- Split messages are only useful if the frontend explicitly renders `messages`; rendering only `response` keeps the current bug where split responses appear as one joined bubble.
+
+### Ready for Proposal
+Yes. The proposal should scope a new authenticated `/admin/chat` workbench, an admin chat proxy or equivalent secure access mechanism, local conversation history, datasheet modal using existing source document metadata and presigned S3 URLs, split-message rendering, removal of the standalone frontend service from local/deployment access, and regression tests ensuring all current admin routes remain available.

--- a/openspec/changes/admin-panel-chat-ui-integration/proposal.md
+++ b/openspec/changes/admin-panel-chat-ui-integration/proposal.md
@@ -1,0 +1,72 @@
+# Proposal: Admin Panel Chat UI Integration
+
+## Intent
+
+Make the test Chat UI available only as an authenticated admin-panel feature, while preserving conversation history, datasheet visibility, split-message rendering, and every existing admin feature.
+
+## Scope
+
+### In Scope
+- Add an authenticated `/admin/chat` workbench in `admin-panel/` with the referenced ChatGPT-like layout: recent/generated conversations in a left sidebar, restored history on selection, right-aligned highlighted user bubbles, larger left/main assistant responses, and a bottom composer.
+- Apply a design-system/theme refresh for the admin Chat UI using Smoky Black `#0F0F0F` and Amber `#FFC200` as primary colors, supported by Dark Silver `#736F72`, Platinum `#D8DDDE`, and Caribbean Green `#09BC8A`.
+- Use an admin-authenticated backend proxy/equivalent so the browser never stores `CHAT_API_KEY`.
+- Persist Chat UI conversation history immediately in admin-scoped browser storage with capped, secret-free metadata.
+- Render split responses from `messages` when present, falling back to `response`.
+- Show `Ver fichas técnicas` when sources exist; open a modal listing deduped fichas from `source_documents` and use admin S3 download/open flows.
+- Remove/disable the standalone `frontend/` service as an access path.
+- Add regression tests for chat behavior and preservation of current admin routes.
+
+### Out of Scope
+- Image generation or multimodal response support.
+- Server-side cross-device chat history beyond existing logs.
+- Rich datasheet snippets unless backend/catalog metadata is already available.
+
+## Capabilities
+
+### New Capabilities
+- `admin-chat-workbench`: Authenticated admin Chat UI, secure chat proxy, local conversation history, source datasheet modal, split-message rendering, and no standalone Chat UI access.
+
+### Modified Capabilities
+- `ecs-runtime-configuration`: Runtime URLs/origins must reflect the admin panel as the single Chat UI browser surface, avoiding direct browser `CHAT_API_KEY` usage.
+- `ecr-cd-promotion`: Image build/promotion/deploy expectations may need to stop treating the removed standalone Chat UI as an independently promoted UI service.
+
+## Approach
+
+Implement `/admin/chat` inside Next.js admin-panel as a feature route and sidebar item without changing existing admin pages. Add admin-protected backend chat proxy endpoints that reuse current chat processing, buffer polling, escalation metadata, token metrics, `source_documents`, and split-message fields. Keep conversation state in admin local storage, render datasheets from source paths, apply the required admin Chat UI theme as a future spec/design input, and retire the separate frontend service from Compose/deployment access.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `admin-panel/app/admin/*` | Modified | Add chat route/navigation, preserve current routes. |
+| `admin-panel/components/*`, `lib/*` | New/Modified | Chat UI, theme tokens, types, storage, datasheet modal, API client. |
+| `backend/main.py` or admin router | Modified | Admin-authenticated chat proxy/buffer endpoints. |
+| `backend/app/admin_s3.py` | Reused | Presigned datasheet access. |
+| `frontend/`, `docker-compose.yml` | Modified/Removed | Disable standalone Chat UI access path. |
+| Tests | Modified | Admin route regressions, source modal, split messages. |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Existing admin features regress | Med | Route-level regression tests and no layout rewrite. |
+| API key exposure | Med | Admin proxy; do not persist chat secrets. |
+| Source metadata is path-only | Med | Modal shows path/filename; snippets optional. |
+| Split responses still render as one bubble | Med | Spec/test `messages` precedence. |
+
+## Rollback Plan
+
+Revert the admin chat route/proxy and restore the previous `frontend` service/image configuration. Existing admin routes remain unaffected because integration is additive behind `/admin/chat`.
+
+## Dependencies
+
+- Existing admin authentication and `POST /admin/s3/presigned-download`.
+- Backend `ChatResponse.messages`, `source_documents`, and buffer-result contract.
+
+## Success Criteria
+
+- [ ] `/admin/chat` is the only supported Chat UI access path.
+- [ ] Current admin features remain reachable and tested.
+- [ ] Conversations restore from recent history after reload.
+- [ ] Datasheet button/modal appears only when sources exist.
+- [ ] Split responses render as multiple assistant messages.

--- a/openspec/changes/admin-panel-chat-ui-integration/specs/admin-chat-workbench/spec.md
+++ b/openspec/changes/admin-panel-chat-ui-integration/specs/admin-chat-workbench/spec.md
@@ -1,0 +1,106 @@
+# Admin Chat Workbench Specification
+
+## Purpose
+
+Define the authenticated admin Chat UI as the single supported browser workbench
+for testing customer conversations, reviewing conversation history, and opening
+datasheet sources without exposing chat secrets.
+
+## Requirements
+
+### Requirement: Authenticated Admin Chat Access
+
+The system MUST provide chat access only as an authenticated admin-panel feature
+and MUST preserve all existing admin features.
+
+#### Scenario: Admin opens chat workbench
+
+- GIVEN an authenticated admin user
+- WHEN the user navigates to the admin chat feature
+- THEN the chat workbench is displayed inside the admin panel
+- AND existing admin routes remain reachable
+
+#### Scenario: Unauthenticated access is blocked
+
+- GIVEN a user without valid admin authentication
+- WHEN the user attempts to open the admin chat feature
+- THEN access is denied or redirected to admin login
+
+### Requirement: Secure Chat Requests
+
+The browser MUST NOT store or require `CHAT_API_KEY`; chat requests SHALL use the
+admin-authenticated access path.
+
+#### Scenario: Chat request uses admin authentication
+
+- GIVEN an authenticated admin user has typed a prompt
+- WHEN the user sends the prompt
+- THEN the request is accepted through an admin-authenticated path
+- AND no chat API key is read from or written to browser storage
+
+### Requirement: ChatGPT-like Conversation Layout
+
+The workbench MUST use a ChatGPT-like layout with a left recent-conversations
+sidebar, selected conversation restore, right-aligned user messages, assistant
+responses in the main/left region, and a bottom composer.
+
+#### Scenario: Existing conversation restores history
+
+- GIVEN recent conversations exist in admin-scoped browser storage
+- WHEN the user selects a recent conversation
+- THEN the full saved message history is restored in the thread
+
+#### Scenario: Message alignment is distinct
+
+- GIVEN a conversation contains user and assistant messages
+- WHEN the thread is rendered
+- THEN user messages are visually highlighted and right-aligned
+- AND assistant responses occupy the main/left response region
+
+### Requirement: Admin Chat Theme Palette
+
+The chat UI MUST apply Smoky Black `#0F0F0F` and Amber `#FFC200` as primary
+colors, supported by Dark Silver `#736F72`, Platinum `#D8DDDE`, and Caribbean
+Green `#09BC8A` for secondary, surface, and state accents.
+
+#### Scenario: Theme tokens are visible in chat UI
+
+- GIVEN the admin chat workbench is displayed
+- WHEN primary surfaces, actions, and status accents are visible
+- THEN the required palette is used consistently
+
+### Requirement: Split Assistant Message Rendering
+
+The workbench MUST render `messages` as separate assistant messages when present
+and MUST fall back to `response` when `messages` is absent or empty.
+
+#### Scenario: Split response is rendered separately
+
+- GIVEN a chat result includes non-empty `messages`
+- WHEN the result is added to the thread
+- THEN each entry is shown as a separate assistant message
+
+#### Scenario: Legacy response fallback
+
+- GIVEN a chat result has no usable `messages`
+- WHEN the result is added to the thread
+- THEN the `response` value is shown as the assistant message
+
+### Requirement: Datasheet Source Modal
+
+The workbench MUST show a datasheet-source action only when source documents
+exist, and the modal SHALL list deduplicated datasheets using admin-authorized
+open/download flows.
+
+#### Scenario: Sources open in modal
+
+- GIVEN a chat response includes duplicate or unique `source_documents`
+- WHEN the user selects `Ver fichas técnicas`
+- THEN a modal lists each source once by path or filename
+- AND each listed source can be opened or downloaded through admin authorization
+
+#### Scenario: No sources hides action
+
+- GIVEN a chat response has no source documents
+- WHEN the response is rendered
+- THEN the datasheet-source action is not shown

--- a/openspec/changes/admin-panel-chat-ui-integration/specs/ecr-cd-promotion/spec.md
+++ b/openspec/changes/admin-panel-chat-ui-integration/specs/ecr-cd-promotion/spec.md
@@ -1,0 +1,62 @@
+# Delta for ECR CD Promotion
+
+## MODIFIED Requirements
+
+### Requirement: CI and Evaluation Gate Before Promotion
+
+Images MUST be promoted to deployable ECR tags only after CI checks, health
+checks, and the evaluation harness succeed. Promotion MUST cover backend and
+admin-panel images required for the integrated admin Chat UI, and MUST NOT treat
+a removed standalone Chat UI as an independently deployable UI service.
+(Previously: promoted backend and frontend images after gates succeeded.)
+
+#### Scenario: Successful gate promotes images
+
+- GIVEN backend and admin-panel images build successfully
+- AND tests, health checks, and evaluation pass
+- WHEN the CI workflow reaches the promotion step
+- THEN immutable image tags are pushed or promoted in ECR
+- AND those tags are eligible for ECS deployment
+
+#### Scenario: Failed evaluation blocks promotion
+
+- GIVEN the evaluation harness fails
+- WHEN the CI workflow continues to deployment-related steps
+- THEN no deployable production image tag is promoted
+- AND no ECS service update is triggered
+
+#### Scenario: Standalone Chat UI is not promoted
+
+- GIVEN the standalone Chat UI is no longer a supported browser surface
+- WHEN deployable UI images are selected for promotion
+- THEN only the admin-panel UI image is treated as deployable for chat access
+
+### Requirement: Immutable Image and Task Definition Promotion
+
+Deployments MUST reference immutable image identifiers or SHA-based tags, and the
+workflow MUST register new ECS task definition revisions before updating
+services. Task definitions SHALL reference backend and admin-panel containers
+needed by the integrated Chat UI and SHALL NOT require a separate standalone
+Chat UI container for browser access.
+(Previously: task definitions referenced backend and frontend containers.)
+
+#### Scenario: SHA-tagged image deployed
+
+- GIVEN a successful `main` build creates images for a commit SHA
+- WHEN the deploy job renders task definitions
+- THEN backend and admin-panel containers reference matching SHA-based ECR tags
+- AND ECS services update to the new task definition revisions
+
+#### Scenario: Rollback target remains identifiable
+
+- GIVEN a deployment has completed
+- WHEN rollback is needed
+- THEN the previous image tag or task definition revision can be identified
+- AND the ECS service can be reverted to that known version
+
+#### Scenario: No standalone Chat UI task required
+
+- GIVEN the integrated admin Chat UI is deployed
+- WHEN ECS services are updated
+- THEN chat browser access is provided by the admin-panel service
+- AND no separate standalone Chat UI service is required

--- a/openspec/changes/admin-panel-chat-ui-integration/specs/ecs-runtime-configuration/spec.md
+++ b/openspec/changes/admin-panel-chat-ui-integration/specs/ecs-runtime-configuration/spec.md
@@ -1,0 +1,60 @@
+# Delta for ECS Runtime Configuration
+
+## MODIFIED Requirements
+
+### Requirement: Configured CORS Origins
+
+The backend MUST accept configured Cloudflare admin origins through environment
+or runtime configuration for browser-facing chat and admin operations.
+Production CORS MUST NOT default to a wildcard origin, and local development
+admin origins SHOULD remain supported.
+(Previously: allowed configured Cloudflare frontend and admin origins.)
+
+#### Scenario: Cloudflare admin UI can call API
+
+- GIVEN the backend is deployed in production
+- AND Terraform provides the allowed Cloudflare admin origin
+- WHEN a browser request reaches the API from that origin
+- THEN the backend includes the expected CORS response headers
+- AND the request is allowed
+
+#### Scenario: Wildcard forbidden in production
+
+- GIVEN the backend is deployed in production
+- WHEN no explicit allowed origins are configured
+- THEN the backend MUST NOT fall back to `*`
+- AND startup or configuration validation MUST fail safely
+
+#### Scenario: Local development remains supported
+
+- GIVEN a developer runs the backend locally
+- WHEN a browser request uses the configured local admin-panel origin
+- THEN the backend allows the origin without requiring Cloudflare hostnames
+
+### Requirement: Deployment-published Runtime URLs
+
+Terraform MUST provide or publish the public URLs and allowed origins needed by
+the backend and admin runtime configuration. The admin panel SHALL be the single
+browser Chat UI surface, and runtime configuration MUST NOT require direct
+browser use of `CHAT_API_KEY`.
+(Previously: published URLs and origins for backend, frontend, and admin.)
+
+#### Scenario: Admin panel receives API URL
+
+- GIVEN the admin container starts in ECS
+- WHEN its runtime configuration is generated
+- THEN it receives the public Cloudflare API URL
+- AND browser calls target the deployed API hostname
+
+#### Scenario: Backend receives admin UI origins
+
+- GIVEN admin Cloudflare hostnames are declared in Terraform
+- WHEN backend task configuration is rendered
+- THEN the corresponding origins are included in allowed-origin configuration
+
+#### Scenario: Standalone Chat UI is not configured
+
+- GIVEN production runtime configuration is rendered
+- WHEN browser UI URLs and origins are published
+- THEN no standalone Chat UI origin is required for customer-chat testing
+- AND chat access is represented by the admin panel surface

--- a/openspec/changes/admin-panel-chat-ui-integration/tasks.md
+++ b/openspec/changes/admin-panel-chat-ui-integration/tasks.md
@@ -1,0 +1,51 @@
+# Tasks: Admin Panel Chat UI Integration
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | 900-1,400 |
+| 400-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Suggested split | PR 1 backend proxy → PR 2 admin chat UI → PR 3 runtime/CD cleanup |
+| Delivery strategy | ask-always |
+| Chain strategy | feature-branch-chain |
+
+Decision needed before apply: No
+Chained PRs recommended: Yes
+Chain strategy: feature-branch-chain
+400-line budget risk: High
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Notes |
+|------|------|-----------|-------|
+| 1 | Secure admin chat proxy | PR 1 | Base target: `feature/admin-panel` (tracker PR #207). `backend/app/admin_chat.py`, router/main helpers, backend tests included. |
+| 2 | Authenticated admin workbench | PR 2 | Base target: PR 1 branch. `admin-panel/app/admin/chat/page.tsx`, `components/chat/*`, lib/CSS/tests; depends on PR 1. |
+| 3 | Retire standalone UI runtime | PR 3 | Base target: PR 2 branch. `docker-compose.yml`, `.github/workflows/*`, `infra/terraform/**/*`; depends on PR 2. |
+
+## Phase 1: Backend Proxy (RED/GREEN)
+
+- [x] 1.1 RED: Add `backend/app/tests/test_admin_chat.py` for admin auth, no `CHAT_API_KEY`, split fields, buffer contract.
+- [x] 1.2 GREEN: Create `backend/app/admin_chat.py` with `/admin/chat` and `/admin/chat/buffer-result/{session_id}` using `verify_admin_key`.
+- [x] 1.3 GREEN: Modify `backend/app/admin_router.py` and `backend/main.py` only as needed to reuse current chat/buffer processing unchanged.
+
+## Phase 2: Admin Workbench UI (RED/GREEN)
+
+- [x] 2.1 RED: Add `admin-panel/__tests__/admin-chat.test.tsx` for route auth, history restore, split bubbles, source modal, no stored chat key.
+- [x] 2.2 GREEN: Extend `admin-panel/lib/types.ts` and `admin-panel/lib/api.ts` with chat, buffer, source, and history contracts via `adminFetch`.
+- [x] 2.3 GREEN: Create `admin-panel/app/admin/chat/page.tsx` and `admin-panel/components/chat/*` for sidebar, thread, composer, bubbles, badges, and sources modal.
+- [x] 2.4 GREEN: Modify `admin-panel/app/admin/layout.tsx` to add Chat navigation while preserving Dashboard, Config, Escalation, S3, Catalog, Guides, Logs.
+- [x] 2.5 GREEN: Add route-scoped palette tokens in `admin-panel/app/globals.css` using `#0F0F0F`, `#FFC200`, `#736F72`, `#D8DDDE`, `#09BC8A`.
+
+## Phase 3: Runtime and Promotion Cleanup
+
+- [x] 3.1 RED: Add/extend deployment tests or checks proving admin origin only and no standalone Chat UI promotion/service.
+- [x] 3.2 GREEN: Update `docker-compose.yml` to disable/remove standalone `frontend` as a browser access path.
+- [x] 3.3 GREEN: Update `.github/workflows/ci.yml`, `.github/workflows/admin-panel.yml`, and `infra/terraform/**/*` references so backend/admin-panel are deployable and standalone Chat UI is not.
+
+## Phase 4: Verification
+
+- [x] 4.1 Run backend pytest for admin chat plus existing admin S3/catalog/log routes.
+- [x] 4.2 Run admin-panel Vitest/RTL tests for chat behavior and existing route reachability.
+- [x] 4.3 Verify OpenSpec scenarios: authenticated access, secure requests, layout, theme, split messages, datasheet modal, CORS/runtime, ECR promotion.

--- a/openspec/changes/admin-panel-chat-ui-integration/verify-report.md
+++ b/openspec/changes/admin-panel-chat-ui-integration/verify-report.md
@@ -1,0 +1,80 @@
+# Verify Report: Admin Panel Chat UI Integration
+
+## status
+success
+
+## executive_summary
+Verification passed for `admin-panel-chat-ui-integration`: backend admin chat proxy, admin-panel chat workbench, runtime/CD cleanup, and OpenSpec scenario coverage were validated with runtime tests and artifact inspection. Phase 4 tasks were marked complete because the required evidence was executed and passed. Lint completed with two pre-existing React Compiler warnings in unrelated admin-panel components.
+
+## artifacts
+- `openspec/changes/admin-panel-chat-ui-integration/verify-report.md`
+- `openspec/changes/admin-panel-chat-ui-integration/tasks.md` — Phase 4 checkboxes updated to complete
+- Engram topic `sdd/admin-panel-chat-ui-integration/verify-report`
+
+## commands_run
+| Command | Result | Evidence |
+|---|---:|---|
+| `uv run pytest backend/app/tests/test_admin_chat.py backend/app/tests/test_admin_slice1.py::TestAdminHealth backend/app/tests/test_admin_s3.py` | PASS | 21 passed, 2 deprecation warnings in `admin_s3.py` |
+| `uv run pytest backend/app/tests/test_admin_slice2.py backend/app/tests/test_admin_slice3.py` | PASS | 16 passed; covers catalog, guides, logs, dashboard/config admin regressions |
+| `npm test` in `admin-panel/` | PASS | 5 files passed, 18 tests passed, including `admin-chat.test.tsx` |
+| `npm run typecheck` in `admin-panel/` | PASS | `tsc --noEmit` completed with no errors |
+| `npm run lint` in `admin-panel/` | PASS WITH WARNINGS | 0 errors, 2 warnings in pre-existing `components/data-table.tsx` and `components/escalation-form.tsx` |
+| `uv run pytest scripts/tests/test_cd_and_staging_guards.py scripts/tests/test_terraform_foundation.py` | PASS | 16 passed |
+| `terraform fmt -check -recursive infra/terraform` | PASS | no output |
+| `docker compose config --services` | PASS | output exactly `backend`, `admin-panel` |
+| `git diff --check` | PASS | no whitespace errors before and after Phase 4 task update |
+
+## spec_compliance
+| Capability / Requirement | Status | Runtime Evidence | Inspection Evidence |
+|---|---:|---|---|
+| Admin opens chat workbench and existing admin routes remain reachable | PASS | `admin-chat.test.tsx` route/nav test; backend admin slice2/slice3 regressions pass | `admin-panel/app/admin/layout.tsx` includes `/admin/chat` and preserves Dashboard, Config, Escalamiento, S3, Catálogo, Guías, Logs |
+| Unauthenticated access is blocked | PASS | `admin-chat.test.tsx::blocks unauthenticated access`; `TestAdminChatAuth` backend auth tests | `AdminLayout` redirects unauthenticated users to `/admin/login`; backend uses `verify_admin_key` |
+| Chat request uses admin authentication and no browser `CHAT_API_KEY` storage | PASS | `admin-chat.test.tsx::sends chat through admin auth...`; backend `test_admin_chat_does_not_require_chat_api_key` | `useSendAdminChatMessage()` calls `/admin/chat` through `adminFetch`; `adminFetch` sets `X-Admin-API-Key` |
+| Conversation history layout and restore | PASS | `admin-chat.test.tsx::restores saved recent conversation history when selected` | `chat-history.ts`, `chat-sidebar.tsx`, `chat-thread.tsx`, `chat-composer.tsx` implement capped local history, sidebar, thread, bottom composer |
+| Message alignment is distinct | PASS | `admin-chat.test.tsx` renders route and split/user messages | `.chat-message-user { align-self: flex-end; }`; assistant messages use default main/left region |
+| Required theme palette is visible in chat UI | PASS | `admin-chat.test.tsx` route renders chat shell | `globals.css` scopes `#0f0f0f`, `#ffc200`, `#736f72`, `#d8ddde`, `#09bc8a` to `.admin-chat-shell` |
+| Split assistant message rendering and fallback | PASS | `admin-chat.test.tsx` verifies split messages hide fallback; backend split-field test passes | `assistantPartsFromResponse()` prefers non-empty `messages`, falls back to `response` |
+| Datasheet source modal dedupes and uses admin download flow | PASS | `admin-chat.test.tsx::shows deduplicated datasheet sources...` | `dedupeSources()`, `SourceModal`, and `usePresignedDownload()` use `/admin/s3/presigned-download` |
+| No-source response hides datasheet action | PASS | Covered by split/no-source admin chat test querying no source action implicitly through no source response | `ChatMessageBubble` shows button only for assistant messages with `sources.length > 0` |
+| CORS/runtime admin origin only, no standalone Chat UI runtime | PASS | `test_cd_and_staging_guards.py`, `test_terraform_foundation.py`, `docker compose config --services` | Compose has only `backend` and `admin-panel`; Terraform/guard checks reject standalone frontend runtime |
+| ECR/CD promotion excludes standalone Chat UI | PASS | `test_cd_and_staging_guards.py` passed | CI guard checks assert backend/admin-panel image promotion only and no standalone frontend promotion |
+
+## tdd_compliance
+| Check | Result | Details |
+|---|---:|---|
+| TDD evidence reported | PASS | Apply progress includes full `TDD Cycle Evidence` table for tasks 1.1-3.3 |
+| All tasks have tests | PASS | 11/11 implementation tasks list covering test files |
+| RED confirmed | PASS | Referenced test files exist: backend admin chat, admin-panel chat, deployment guards, Terraform foundation |
+| GREEN confirmed | PASS | All referenced test suites passed during verify |
+| Triangulation adequate | PASS | Backend admin chat has 6 cases, admin chat UI has 5 cases, deployment guards have 11 cases, Terraform foundation has 5 cases |
+| Safety net for modified files | PASS | Existing admin health/S3/catalog/log/config UI/backend and deployment guard suites passed |
+| Coverage | SKIPPED | No changed-file coverage command/script was available in detected package scripts; pytest-cov plugin was not present in pytest output |
+| Assertion quality | PASS | No tautologies, ghost loops, or no-production-code assertions found in changed/created test files reviewed |
+| Test layer distribution | INFO | Integration: backend FastAPI tests, admin-panel RTL/Vitest tests, deployment/IaC static integration guard tests. E2E: none |
+| Quality metrics | PASS WITH WARNINGS | Typecheck passed. ESLint had 0 errors and 2 warnings in unrelated pre-existing files |
+
+## task_completeness
+| Phase | Status | Evidence |
+|---|---:|---|
+| Phase 1: Backend Proxy | COMPLETE | `backend/app/admin_chat.py`, `admin_router.py`, `test_admin_chat.py`; backend admin tests pass |
+| Phase 2: Admin Workbench UI | COMPLETE | `/admin/chat` route, chat components, API/types/CSS, admin chat tests; admin-panel tests/typecheck pass |
+| Phase 3: Runtime and Promotion Cleanup | COMPLETE | Compose, CI, Terraform, deploy guard tests; runtime/CD verification commands pass |
+| Phase 4: Verification | COMPLETE | Tasks 4.1-4.3 checked after evidence ran and passed |
+
+## issues
+### CRITICAL
+None.
+
+### WARNING
+- `npm run lint` reports two warnings in unrelated existing files: `admin-panel/components/data-table.tsx` and `admin-panel/components/escalation-form.tsx` due React Compiler incompatible-library warnings.
+- Backend admin S3 tests emit two deprecation warnings for `HTTP_422_UNPROCESSABLE_ENTITY` in `backend/app/admin_s3.py`.
+- Admin-panel Vitest emits Node experimental warnings about localStorage availability; tests still pass in jsdom.
+
+### SUGGESTION
+- Add a dedicated `test:coverage` or changed-file coverage script for admin-panel/backend verification if future Strict TDD verification requires quantitative changed-file coverage.
+
+## final_verdict
+PASS WITH WARNINGS — all required behavior, runtime/CD, TDD evidence, and Phase 4 verification checks passed. Warnings are non-blocking and unrelated to core spec compliance.
+
+## skill_resolution
+paths-injected — loaded/used `sdd-verify`, `sdd-verify/strict-tdd-verify.md`, `work-unit-commits`, `chained-pr`, and shared SDD phase rules.

--- a/scripts/deploy-local-staging.sh
+++ b/scripts/deploy-local-staging.sh
@@ -10,7 +10,6 @@ DESTROY=false
 AUTO_APPROVE=false
 STAGING_ID=""
 BACKEND_TAG=""
-FRONTEND_TAG=""
 ADMIN_TAG=""
 EXPIRES_AT=""
 
@@ -19,7 +18,6 @@ usage() {
 Usage: scripts/deploy-local-staging.sh \
   --staging-id <id> \
   --backend-tag <sha-or-pr-tag> \
-  --frontend-tag <sha-or-pr-tag> \
   --admin-tag <sha-or-pr-tag> \
   [--domain-name artesolutions.com.co] [--aws-region us-east-1] \
   [--expires-at 2026-06-05T12:00:00Z] [--plan-only] [--destroy] [--auto-approve]
@@ -38,7 +36,6 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --staging-id) STAGING_ID="${2:-}"; shift 2 ;;
     --backend-tag) BACKEND_TAG="${2:-}"; shift 2 ;;
-    --frontend-tag) FRONTEND_TAG="${2:-}"; shift 2 ;;
     --admin-tag) ADMIN_TAG="${2:-}"; shift 2 ;;
     --domain-name) DOMAIN_NAME="${2:-}"; shift 2 ;;
     --aws-region) AWS_REGION="${2:-}"; shift 2 ;;
@@ -57,7 +54,6 @@ fi
 
 [[ -n "$STAGING_ID" ]] || fail "--staging-id is required"
 [[ -n "$BACKEND_TAG" ]] || fail "--backend-tag is required"
-[[ -n "$FRONTEND_TAG" ]] || fail "--frontend-tag is required"
 [[ -n "$ADMIN_TAG" ]] || fail "--admin-tag is required"
 
 if ! [[ "$STAGING_ID" =~ ^[a-z0-9][a-z0-9-]{1,30}$ ]]; then
@@ -77,7 +73,6 @@ validate_tag() {
 }
 
 validate_tag "backend" "$BACKEND_TAG"
-validate_tag "frontend" "$FRONTEND_TAG"
 validate_tag "admin" "$ADMIN_TAG"
 
 if [[ "$DOMAIN_NAME" != "artesolutions.com.co" ]]; then
@@ -101,11 +96,10 @@ if expires_at <= now or expires_at > now + timedelta(days=3, minutes=1):
     raise SystemExit(1)
 PY
 
-FRONTEND_HOSTNAME="staging-chatbot-${STAGING_ID}.${DOMAIN_NAME}"
 BACKEND_HOSTNAME="staging-chatbot-api-${STAGING_ID}.${DOMAIN_NAME}"
 ADMIN_HOSTNAME="staging-chatbot-admin-${STAGING_ID}.${DOMAIN_NAME}"
 
-for hostname in "$FRONTEND_HOSTNAME" "$BACKEND_HOSTNAME" "$ADMIN_HOSTNAME"; do
+for hostname in "$BACKEND_HOSTNAME" "$ADMIN_HOSTNAME"; do
   case "$hostname" in
     "api.${DOMAIN_NAME}"|"app.${DOMAIN_NAME}"|"admin.${DOMAIN_NAME}")
       fail "production URL/name rejected for local staging: $hostname"
@@ -119,13 +113,10 @@ required_tf_vars=(
   TF_VAR_cloudflare_account_id
   TF_VAR_cloudflare_zone_id
   TF_VAR_backend_tunnel_secret
-  TF_VAR_frontend_tunnel_secret
   TF_VAR_admin_tunnel_secret
   TF_VAR_backend_ecr_repository_url
-  TF_VAR_frontend_ecr_repository_url
   TF_VAR_admin_ecr_repository_url
   TF_VAR_backend_ecr_repository_arn
-  TF_VAR_frontend_ecr_repository_arn
   TF_VAR_admin_ecr_repository_arn
   TF_VAR_aws_bucket_name
   TF_VAR_backend_runtime_secret_arns
@@ -147,12 +138,11 @@ export TF_VAR_staging_id="$STAGING_ID"
 export TF_VAR_domain_name="$DOMAIN_NAME"
 export TF_VAR_aws_region="$AWS_REGION"
 export TF_VAR_backend_image_tag="$BACKEND_TAG"
-export TF_VAR_frontend_image_tag="$FRONTEND_TAG"
 export TF_VAR_admin_image_tag="$ADMIN_TAG"
 export TF_VAR_expiration_at="$EXPIRES_AT"
 
 echo "Local staging: $STAGING_ID"
-echo "Hostnames: $BACKEND_HOSTNAME, $FRONTEND_HOSTNAME, $ADMIN_HOSTNAME"
+echo "Hostnames: $BACKEND_HOSTNAME, $ADMIN_HOSTNAME"
 echo "Expires at: $EXPIRES_AT"
 
 terraform -chdir="$TF_DIR" init -reconfigure -backend-config="path=$STATE_PATH"

--- a/scripts/deployment_guard_checks.py
+++ b/scripts/deployment_guard_checks.py
@@ -9,12 +9,14 @@ import re
 
 
 WORKFLOW_PATH = Path(".github/workflows/ci.yml")
+ADMIN_WORKFLOW_PATH = Path(".github/workflows/admin-panel.yml")
+COMPOSE_PATH = Path("docker-compose.yml")
+PROD_ROOT = Path("infra/terraform/envs/prod")
 LOCAL_STAGING_ROOT = Path("infra/terraform/envs/local-staging")
 DEPLOY_SCRIPT_PATH = Path("scripts/deploy-local-staging.sh")
 
 
-SERVICES = ("backend", "frontend", "admin")
-PRODUCTION_HOSTS = ("api", "app", "admin")
+DEPLOYABLE_SERVICES = ("backend", "admin")
 
 
 def check_cd_and_staging_guards(project_root: Path) -> list[str]:
@@ -22,13 +24,29 @@ def check_cd_and_staging_guards(project_root: Path) -> list[str]:
     findings: list[str] = []
 
     workflow = _read(project_root / WORKFLOW_PATH)
+    admin_workflow = _read(project_root / ADMIN_WORKFLOW_PATH)
+    compose = _read(project_root / COMPOSE_PATH)
+    prod_main = _read(project_root / PROD_ROOT / "main.tf")
+    prod_variables = _read(project_root / PROD_ROOT / "variables.tf")
+    prod_outputs = _read(project_root / PROD_ROOT / "outputs.tf")
     staging_main = _read(project_root / LOCAL_STAGING_ROOT / "main.tf")
     staging_variables = _read(project_root / LOCAL_STAGING_ROOT / "variables.tf")
+    staging_outputs = _read(project_root / LOCAL_STAGING_ROOT / "outputs.tf")
     staging_providers = _read(project_root / LOCAL_STAGING_ROOT / "providers.tf")
     deploy_script = _read(project_root / DEPLOY_SCRIPT_PATH)
 
     findings.extend(_check_workflow(workflow))
-    findings.extend(_check_local_staging_root(staging_main, staging_variables, staging_providers))
+    findings.extend(_check_admin_workflow(admin_workflow))
+    findings.extend(_check_compose(compose))
+    findings.extend(_check_production_root(prod_main, prod_variables, prod_outputs))
+    findings.extend(
+        _check_local_staging_root(
+            staging_main,
+            staging_variables,
+            staging_providers,
+            staging_outputs,
+        )
+    )
     findings.extend(_check_deploy_script(deploy_script))
 
     return findings
@@ -37,10 +55,13 @@ def check_cd_and_staging_guards(project_root: Path) -> list[str]:
 def _check_workflow(workflow: str) -> list[str]:
     findings: list[str] = []
 
-    build_mentions = [f"{service}_image" in workflow or f"{service}-image" in workflow for service in SERVICES]
-    dockerfiles = [f"{service}/Dockerfile" in workflow for service in SERVICES]
+    build_mentions = [f"{service}_image" in workflow or f"{service}-image" in workflow for service in DEPLOYABLE_SERVICES]
+    dockerfiles = [f"{service}/Dockerfile" in workflow or f"{service}-panel/Dockerfile" in workflow for service in DEPLOYABLE_SERVICES]
     if not all(build_mentions) or not all(dockerfiles):
-        findings.append("workflow must build backend, frontend, and admin images")
+        findings.append("workflow must build backend and admin-panel images")
+
+    if _contains_any(workflow, ["frontend-image", "frontend/Dockerfile", "arte-chatbot-frontend", "FRONTEND_ECR_REPOSITORY_URL"]):
+        findings.append("workflow must not build or promote standalone frontend images")
 
     publish_job = _job_block(workflow, "publish-candidate-images")
     if not publish_job or not _contains_all(publish_job, ["needs: evaluation", "docker push"]):
@@ -71,7 +92,56 @@ def _check_workflow(workflow: str) -> list[str]:
     return findings
 
 
-def _check_local_staging_root(main_tf: str, variables_tf: str, providers_tf: str) -> list[str]:
+def _check_admin_workflow(admin_workflow: str) -> list[str]:
+    findings: list[str] = []
+
+    if not _contains_all(admin_workflow, ["admin-panel/**", "npm run lint", "npm run typecheck", "npm run test:unit"]):
+        findings.append("admin-panel workflow must keep lint, typecheck, and unit tests deployable")
+    if "frontend/**" in admin_workflow:
+        findings.append("admin-panel workflow must not trigger on standalone frontend changes")
+
+    return findings
+
+
+def _check_compose(compose: str) -> list[str]:
+    findings: list[str] = []
+
+    if not _contains_all(compose, ["backend:", "admin-panel:", '"8000:8000"', '"3001:3000"']):
+        findings.append("compose must expose only backend and admin-panel browser services")
+    if _contains_any(compose, ["frontend:", "frontend/Dockerfile", '"3000:3000"', "arte-chatbot-frontend"]):
+        findings.append("compose must not expose standalone frontend as a browser access path")
+
+    return findings
+
+
+def _check_production_root(main_tf: str, variables_tf: str, outputs_tf: str) -> list[str]:
+    findings: list[str] = []
+
+    if not main_tf or not variables_tf or not outputs_tf:
+        return ["production Terraform root must exist"]
+
+    if not _contains_all(main_tf, ["module \"backend_service\"", "module \"admin_service\"", "local.public_admin_url"]):
+        findings.append("production Terraform must keep backend and admin services deployable")
+    if _contains_any(
+        "\n".join([main_tf, variables_tf, outputs_tf]),
+        [
+            "frontend_service",
+            "frontend_cloudflare_tunnel",
+            "frontend_ecr",
+            "frontend_image_tag",
+            "frontend_tunnel_secret",
+            "PUBLIC_FRONTEND_URL",
+            "public_frontend_url",
+            "local.frontend_hostname",
+            "frontend =",
+        ],
+    ):
+        findings.append("production Terraform must not configure standalone frontend runtime")
+
+    return findings
+
+
+def _check_local_staging_root(main_tf: str, variables_tf: str, providers_tf: str, outputs_tf: str) -> list[str]:
     findings: list[str] = []
 
     if not main_tf or not variables_tf or not providers_tf:
@@ -84,7 +154,6 @@ def _check_local_staging_root(main_tf: str, variables_tf: str, providers_tf: str
         main_tf,
         [
             'environment = "local-staging"',
-            "staging-chatbot-${var.staging_id}",
             "staging-chatbot-api-${var.staging_id}",
             "staging-chatbot-admin-${var.staging_id}",
         ],
@@ -100,6 +169,24 @@ def _check_local_staging_root(main_tf: str, variables_tf: str, providers_tf: str
     if "timeadd(timestamp(), \"72h\")" not in main_tf and "expiration_at" not in variables_tf:
         findings.append("local-staging must record expiration metadata")
 
+    if not _contains_all(main_tf, ["module \"backend_service\"", "module \"admin_service\"", "local.public_admin_url"]):
+        findings.append("local-staging must keep backend and admin services deployable")
+    if _contains_any(
+        "\n".join([main_tf, variables_tf, outputs_tf]),
+        [
+            "frontend_service",
+            "frontend_cloudflare_tunnel",
+            "frontend_image_tag",
+            "frontend_tunnel_secret",
+            "frontend_ecr_repository",
+            "PUBLIC_FRONTEND_URL",
+            "public_frontend_url",
+            "local.frontend_hostname",
+            "frontend =",
+        ],
+    ):
+        findings.append("local-staging Terraform must not configure standalone frontend runtime")
+
     return findings
 
 
@@ -108,8 +195,10 @@ def _check_deploy_script(script: str) -> list[str]:
 
     if not _contains_all(script, ["CI", "GITHUB_ACTIONS", "local staging cannot run in CI"]):
         findings.append("deploy script must reject CI execution")
-    if not _contains_all(script, ["--backend-tag", "--frontend-tag", "--admin-tag", "explicit immutable ECR tag"]):
+    if not _contains_all(script, ["--backend-tag", "--admin-tag", "explicit immutable ECR tag"]):
         findings.append("deploy script must require explicit image tags")
+    if _contains_any(script, ["--frontend-tag", "FRONTEND_TAG", "TF_VAR_frontend"]):
+        findings.append("deploy script must not require standalone frontend tags")
     if not _contains_all(script, ["staging-chatbot", "api|app|admin", "expiration must be no later than 3 days"]):
         findings.append("deploy script must reject prod names and long expirations")
     if not _contains_all(script, ["TF_VAR_vpc_id", "TF_VAR_private_subnet_ids", "CLOUDFLARE_API_TOKEN"]):
@@ -132,3 +221,7 @@ def _read(path: Path) -> str:
 
 def _contains_all(text: str, needles: list[str]) -> bool:
     return all(needle in text for needle in needles)
+
+
+def _contains_any(text: str, needles: list[str]) -> bool:
+    return any(needle in text for needle in needles)

--- a/scripts/terraform_foundation_checks.py
+++ b/scripts/terraform_foundation_checks.py
@@ -30,24 +30,21 @@ def check_foundation(project_root: Path) -> list[str]:
         prod_main,
         [
             'module "backend_cloudflare_tunnel"',
-            'module "frontend_cloudflare_tunnel"',
             'module "admin_cloudflare_tunnel"',
         ],
     ):
-        findings.append("prod must declare backend, frontend, and admin scoped tunnels")
+        findings.append("prod must declare backend and admin scoped tunnels")
 
     if "localhost:8000" not in prod_main or "local.backend_hostname" not in prod_main:
         findings.append("backend tunnel must route api hostname to localhost:8000")
-    if "localhost:3000" not in prod_main or "local.frontend_hostname" not in prod_main:
-        findings.append("frontend tunnel must route app hostname to localhost:3000")
     if "localhost:3000" not in prod_main or "local.admin_hostname" not in prod_main:
         findings.append("admin tunnel must route admin hostname to localhost:3000")
 
     if "central_connector_mode" not in tunnel_variables or "distinct" not in tunnel_variables:
         findings.append("cloudflare tunnel module must reject mixed localhost origins")
 
-    if len(re.findall(r'module\s+"[^"]+_cloudflare_tunnel"', prod_main)) < 3:
-        findings.append("prod must not reuse one tunnel for backend, frontend, and admin")
+    if len(re.findall(r'module\s+"[^"]+_cloudflare_tunnel"', prod_main)) < 2:
+        findings.append("prod must not reuse one tunnel for backend and admin")
 
     if not _output_block_is_sensitive(tunnel_outputs, "tunnel_token"):
         findings.append("cloudflare tunnel token output must be sensitive")
@@ -64,11 +61,16 @@ def check_foundation(project_root: Path) -> list[str]:
 
     expected_hostname_labels = [
         r'api\s*=\s*"chatbot"',
-        r'app\s*=\s*"app"',
         r'admin\s*=\s*"admin"',
     ]
     if not all(re.search(pattern, prod_main) for pattern in expected_hostname_labels) or "var.domain_name" not in prod_main:
-        findings.append("prod hostnames must derive chatbot, app, and admin from domain_name")
+        findings.append("prod hostnames must derive chatbot and admin from domain_name")
+
+    if any(
+        needle in "\n".join([prod_main, prod_variables, prod_outputs])
+        for needle in ["frontend_cloudflare_tunnel", "frontend_service", "frontend_image_tag", "public_frontend_url"]
+    ):
+        findings.append("prod must not define standalone frontend runtime resources")
 
     if "staging" not in prod_variables or "strcontains" not in prod_variables:
         findings.append("prod name prefix must reject staging values")

--- a/scripts/tests/test_cd_and_staging_guards.py
+++ b/scripts/tests/test_cd_and_staging_guards.py
@@ -23,11 +23,12 @@ def _findings() -> list[str]:
     return check_cd_and_staging_guards(ROOT)
 
 
-def test_workflow_builds_all_images_and_pushes_sha_candidate_tags_after_gates() -> None:
-    """PR candidates must be immutable SHA-visible tags and only publish after gates pass."""
+def test_workflow_builds_backend_and_admin_images_after_gates() -> None:
+    """PR candidates must promote only deployable backend and admin-panel images."""
     findings = _findings()
 
-    assert "workflow must build backend, frontend, and admin images" not in findings
+    assert "workflow must build backend and admin-panel images" not in findings
+    assert "workflow must not build or promote standalone frontend images" not in findings
     assert "candidate image push must wait for test-health and evaluation gates" not in findings
     assert "candidate tags must include PR and SHA rollback identifiers" not in findings
 
@@ -42,6 +43,31 @@ def test_workflow_deploys_production_only_from_main_with_oidc() -> None:
     assert "pull requests must not contain a production deploy job path" not in findings
 
 
+def test_admin_panel_workflow_remains_deployable_without_standalone_frontend() -> None:
+    """Admin-panel CI must cover the integrated browser surface, not frontend/."""
+    findings = _findings()
+
+    assert "admin-panel workflow must keep lint, typecheck, and unit tests deployable" not in findings
+    assert "admin-panel workflow must not trigger on standalone frontend changes" not in findings
+
+
+def test_compose_exposes_admin_panel_but_not_standalone_frontend() -> None:
+    """Local Docker must expose /admin/chat through admin-panel only."""
+    findings = _findings()
+
+    assert "compose must expose only backend and admin-panel browser services" not in findings
+    assert "compose must not expose standalone frontend as a browser access path" not in findings
+
+
+def test_production_runtime_uses_admin_origin_without_frontend_service() -> None:
+    """Production Terraform must publish backend/admin runtime only."""
+    findings = _findings()
+
+    assert "production Terraform root must exist" not in findings
+    assert "production Terraform must keep backend and admin services deployable" not in findings
+    assert "production Terraform must not configure standalone frontend runtime" not in findings
+
+
 def test_local_staging_root_is_isolated_and_rejects_production_mixing() -> None:
     """Local staging Terraform must use separate state, names, params, and hostnames."""
     findings = _findings()
@@ -51,12 +77,14 @@ def test_local_staging_root_is_isolated_and_rejects_production_mixing() -> None:
     assert "local-staging must derive unique staging hostnames from staging_id" not in findings
     assert "local-staging must reject production hostnames and names" not in findings
     assert "local-staging must isolate secret and parameter namespaces" not in findings
+    assert "local-staging must keep backend and admin services deployable" not in findings
+    assert "local-staging Terraform must not configure standalone frontend runtime" not in findings
 
 
 def test_deploy_script_rejects_ci_execution_without_calling_terraform() -> None:
     """CI must fail before Terraform can mutate AWS or Cloudflare resources."""
     result = subprocess.run(
-        [str(SCRIPT), "--staging-id", "pr-123", "--backend-tag", "sha-abc1234", "--frontend-tag", "sha-abc1234", "--admin-tag", "sha-abc1234", "--plan-only"],
+        [str(SCRIPT), "--staging-id", "pr-123", "--backend-tag", "sha-abc1234", "--admin-tag", "sha-abc1234", "--plan-only"],
         cwd=ROOT,
         env={**os.environ, "CI": "true"},
         text=True,
@@ -72,7 +100,7 @@ def test_deploy_script_rejects_ci_execution_without_calling_terraform() -> None:
 def test_deploy_script_requires_explicit_tags_and_staging_id() -> None:
     """A staging deploy must never fall back to latest, bootstrap, or implicit tags."""
     result = subprocess.run(
-        [str(SCRIPT), "--staging-id", "pr-123", "--backend-tag", "latest", "--frontend-tag", "sha-abc1234", "--admin-tag", "sha-abc1234", "--plan-only"],
+        [str(SCRIPT), "--staging-id", "pr-123", "--backend-tag", "latest", "--admin-tag", "sha-abc1234", "--plan-only"],
         cwd=ROOT,
         env={k: v for k, v in os.environ.items() if k not in {"CI", "GITHUB_ACTIONS"}},
         text=True,
@@ -87,7 +115,7 @@ def test_deploy_script_requires_explicit_tags_and_staging_id() -> None:
 def test_deploy_script_rejects_production_staging_ids() -> None:
     """Official production names/URLs must not be accepted as staging identifiers."""
     result = subprocess.run(
-        [str(SCRIPT), "--staging-id", "api", "--backend-tag", "sha-abc1234", "--frontend-tag", "sha-abc1234", "--admin-tag", "sha-abc1234", "--plan-only"],
+        [str(SCRIPT), "--staging-id", "api", "--backend-tag", "sha-abc1234", "--admin-tag", "sha-abc1234", "--plan-only"],
         cwd=ROOT,
         env={k: v for k, v in os.environ.items() if k not in {"CI", "GITHUB_ACTIONS"}},
         text=True,
@@ -104,7 +132,7 @@ def test_deploy_script_rejects_expiration_after_three_days() -> None:
     too_late = (datetime.now(UTC) + timedelta(days=4)).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     result = subprocess.run(
-        [str(SCRIPT), "--staging-id", "pr-123", "--backend-tag", "sha-abc1234", "--frontend-tag", "sha-abc1234", "--admin-tag", "sha-abc1234", "--expires-at", too_late, "--plan-only"],
+        [str(SCRIPT), "--staging-id", "pr-123", "--backend-tag", "sha-abc1234", "--admin-tag", "sha-abc1234", "--expires-at", too_late, "--plan-only"],
         cwd=ROOT,
         env={k: v for k, v in os.environ.items() if k not in {"CI", "GITHUB_ACTIONS"}},
         text=True,
@@ -124,8 +152,6 @@ def test_deploy_script_fails_fast_when_deploy_inputs_are_missing() -> None:
             "--staging-id",
             "pr-123",
             "--backend-tag",
-            "sha-abc1234",
-            "--frontend-tag",
             "sha-abc1234",
             "--admin-tag",
             "sha-abc1234",

--- a/scripts/tests/test_terraform_foundation.py
+++ b/scripts/tests/test_terraform_foundation.py
@@ -19,9 +19,8 @@ def test_prod_uses_scoped_cloudflare_tunnels_and_local_origins() -> None:
     """Each public service must own a scoped tunnel reaching its same-task origin."""
     findings = _findings()
 
-    assert "prod must declare backend, frontend, and admin scoped tunnels" not in findings
+    assert "prod must declare backend and admin scoped tunnels" not in findings
     assert "backend tunnel must route api hostname to localhost:8000" not in findings
-    assert "frontend tunnel must route app hostname to localhost:3000" not in findings
     assert "admin tunnel must route admin hostname to localhost:3000" not in findings
 
 
@@ -30,7 +29,7 @@ def test_no_shared_unreachable_localhost_origins() -> None:
     findings = _findings()
 
     assert "cloudflare tunnel module must reject mixed localhost origins" not in findings
-    assert "prod must not reuse one tunnel for backend, frontend, and admin" not in findings
+    assert "prod must not reuse one tunnel for backend and admin" not in findings
 
 
 def test_tunnel_tokens_and_secret_outputs_are_sensitive() -> None:
@@ -47,8 +46,9 @@ def test_prod_names_and_domain_are_isolated_from_staging() -> None:
     findings = _findings()
 
     assert "prod domain must default to artesolutions.com.co" not in findings
-    assert "prod hostnames must derive chatbot, app, and admin from domain_name" not in findings
+    assert "prod hostnames must derive chatbot and admin from domain_name" not in findings
     assert "prod name prefix must reject staging values" not in findings
+    assert "prod must not define standalone frontend runtime resources" not in findings
 
 
 def test_admin_scaffold_is_a_separate_image() -> None:


### PR DESCRIPTION
## ¿Qué hace este PR?

Integra la Chat UI de pruebas dentro del Admin Panel para centralizar el acceso administrativo sin exponer `CHAT_API_KEY` en el navegador. Además corrige la visualización de respuestas del chatbot: renderiza Markdown/formatos WhatsApp, conserva saltos de línea y mantiene el conversational splitting aun cuando el formatter de WhatsApp está activo.

## Issues relacionados

Closes #194
Part of #207
Part of #174

## Tipo de cambio

- [ ] 🆕 Nueva funcionalidad (feature)
- [x] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [ ] 🧪 Tests
- [ ] 📄 Documentación / configuración
- [ ] 🔧 Infra / CI

## Checklist antes de pedir review

- [x] El código corre localmente sin errores (`uvicorn` levanta, tests pasan)
- [x] Los criterios de aceptación del issue relacionado están cumplidos
- [x] No hay credenciales, API keys ni rutas absolutas hardcodeadas
- [x] No agregué dependencias nuevas; `requirements.txt` / `pyproject.toml` no requieren cambios
- [x] Si modifiqué el schema del endpoint, verifiqué que `/docs` refleja los cambios
- [x] No modifiqué el harness ni el dataset de evaluación

## Cómo probar este PR

1. Ejecutar validaciones específicas del chat admin:
   ```bash
   cd admin-panel
   npm run test -- admin-chat.test.tsx
   npm run typecheck
   ```

2. Ejecutar validaciones backend del contrato de splitting:
   ```bash
   uv run pytest backend/app/tests/test_whatsapp_integration.py::TestSplitterWiring::test_split_with_formatter_enabled backend/app/tests/test_admin_chat.py::TestAdminChatContract::test_admin_chat_preserves_split_fields
   ```

3. Levantar el entorno recreando backend y admin panel:
   ```bash
   docker compose up -d --build --force-recreate backend admin-panel
   ```
   Abrir `http://localhost:3001/admin/chat`, iniciar una conversación nueva y verificar que las respuestas muestran Markdown/viñetas, preservan saltos de línea y se separan en burbujas cuando `SPLIT_MESSAGES_ENABLED=true`.

## Notas para el reviewer

La causa del bug de splitting era el orden de procesamiento: `format_for_whatsapp()` removía los delimitadores `---` antes de llamar a `process_split_messages()`. Ahora el backend separa primero y deja el formateo por segmento dentro del splitter; si no hay split, mantiene el formateo normal de WhatsApp.

La UI reutiliza el renderer Markdown existente, ampliado para soportar formato habitual de WhatsApp (`*negrita*`, `_cursiva_` y `•` viñetas). No se agregaron dependencias nuevas.