### PR TITLE
fix(session): bound latest DynamoDB turn reads

### DIFF
--- a/backend/app/dynamodb_state_repository.py
+++ b/backend/app/dynamodb_state_repository.py
@@ -266,10 +266,7 @@ class DynamoDBStateRepository:
             if not exclusive_start_key:
                 break
 
-        return [
-            self._turn_from_item(item)
-            for item in reversed(items)
-        ]
+        return [self._turn_from_item(item) for item in reversed(items)]
 
     def _put_buffer_state(self, state: BufferState) -> None:
         self._table.put_item(

--- a/backend/app/dynamodb_state_repository.py
+++ b/backend/app/dynamodb_state_repository.py
@@ -48,11 +48,14 @@ class DynamoDBStateRepository:
         self._buffer_ttl_seconds = buffer_ttl_seconds
         self._rate_ttl_seconds = rate_ttl_seconds
 
-    def get_session(self, session_id: str) -> SessionState:
+    def get_session(self, session_id: str, max_turns: int = 20) -> SessionState:
         """Return persisted session state or an empty state for cold starts."""
+        if max_turns < 1:
+            raise ValueError("max_turns must be greater than zero")
+
         meta = self._get_item(self._session_pk(session_id), "META")
         tokens = self.get_token_totals(session_id)
-        turns = self._get_turns(session_id)
+        turns = self._get_turns(session_id, max_turns)
         return SessionState(
             session_id=session_id,
             owner=meta.get("owner") if meta else None,
@@ -240,16 +243,33 @@ class DynamoDBStateRepository:
         state.processing_started_at = None
         self._put_buffer_state(state)
 
-    def _get_turns(self, session_id: str) -> list[ChatTurn]:
-        response = self._table.query(
-            KeyConditionExpression="PK = :pk AND begins_with(SK, :prefix)",
-            ExpressionAttributeValues={
-                ":pk": self._session_pk(session_id),
-                ":prefix": "TURN#",
-            },
-            ScanIndexForward=True,
-        )
-        return [self._turn_from_item(item) for item in response.get("Items", [])]
+    def _get_turns(self, session_id: str, max_turns: int) -> list[ChatTurn]:
+        items: list[dict[str, Any]] = []
+        exclusive_start_key: Optional[dict[str, Any]] = None
+
+        while len(items) < max_turns:
+            query_options: dict[str, Any] = {
+                "KeyConditionExpression": "PK = :pk AND begins_with(SK, :prefix)",
+                "ExpressionAttributeValues": {
+                    ":pk": self._session_pk(session_id),
+                    ":prefix": "TURN#",
+                },
+                "ScanIndexForward": False,
+                "Limit": max_turns - len(items),
+            }
+            if exclusive_start_key is not None:
+                query_options["ExclusiveStartKey"] = exclusive_start_key
+
+            response = self._table.query(**query_options)
+            items.extend(response.get("Items", []))
+            exclusive_start_key = response.get("LastEvaluatedKey")
+            if not exclusive_start_key:
+                break
+
+        return [
+            self._turn_from_item(item)
+            for item in reversed(items)
+        ]
 
     def _put_buffer_state(self, state: BufferState) -> None:
         self._table.put_item(

--- a/backend/app/session.py
+++ b/backend/app/session.py
@@ -47,6 +47,9 @@ class SessionManager:
         max_turns: int = 20,
         state_repository: Optional[ChatbotStateRepository] = None,
     ):
+        if max_turns < 1:
+            raise ValueError("max_turns must be greater than zero")
+
         self.sessions: Dict[str, List[ChatTurn]] = {}
         self.profiles: Dict[str, str] = {}
         self.token_totals: Dict[str, TokenTotals] = {}
@@ -139,7 +142,9 @@ class SessionManager:
             Lista de turnos de la sesión, ordenados cronológicamente
         """
         if self.state_repository is not None:
-            state = self.state_repository.get_session(session_id)
+            state = self.state_repository.get_session(
+                session_id, max_turns=self.max_turns
+            )
             return [
                 ChatTurn(
                     question=turn.question,
@@ -147,7 +152,7 @@ class SessionManager:
                     timestamp=turn.timestamp,
                     source_documents=turn.source_documents,
                 )
-                for turn in state.turns[-self.max_turns :]
+                for turn in state.turns
             ]
         return self.sessions.get(session_id, [])
 

--- a/backend/app/state_repository.py
+++ b/backend/app/state_repository.py
@@ -79,8 +79,8 @@ class RateLimitDecision(BaseModel):
 class ChatbotStateRepository(Protocol):
     """Persistence boundary for Lambda-safe chatbot state."""
 
-    def get_session(self, session_id: str) -> SessionState:
-        """Return persisted session state or an empty state for missing sessions."""
+    def get_session(self, session_id: str, max_turns: int = 20) -> SessionState:
+        """Return persisted session state with at most the latest turns."""
 
     def append_turn(self, session_id: str, turn: ChatTurn) -> None:
         """Append one conversation turn."""

--- a/backend/tests/test_session.py
+++ b/backend/tests/test_session.py
@@ -5,6 +5,8 @@ Unit tests for the session management service.
 import threading
 from datetime import datetime
 
+import pytest
+
 from backend.app.dynamodb_state_repository import DynamoDBStateRepository
 from backend.app.session import SessionManager
 from backend.app.state_repository import ChatTurn, TokenTotals
@@ -23,6 +25,13 @@ def test_session_manager_custom_max_turns():
     """Test that SessionManager accepts custom max_turns."""
     sm = SessionManager(max_turns=5)
     assert sm.max_turns == 5
+
+
+@pytest.mark.parametrize("max_turns", [0, -1])
+def test_session_manager_rejects_non_positive_max_turns(max_turns: int):
+    """Test that SessionManager rejects invalid history limits."""
+    with pytest.raises(ValueError, match="max_turns must be greater than zero"):
+        SessionManager(max_turns=max_turns)
 
 
 def test_add_turn_creates_new_session():

--- a/backend/tests/test_state_repository.py
+++ b/backend/tests/test_state_repository.py
@@ -17,8 +17,10 @@ from backend.app.state_repository import (
 class FakeDynamoDBTable:
     """Small in-memory DynamoDB Table fake for repository unit tests."""
 
-    def __init__(self) -> None:
+    def __init__(self, query_page_size: int | None = None) -> None:
         self.items: dict[tuple[str, str], dict[str, Any]] = {}
+        self.query_calls: list[dict[str, Any]] = []
+        self.query_page_size = query_page_size
 
     def get_item(self, Key: dict[str, str]) -> dict[str, Any]:
         item = self.items.get((Key["PK"], Key["SK"]))
@@ -32,8 +34,17 @@ class FakeDynamoDBTable:
         KeyConditionExpression: str,
         ExpressionAttributeValues: dict[str, Any],
         ScanIndexForward: bool = True,
-    ) -> dict[str, list[dict[str, Any]]]:
+        Limit: int | None = None,
+        ExclusiveStartKey: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
         del KeyConditionExpression
+        self.query_calls.append(
+            {
+                "ScanIndexForward": ScanIndexForward,
+                "Limit": Limit,
+                "ExclusiveStartKey": ExclusiveStartKey,
+            }
+        )
         prefix = ExpressionAttributeValues[":prefix"]
         pk = ExpressionAttributeValues[":pk"]
         items = [
@@ -41,7 +52,31 @@ class FakeDynamoDBTable:
             for (item_pk, item_sk), item in self.items.items()
             if item_pk == pk and item_sk.startswith(prefix)
         ]
-        return {"Items": sorted(items, key=lambda item: item["SK"])}
+        items = sorted(
+            items,
+            key=lambda item: item["SK"],
+            reverse=not ScanIndexForward,
+        )
+        if ExclusiveStartKey is not None:
+            start_index = next(
+                index + 1
+                for index, item in enumerate(items)
+                if item["PK"] == ExclusiveStartKey["PK"]
+                and item["SK"] == ExclusiveStartKey["SK"]
+            )
+            items = items[start_index:]
+
+        page_limit = Limit
+        if self.query_page_size is not None:
+            page_limit = min(Limit or self.query_page_size, self.query_page_size)
+        page_items = items[:page_limit]
+        response: dict[str, Any] = {"Items": page_items}
+        if page_limit is not None and len(items) > page_limit:
+            response["LastEvaluatedKey"] = {
+                "PK": page_items[-1]["PK"],
+                "SK": page_items[-1]["SK"],
+            }
+        return response
 
     def update_item(
         self,
@@ -139,6 +174,77 @@ def test_session_survives_cold_start_with_new_repository_instance() -> None:
     assert state.profile == "experto"
     assert state.turns[0].source_documents == ["panel.pdf"]
     assert state.token_totals.total_tokens == 5
+
+
+@pytest.mark.parametrize(
+    ("turn_count", "max_turns", "expected_questions"),
+    [
+        (2, 3, ["Q0", "Q1"]),
+        (3, 3, ["Q0", "Q1", "Q2"]),
+        (5, 3, ["Q2", "Q3", "Q4"]),
+    ],
+)
+def test_get_session_reads_only_latest_turns_in_chronological_order(
+    turn_count: int,
+    max_turns: int,
+    expected_questions: list[str],
+) -> None:
+    """The repository bounds reads while preserving consumer ordering."""
+    table = FakeDynamoDBTable()
+    repository = DynamoDBStateRepository(table=table)
+    for index in range(turn_count):
+        repository.append_turn(
+            "s1",
+            ChatTurn(
+                question=f"Q{index}",
+                answer=f"A{index}",
+                timestamp=datetime(2026, 1, 1, 0, index, tzinfo=timezone.utc),
+            ),
+        )
+
+    state = repository.get_session("s1", max_turns=max_turns)
+
+    assert [turn.question for turn in state.turns] == expected_questions
+    assert table.query_calls == [
+        {
+            "ScanIndexForward": False,
+            "Limit": max_turns,
+            "ExclusiveStartKey": None,
+        }
+    ]
+
+
+def test_get_session_follows_dynamodb_pagination() -> None:
+    """The repository follows continuation keys until the turn limit is reached."""
+    table = FakeDynamoDBTable(query_page_size=2)
+    repository = DynamoDBStateRepository(table=table)
+    for index in range(5):
+        repository.append_turn(
+            "s1",
+            ChatTurn(
+                question=f"Q{index}",
+                answer=f"A{index}",
+                timestamp=datetime(2026, 1, 1, 0, index, tzinfo=timezone.utc),
+            ),
+        )
+
+    state = repository.get_session("s1", max_turns=3)
+
+    assert [turn.question for turn in state.turns] == ["Q2", "Q3", "Q4"]
+    assert [call["Limit"] for call in table.query_calls] == [3, 1]
+    assert table.query_calls[1]["ExclusiveStartKey"] is not None
+
+
+@pytest.mark.parametrize("max_turns", [0, -1])
+def test_get_session_rejects_non_positive_turn_limit(max_turns: int) -> None:
+    """Invalid limits fail before issuing a DynamoDB query."""
+    table = FakeDynamoDBTable()
+    repository = DynamoDBStateRepository(table=table)
+
+    with pytest.raises(ValueError, match="max_turns must be greater than zero"):
+        repository.get_session("s1", max_turns=max_turns)
+
+    assert table.query_calls == []
 
 
 def test_bind_owner_allows_same_owner_and_rejects_conflict(


### PR DESCRIPTION
## ¿Qué hace este PR?

- Limita la lectura de historial en DynamoDB a los últimos turnos configurados, evitando recorrer sesiones completas.
- Consulta en orden descendente, sigue páginas parciales con `LastEvaluatedKey` y devuelve los turnos en orden cronológico.
- Valida límites inválidos y amplía el fake de DynamoDB para cubrir paginación real.

| Archivo | Cambio |
|---|---|
| `backend/app/dynamodb_state_repository.py` | Consulta limitada, descendente y paginada mediante `ExclusiveStartKey`. |
| `backend/app/session.py` | Propaga y valida `max_turns`. |
| `backend/app/state_repository.py` | Actualiza el contrato de recuperación de sesión. |
| `backend/tests/test_state_repository.py` | Cubre límites, orden y páginas parciales. |
| `backend/tests/test_session.py` | Cubre límites no positivos. |

## Issues relacionados

Closes #237
Part of #8

## Tipo de cambio

- [ ] 🆕 Nueva funcionalidad (feature)
- [x] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [ ] 🧪 Tests
- [ ] 📄 Documentación / configuración
- [ ] 🔧 Infra / CI

## Checklist antes de pedir review

- [x] El código corre localmente sin errores (tests pasan)
- [x] Los criterios de aceptación del issue relacionado están cumplidos
- [x] No hay credenciales, API keys ni rutas absolutas hardcodeadas
- [x] No se agregaron dependencias nuevas
- [x] No se modificó el schema del endpoint
- [x] No se modificó el harness ni el dataset

## Cómo probar este PR

1. Ejecutar `uv run pytest backend/tests/test_state_repository.py backend/tests/test_session.py` y verificar 35 tests aprobados.
2. Ejecutar `uv run pytest backend/tests` y verificar 289 tests aprobados y 3 omitidos.
3. Ejecutar `uv run --group lint ruff check backend/app/state_repository.py backend/app/dynamodb_state_repository.py backend/app/session.py backend/tests/test_state_repository.py backend/tests/test_session.py`.

## Notas para el reviewer

Cada consulta de continuación usa como `Limit` solamente la cantidad de turnos restante. Esto permite atravesar el límite de página de 1 MB de DynamoDB sin leer más de `max_turns` elementos.