### PR TITLE
chore(github): add structured issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,116 @@
+name: Bug report
+description: Report a reproducible defect in ARTE Chatbot
+title: "fix(scope): "
+labels:
+  - type:bug
+  - status:needs-review
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a defect. Search existing issues first and keep the proposed fix limited to one reviewable behavior.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I searched open and closed issues and found no duplicate.
+          required: true
+        - label: I understand this issue requires `status:approved` before implementation or a pull request begins.
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug description
+      description: Describe the defect and why it matters.
+      placeholder: The system currently...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Provide the smallest deterministic reproduction.
+      placeholder: |
+        1. Configure...
+        2. Send...
+        3. Observe...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: The system should...
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: Instead, the system...
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List observable conditions required to consider the bug fixed.
+      placeholder: |
+        - [ ] The failing scenario is covered by a regression test.
+        - [ ] The expected behavior is restored.
+        - [ ] Existing behavior remains compatible.
+    validations:
+      required: true
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: State adjacent changes that must not be included in this issue.
+      placeholder: This issue does not redesign...
+    validations:
+      required: true
+
+  - type: textarea
+    id: code_reference
+    attributes:
+      label: Code reference
+      description: Add permanent commit, PR, file, or compare links when available.
+      placeholder: |
+        - Baseline SHA: ...
+        - Reference PR: ...
+        - Relevant files: ...
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Remove credentials, tokens, customer data, and other secrets.
+      render: shell
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      options:
+        - Local development
+        - Pull request preview
+        - Staging
+        - Production
+        - CI only
+        - Not environment-specific
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context
+      description: Add sanitized screenshots, trade-offs, dependencies, or rollout notes.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,125 @@
+name: Feature request
+description: Propose a scoped user or technical capability for ARTE Chatbot
+title: "feat(scope): "
+labels:
+  - type:feature
+  - status:needs-review
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe one reviewable capability. Large features must be split into chained issues or technical stories.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I searched open and closed issues and found no duplicate.
+          required: true
+        - label: I understand this issue requires `status:approved` before implementation or a pull request begins.
+          required: true
+
+  - type: dropdown
+    id: story_type
+    attributes:
+      label: Story type
+      options:
+        - User story (US)
+        - Technical story (TS)
+        - Feature (FEAT)
+        - Architecture decision (ADR)
+        - Maintenance chore
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem description
+      description: Explain the user, operational, or engineering problem without prescribing unnecessary implementation details.
+      placeholder: Today, the system cannot...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed outcome
+      description: Describe the behavior or capability that should exist when this issue is complete.
+      placeholder: The system should...
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] The behavior is covered by automated tests.
+        - [ ] Failure modes are explicit.
+        - [ ] Configuration and documentation are updated when applicable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: Explicitly exclude adjacent features to protect review scope.
+      placeholder: This issue does not include...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: affected_area
+    attributes:
+      label: Affected area
+      options:
+        - Backend
+        - Catalog and data
+        - LLM and File Inputs
+        - Chatwoot integration
+        - Frontend
+        - Admin Panel
+        - Evaluation
+        - Infrastructure and CI/CD
+        - Documentation
+        - Cross-cutting architecture
+    validations:
+      required: true
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: Link prerequisite issues, decisions, or external systems.
+      placeholder: Blocked by #...
+
+  - type: textarea
+    id: code_reference
+    attributes:
+      label: Existing code reference
+      description: Link a permanent commit, PR, recovery branch, or compare view if implementation already exists elsewhere.
+      placeholder: |
+        - Reference PR: ...
+        - Snapshot SHA: ...
+        - Reusable files: ...
+
+  - type: textarea
+    id: delivery
+    attributes:
+      label: Delivery and verification
+      description: Describe tests, preview/staging validation, migration, and rollback expectations.
+      placeholder: |
+        - Unit/integration tests:
+        - Preview or staging checks:
+        - Rollback or compatibility:
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Briefly record rejected approaches and their trade-offs.


### PR DESCRIPTION
## ¿Qué hace este PR?

Añade formularios estructurados para reportes de bugs y solicitudes de funcionalidades. Los formularios exigen criterios de aceptación, límites de alcance y confirmación del flujo de aprobación antes de iniciar implementación.

## Issues relacionados

Closes #228

## Tipo de cambio

- [ ] 🆕 Nueva funcionalidad (feature)
- [ ] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [ ] 🧪 Tests
- [x] 📄 Documentación / configuración
- [ ] 🔧 Infra / CI

## Checklist antes de pedir review

- [x] Los formularios pasan validación YAML con `npx --yes yaml-lint ".github/ISSUE_TEMPLATE/*.yml"`
- [x] Los criterios de aceptación del issue relacionado están cumplidos
- [x] No hay credenciales, API keys ni rutas absolutas hardcodeadas
- [x] No se agregaron dependencias al proyecto
- [x] No se modificó el schema del API
- [x] No se modificó el harness ni el dataset

## Cómo probar este PR

1. Ejecutar `npx --yes yaml-lint ".github/ISSUE_TEMPLATE/*.yml"`.
2. Revisar que cada formulario incluya `status:needs-review` y exactamente un label inicial `type:*`.
3. Tras el merge, abrir el selector de issues y confirmar que aparecen Bug report y Feature request.

## Notas para el reviewer

El label `status:needs-review` ya existe en el repositorio. El cambio ajeno en `.kilo/package-lock.json` quedó fuera del commit y de esta PR.