### PR TITLE
fix(profile): infer profile from current message

### DIFF
--- a/backend/app/user_profiler.py
+++ b/backend/app/user_profiler.py
@@ -5,7 +5,10 @@ conversation history analysis.
 """
 
 import re
-from typing import List, Dict
+from typing import Dict, List, Optional
+
+
+PROFILE_INFERENCE_MAX_USER_MESSAGES = 2
 
 PROFILE_INSTRUCTIONS = {
     "novato": "Explica con analogías simples. Evita siglas técnicas sin definirlas primero. Usa ejemplos cotidianos.",
@@ -240,7 +243,31 @@ def _extract_acronym_score(text: str) -> float:
     return min(score, 1.0)
 
 
-def infer_user_profile(history: List[Dict[str, str]]) -> str:
+def should_recalibrate_user_profile(
+    existing_profile: Optional[str], prior_user_message_count: int
+) -> bool:
+    """Return whether the bounded profile inference window is still open.
+
+    Profiles are inferred from at most the first two user messages. Recomputing
+    during that window lets the second message refine the first-turn result;
+    afterwards, the stored profile remains stable.
+
+    Args:
+        existing_profile: Profile currently stored for the session, if any.
+        prior_user_message_count: User messages stored before the current turn.
+
+    Returns:
+        True when the profile must be inferred or recalibrated.
+    """
+    return (
+        existing_profile is None
+        or prior_user_message_count < PROFILE_INFERENCE_MAX_USER_MESSAGES
+    )
+
+
+def infer_user_profile(
+    history: List[Dict[str, str]], current_message: Optional[str] = None
+) -> str:
     """
     Infer user expertise level based on conversation history.
 
@@ -251,17 +278,22 @@ def infer_user_profile(history: List[Dict[str, str]]) -> str:
 
     Args:
         history: List of conversation turns in format [{"role": "user", "content": "..."}].
-                 Only "user" role messages are analyzed.
+            Only "user" role messages are analyzed.
+        current_message: Current user message when it has not yet been persisted.
 
     Returns:
         One of "novato", "intermedio", or "experto".
     """
-    # Filter user messages only and take first 2
+    # Filter stored user messages before adding the not-yet-persisted current turn.
     user_messages = [
         turn.get("content", "")
         for turn in history
         if turn.get("role") == "user" and turn.get("content")
-    ][:2]
+    ]
+    if current_message:
+        user_messages.append(current_message)
+
+    user_messages = user_messages[:PROFILE_INFERENCE_MAX_USER_MESSAGES]
 
     # Default to intermedio if no user messages
     if not user_messages:

--- a/backend/main.py
+++ b/backend/main.py
@@ -88,7 +88,11 @@ from backend.app.security import (
 from backend.app.session import session_manager
 from backend.app.state_repository import ChatbotStateRepository
 from backend.app.tools import get_tool_definitions, validate_s3_path
-from backend.app.user_profiler import PROFILE_INSTRUCTIONS, infer_user_profile
+from backend.app.user_profiler import (
+    PROFILE_INSTRUCTIONS,
+    infer_user_profile,
+    should_recalibrate_user_profile,
+)
 from backend.app.whatsapp_formatter import format_for_whatsapp
 from rag import (
     DEFAULT_ESCALATION_MESSAGE,
@@ -876,12 +880,12 @@ async def _process_chat_message(
         redact_text(message)[:100],
     )
 
-    # Infer user profile if not already inferred for this session
+    # Infer from the first turn and recalibrate once on the second user message.
     existing_profile = session_manager.get_user_profile(session_id)
-    if existing_profile is None:
-        history = session_manager.get_history(session_id)
+    history = session_manager.get_history(session_id)
+    if should_recalibrate_user_profile(existing_profile, len(history)):
         history_dicts = [{"role": "user", "content": turn.question} for turn in history]
-        inferred_profile = infer_user_profile(history_dicts)
+        inferred_profile = infer_user_profile(history_dicts, current_message=message)
         session_manager.set_user_profile(session_id, inferred_profile)
         logger.info(
             "User profile inferred: session_id=%s, profile=%s, turn_count=%d",

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -225,6 +225,30 @@ class TestChatEndpointUnit:
         assert add_kwargs["answer"] == "Mocked LLM Response"
 
     @patch("backend.main.llm_client.get_llm_response_with_tools")
+    @patch("backend.main.session_manager")
+    def test_chat_infers_profile_from_current_first_message(
+        self, mock_session_manager, mock_llm
+    ) -> None:
+        """Test the first user message participates in profile inference."""
+        mock_llm.return_value = make_llm_response(text="Mocked LLM Response")
+        mock_session_manager.get_user_profile.return_value = None
+        mock_session_manager.get_history.return_value = []
+        _bind_test_session("first-profile-turn")
+
+        response = client.post(
+            "/chat",
+            json={
+                "message": "¿Cuál es el Voc del JinkoSolar 460W a 25°C?",
+                "session_id": "first-profile-turn",
+            },
+        )
+
+        assert response.status_code == 200
+        mock_session_manager.set_user_profile.assert_called_once_with(
+            "first-profile-turn", "experto"
+        )
+
+    @patch("backend.main.llm_client.get_llm_response_with_tools")
     def test_chat_returns_escalation_message(self, mock_llm) -> None:
         """Test that escalation response includes the escalation message."""
         mock_llm.return_value = make_llm_response(

--- a/backend/tests/test_user_profiler.py
+++ b/backend/tests/test_user_profiler.py
@@ -3,10 +3,11 @@ Unit tests for the user profile inference module.
 """
 
 from backend.app.user_profiler import (
-    infer_user_profile,
-    _extract_technical_score,
-    _extract_specificity_score,
     _extract_acronym_score,
+    _extract_specificity_score,
+    _extract_technical_score,
+    infer_user_profile,
+    should_recalibrate_user_profile,
 )
 from backend.app.session import SessionManager
 
@@ -135,6 +136,45 @@ class TestInferUserProfile:
         profile = infer_user_profile(history)
         assert profile == "intermedio"
 
+    def test_current_novice_message_is_included_on_first_turn(self):
+        """Test first-turn inference includes a separate current message."""
+        profile = infer_user_profile([], current_message="¿Qué es un panel solar?")
+
+        assert profile == "novato"
+
+    def test_current_intermediate_message_is_included_on_first_turn(self):
+        """Test an intermediate current message is classified on turn one."""
+        profile = infer_user_profile(
+            [], current_message="¿Cuánto cuesta un panel de 300W?"
+        )
+
+        assert profile == "intermedio"
+
+    def test_current_expert_message_is_included_on_first_turn(self):
+        """Test an expert current message is classified on turn one."""
+        profile = infer_user_profile(
+            [], current_message="¿Cuál es el Voc del JinkoSolar 460W a 25°C?"
+        )
+
+        assert profile == "experto"
+
+    def test_ambiguous_current_message_defaults_to_novice(self):
+        """Test an ambiguous but present first message is treated as novice."""
+        profile = infer_user_profile([], current_message="Hola")
+
+        assert profile == "novato"
+
+    def test_current_message_combines_with_history_once(self):
+        """Test the current message combines with stored history exactly once."""
+        history = [{"role": "user", "content": "¿Qué es un panel?"}]
+
+        profile = infer_user_profile(
+            history,
+            current_message="¿Cuál es el Voc del JinkoSolar 460W a 25°C?",
+        )
+
+        assert profile == "experto"
+
     def test_two_user_messages_combined(self):
         """Test that only first 2 user messages are analyzed."""
         history = [
@@ -242,6 +282,22 @@ class TestInferUserProfile:
         history_lower = [{"role": "user", "content": "panel solar básico"}]
         history_mixed = [{"role": "user", "content": "Panel Solar Básico"}]
         assert infer_user_profile(history_lower) == infer_user_profile(history_mixed)
+
+
+class TestProfileRecalibrationPolicy:
+    """Tests for the bounded two-message recalibration policy."""
+
+    def test_missing_stored_profile_is_always_inferred(self):
+        """Test legacy sessions without a profile remain compatible."""
+        assert should_recalibrate_user_profile(None, 4) is True
+
+    def test_stored_profile_is_recalibrated_before_second_message(self):
+        """Test a first-turn profile can be refined by the second message."""
+        assert should_recalibrate_user_profile("novato", 1) is True
+
+    def test_stored_profile_is_stable_after_two_messages(self):
+        """Test inference stops once the bounded window is complete."""
+        assert should_recalibrate_user_profile("experto", 2) is False
 
 
 class TestSessionManagerProfileIntegration:


### PR DESCRIPTION
## ¿Qué hace este PR?

- Incluye el mensaje actual en la inferencia del perfil antes de persistir el turno.
- Recalibra el perfil durante una ventana explícita de dos mensajes y luego conserva el valor almacenado.
- Añade cobertura para perfiles novato, intermedio, experto y ambiguo.

## Issues relacionados

Closes #236

## Tipo de cambio

- [ ] 🆕 Nueva funcionalidad (feature)
- [x] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [ ] 🧪 Tests
- [ ] 📄 Documentación / configuración
- [ ] 🔧 Infra / CI

## Cambios

| Archivo | Cambio |
|---|---|
| `backend/app/user_profiler.py` | Añade el mensaje actual y explicita la ventana de recalibración. |
| `backend/main.py` | Recalibra durante los primeros dos turnos y persiste el resultado. |
| `backend/tests/test_user_profiler.py` | Cubre categorías, compatibilidad y estabilidad. |
| `backend/tests/test_chat.py` | Verifica la inferencia del primer mensaje en el endpoint. |

## Checklist antes de pedir review

- [x] Los tests focalizados pasan: `uv run pytest backend/tests/test_user_profiler.py backend/tests/test_chat.py` (106 passed, 3 skipped).
- [x] Ruff pasa: `uv run --group lint ruff check backend/app/user_profiler.py backend/main.py backend/tests/test_user_profiler.py backend/tests/test_chat.py`.
- [x] Los criterios de aceptación del issue relacionado están cumplidos.
- [x] No hay credenciales, API keys ni rutas absolutas hardcodeadas.
- [x] No se agregaron dependencias ni se modificó el schema del endpoint.
- [x] El commit usa formato convencional y no contiene trailers de atribución.

## Cómo probar este PR

1. Ejecutar `uv run pytest backend/tests/test_user_profiler.py backend/tests/test_chat.py`.
2. Iniciar una sesión y enviar una consulta con indicadores novatos o expertos.
3. Verificar que el primer mensaje define el perfil y que solo se recalibra durante los dos primeros mensajes.

## Notas para el reviewer

La suite completa presenta fallos preexistentes por respuestas `401 Unauthorized` dependientes del orden global; `backend/tests/test_chat.py` pasa cuando se ejecuta de forma focalizada.