### PR TITLE
fix(tests): isolate FastAPI dependency overrides

### DIFF
--- a/backend/app/tests/test_message_buffer.py
+++ b/backend/app/tests/test_message_buffer.py
@@ -488,7 +488,11 @@ class TestEndpointBufferIntegration:
         from backend.main import app
         from backend.app.auth import verify_api_key
 
-        app.dependency_overrides[verify_api_key] = lambda: "test_key"
+        monkeypatch.setattr(
+            app,
+            "dependency_overrides",
+            {verify_api_key: lambda: "test_key"},
+        )
         client = TestClient(app)
         return client, app
 

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -27,8 +27,14 @@ def _bind_test_session(session_id: str) -> None:
     session_manager.bind_session(session_id, TEST_API_PRINCIPAL)
 
 
-# Override auth for unit tests
-app.dependency_overrides[verify_api_key] = lambda: TEST_API_KEY
+@pytest.fixture(autouse=True)
+def _chat_dependency_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Give every chat test an isolated authentication override."""
+    monkeypatch.setattr(
+        app,
+        "dependency_overrides",
+        {verify_api_key: lambda: TEST_API_KEY},
+    )
 
 
 class TestHealthEndpoint:

--- a/backend/tests/test_lambda_runtime.py
+++ b/backend/tests/test_lambda_runtime.py
@@ -115,9 +115,8 @@ def _lambda_test_environment(monkeypatch: pytest.MonkeyPatch) -> None:
 
     from backend.main import app
 
-    app.dependency_overrides.clear()
+    monkeypatch.setattr(app, "dependency_overrides", {})
     yield
-    app.dependency_overrides.clear()
     settings.reset()
 
 

--- a/backend/tests/test_security_hardening.py
+++ b/backend/tests/test_security_hardening.py
@@ -19,7 +19,7 @@ def _client_with_auth(monkeypatch) -> TestClient:
     monkeypatch.setenv("RATE_LIMIT_WINDOW_SECONDS", "60")
     settings.reset()
     rate_limiter.reset()
-    app.dependency_overrides.clear()
+    monkeypatch.setattr(app, "dependency_overrides", {})
     return TestClient(app)
 
 
@@ -80,7 +80,7 @@ def test_rate_limit_returns_429(monkeypatch) -> None:
     monkeypatch.setenv("RATE_LIMIT_WINDOW_SECONDS", "60")
     settings.reset()
     rate_limiter.reset()
-    app.dependency_overrides.clear()
+    monkeypatch.setattr(app, "dependency_overrides", {})
     client = TestClient(app)
 
     headers = {"X-API-Key": "test-secret"}


### PR DESCRIPTION
## ¿Qué hace este PR?

- Aísla `app.dependency_overrides` por test para evitar contaminación global entre módulos de pytest.
- Usa `monkeypatch.setattr` con mappings propios, de modo que el teardown restaura exactamente el objeto previo.
- Conserva escenarios con autenticación real usando un mapping vacío por test.

## Issues relacionados

Closes #267

## Tipo de cambio

- [ ] 🆕 Nueva funcionalidad (feature)
- [x] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [ ] 🧪 Tests
- [ ] 📄 Documentación / configuración
- [ ] 🔧 Infra / CI

## Cambios

| Archivo | Cambio |
|---|---|
| `backend/tests/test_chat.py` | Instala el override de autenticación en un fixture autouse aislado por test. |
| `backend/tests/test_lambda_runtime.py` | Reemplaza el mapping de overrides durante cada test Lambda y permite que monkeypatch restaure el anterior. |
| `backend/tests/test_security_hardening.py` | Usa mappings vacíos aislados para conservar la validación de autenticación real. |
| `backend/app/tests/test_message_buffer.py` | Aísla el override de autenticación del cliente del endpoint de buffer. |

## Checklist antes de pedir review

- [x] El código corre localmente sin errores (`466 passed, 3 skipped`).
- [x] Los criterios de aceptación del issue relacionado están cumplidos.
- [x] No hay credenciales, API keys ni rutas absolutas hardcodeadas.
- [x] Dependencias nuevas: N/A; no se agregaron dependencias.
- [x] Schema del endpoint: N/A; no se modificó.
- [x] Harness o dataset: N/A; no se modificaron.
- [x] El issue aprobado está vinculado con `Closes #267`.
- [x] El PR usa exactamente un label `type:*`: `type:bug`.
- [x] El commit sigue Conventional Commits y no incluye `Co-Authored-By`.

## Cómo probar este PR

1. Ejecutar `pytest backend/tests backend/app/tests`.
2. Confirmar el resultado esperado: `466 passed, 3 skipped`.
3. Ejecutar los módulos afectados en distinto orden y confirmar que ningún override de autenticación persiste entre tests.

## Test plan

- [x] Suite backend completa: `466 passed, 3 skipped`.
- [x] Revisión fresca de los cuatro archivos: PASS, sin hallazgos críticos ni warnings.
- [x] Shellcheck: N/A; este PR no modifica scripts de shell.

## Notas para el reviewer

El cambio es exclusivamente de tests. La restauración depende de `monkeypatch`, que repone el mapping anterior al finalizar cada test; no se incluyen cambios de OpenSpec, DynamoDB, secretos ni package-locks.