### PR TITLE
ci: [TS-R0-01] run complete backend test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,39 @@ jobs:
       - name: Check Python syntax
         run: python -m py_compile backend/main.py
 
+  test-deterministic:
+    name: Test Deterministic Python Suites
+    runs-on: ubuntu-latest
+    needs: lint
+    env:
+      OPENAI_API_KEY: test-openai-key
+      CHAT_API_KEY: test-chat-key
+      AWS_ACCESS_KEY_ID: testing
+      AWS_SECRET_ACCESS_KEY: testing
+      AWS_SESSION_TOKEN: testing
+      AWS_REGION: us-east-1
+      AWS_DEFAULT_REGION: us-east-1
+      AWS_BUCKET_NAME: test-bucket
+      AWS_EC2_METADATA_DISABLED: "true"
+      ARTE_CHATBOT_DISABLE_DOTENV: "1"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install test dependencies
+        run: uv sync --frozen --group dev
+
+      - name: Run deterministic Python suites
+        run: uv run pytest backend/tests backend/app/tests rag/tests -m "not live"
+
   build:
     name: Build Docker Images
     runs-on: ubuntu-latest
@@ -113,7 +146,7 @@ jobs:
   lambda-package:
     name: Test and Package Lambda Backend
     runs-on: ubuntu-latest
-    needs: lint
+    needs: [lint, test-deterministic]
     outputs:
       package-sha256: ${{ steps.package.outputs.sha256 }}
     steps:

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -397,6 +397,7 @@ def chat_api_key():
 
 
 @pytest.mark.integration
+@pytest.mark.live
 def test_chat_status_200(chat_api_key):
     """Verify the /chat endpoint returns 200 for a valid request with auth header."""
     payload = {"message": "Hello", "session_id": str(uuid.uuid4())}
@@ -410,6 +411,7 @@ def test_chat_status_200(chat_api_key):
 
 
 @pytest.mark.integration
+@pytest.mark.live
 def test_chat_response_not_empty(api_key, chat_api_key):
     """Verify the response body is non-empty when the API key is available."""
     payload = {"message": "Test", "session_id": str(uuid.uuid4())}
@@ -423,6 +425,7 @@ def test_chat_response_not_empty(api_key, chat_api_key):
 
 
 @pytest.mark.integration
+@pytest.mark.live
 def test_session_id_uuid_format(api_key, chat_api_key):
     """Verify the returned session_id is a valid UUID."""
     session_id = str(uuid.uuid4())
@@ -442,6 +445,7 @@ def test_session_id_uuid_format(api_key, chat_api_key):
 
 
 @pytest.mark.integration
+@pytest.mark.live
 def test_openai_api_key_loaded_from_env(api_key):
     """Verify the OPENAI_API_KEY environment variable is set."""
     assert os.getenv("OPENAI_API_KEY") is not None, (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,10 @@ dependencies = [
 ]
 
 [tool.pytest.ini_options]
-markers = ["integration: marks tests as integration tests"]
+markers = [
+  "integration: marks tests as integration tests",
+  "live: marks tests that require a running service or external credentials",
+]
 
 [tool.arte_chatbot.lambda_package]
 build_command = "uv export --no-dev --format requirements-txt --output-file requirements.txt"

--- a/scripts/tests/test_workflow_deploy_checks.py
+++ b/scripts/tests/test_workflow_deploy_checks.py
@@ -1,7 +1,10 @@
 """Static checks for Lambda-only production deploy workflows."""
 
 from pathlib import Path
+import shutil
 import sys
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -9,10 +12,32 @@ from workflow_deploy_checks import check_workflow_deploy
 
 
 ROOT = Path(__file__).resolve().parents[2]
+DETERMINISTIC_GATE_FINDING = "deterministic test job must run all Python test roots offline with fake credentials"
+LAMBDA_GATE_FINDING = "lambda package job must depend on the deterministic test gate"
 
 
 def _findings() -> list[str]:
     return check_workflow_deploy(ROOT)
+
+
+def _mutated_project(tmp_path: Path, old: str, new: str) -> Path:
+    """Copy checked inputs and apply one mutation to the CI workflow."""
+    checked_paths = [
+        Path(".github/workflows/ci.yml"),
+        Path(".github/workflows/lambda-preview-cleanup.yml"),
+        Path(".python-version"),
+        Path("infra/terraform/modules/lambda_backend/variables.tf"),
+    ]
+    for relative_path in checked_paths:
+        destination = tmp_path / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(ROOT / relative_path, destination)
+
+    workflow_path = tmp_path / ".github/workflows/ci.yml"
+    workflow = workflow_path.read_text(encoding="utf-8")
+    assert old in workflow, f"mutation target is missing: {old}"
+    workflow_path.write_text(workflow.replace(old, new, 1), encoding="utf-8")
+    return tmp_path
 
 
 def test_workflow_keeps_production_lambda_deploys_on_main_after_gates() -> None:
@@ -69,6 +94,148 @@ def test_lambda_package_job_tests_scans_and_uploads_same_package_artifact() -> N
         "lambda package Python version must match Terraform Lambda runtime"
         not in findings
     )
+
+
+def test_deterministic_suites_gate_lambda_packaging() -> None:
+    """All deterministic roots must run offline before packaging starts."""
+    findings = _findings()
+
+    assert DETERMINISTIC_GATE_FINDING not in findings
+    assert LAMBDA_GATE_FINDING not in findings
+
+
+@pytest.mark.parametrize(
+    "test_root",
+    ["backend/tests", "backend/app/tests", "rag/tests"],
+)
+def test_deterministic_gate_rejects_an_omitted_test_root(
+    tmp_path: Path, test_root: str
+) -> None:
+    """Removing any required test root must break the static CI guard."""
+    project_root = _mutated_project(tmp_path, f" {test_root}", "")
+
+    assert DETERMINISTIC_GATE_FINDING in check_workflow_deploy(project_root)
+
+
+@pytest.mark.parametrize(
+    ("old", "new"),
+    [
+        pytest.param('-m "not live"', "", id="missing-live-filter"),
+        pytest.param(
+            "backend/tests backend/app/tests",
+            "backend/tests/test_config.py backend/app/tests",
+            id="root-prefix-substitution",
+        ),
+        pytest.param('-m "not live"', '# -m "not live"', id="commented-live-filter"),
+        pytest.param(
+            "      OPENAI_API_KEY: test-openai-key",
+            "      # OPENAI_API_KEY: test-openai-key",
+            id="commented-fake-environment",
+        ),
+        pytest.param(
+            "run: uv run pytest backend/tests",
+            "run: echo uv run pytest backend/tests",
+            id="echo-wrapper",
+        ),
+        pytest.param(
+            '        run: uv run pytest backend/tests backend/app/tests rag/tests -m "not live"',
+            "        run: |\n"
+            "          uv run pytest backend/tests backend/app/tests rag/tests "
+            '-m "not live"\n'
+            "          uv run pytest backend/tests backend/app/tests rag/tests "
+            '-m "not live"',
+            id="multiple-pytest-commands",
+        ),
+        pytest.param(
+            '        run: uv run pytest backend/tests backend/app/tests rag/tests -m "not live"',
+            "        run: |\n"
+            "          uv run pytest backend/tests\n"
+            '          uv run pytest backend/app/tests rag/tests -m "not live"',
+            id="split-pytest-arguments",
+        ),
+        pytest.param(
+            "run: uv run pytest backend/tests",
+            "run: RESULT=$(uv run pytest backend/tests",
+            id="command-substitution",
+        ),
+        pytest.param(
+            "      - name: Run deterministic Python suites\n",
+            "      - name: Run deterministic Python suites\n"
+            "        continue-on-error: true\n",
+            id="continue-on-error",
+        ),
+        pytest.param(
+            "      - name: Run deterministic Python suites\n"
+            '        run: uv run pytest backend/tests backend/app/tests rag/tests -m "not live"',
+            "      - name: Run deterministic Python suites\n"
+            "        shell: bash {0}\n"
+            "        run: |\n"
+            "          uv run pytest backend/tests backend/app/tests rag/tests "
+            '-m "not live"\n\n'
+            "          true",
+            id="custom-shell-blank-line-multicommand",
+        ),
+    ],
+)
+def test_deterministic_gate_rejects_semantic_bypasses(
+    tmp_path: Path, old: str, new: str
+) -> None:
+    """Known command, environment, and step-control bypasses must fail."""
+    project_root = _mutated_project(tmp_path, old, new)
+
+    assert DETERMINISTIC_GATE_FINDING in check_workflow_deploy(project_root)
+
+
+@pytest.mark.parametrize(
+    "operator", ["; true", "&& true", "|| true", "| cat", "& true"]
+)
+def test_deterministic_gate_rejects_shell_operators(
+    tmp_path: Path, operator: str
+) -> None:
+    """Shell composition is outside the conservative deterministic-step contract."""
+    project_root = _mutated_project(
+        tmp_path,
+        '-m "not live"',
+        f'-m "not live" {operator}',
+    )
+
+    assert DETERMINISTIC_GATE_FINDING in check_workflow_deploy(project_root)
+
+
+def test_deterministic_gate_accepts_safe_equals_marker_syntax(tmp_path: Path) -> None:
+    """Quoted equals syntax remains one safe marker argument."""
+    project_root = _mutated_project(
+        tmp_path,
+        '-m "not live"',
+        "-m='not live'",
+    )
+
+    assert DETERMINISTIC_GATE_FINDING not in check_workflow_deploy(project_root)
+
+
+def test_lambda_package_rejects_missing_deterministic_dependency(
+    tmp_path: Path,
+) -> None:
+    """Packaging must not start unless the deterministic suite succeeds."""
+    project_root = _mutated_project(
+        tmp_path,
+        "needs: [lint, test-deterministic]",
+        "needs: lint",
+    )
+
+    assert LAMBDA_GATE_FINDING in check_workflow_deploy(project_root)
+
+
+@pytest.mark.parametrize("condition", ["always()", "success()"])
+def test_lambda_package_rejects_job_condition(tmp_path: Path, condition: str) -> None:
+    """Packaging conservatively relies on the default successful-needs gate."""
+    project_root = _mutated_project(
+        tmp_path,
+        "    needs: [lint, test-deterministic]",
+        f"    needs: [lint, test-deterministic]\n    if: {condition}",
+    )
+
+    assert LAMBDA_GATE_FINDING in check_workflow_deploy(project_root)
 
 
 def test_lambda_staging_deploy_and_smoke_validate_isolated_serverless_runtime() -> None:

--- a/scripts/workflow_deploy_checks.py
+++ b/scripts/workflow_deploy_checks.py
@@ -4,8 +4,9 @@ The checks read repository files only. They intentionally avoid GitHub, AWS,
 Cloudflare, Docker, and Terraform calls so they can run safely in PR CI.
 """
 
-from pathlib import Path
 import re
+import shlex
+from pathlib import Path
 
 
 WORKFLOW_PATH = Path(".github/workflows/ci.yml")
@@ -33,6 +34,7 @@ def check_workflow_deploy(project_root: Path) -> list[str]:
     preview_comment_job = _job_block(workflow, "comment-lambda-preview")
 
     findings: list[str] = []
+    findings.extend(_check_deterministic_test_gate(workflow))
     findings.extend(
         _check_main_deploy_gates(
             workflow,
@@ -61,6 +63,68 @@ def check_workflow_deploy(project_root: Path) -> list[str]:
             local_python_version,
         )
     )
+    return findings
+
+
+def _check_deterministic_test_gate(workflow: str) -> list[str]:
+    """Require the complete offline suite before Lambda packaging."""
+    deterministic_job = _job_block(workflow, "test-deterministic")
+    lambda_package_job = _job_block(workflow, "lambda-package")
+    pytest_arguments = _inline_step_command_arguments(
+        deterministic_job,
+        "Run deterministic Python suites",
+        ["uv", "run", "pytest"],
+    )
+    deterministic_env = _job_environment(deterministic_job)
+    required_environment = {
+        "OPENAI_API_KEY": "test-openai-key",
+        "CHAT_API_KEY": "test-chat-key",
+        "AWS_ACCESS_KEY_ID": "testing",
+        "AWS_SECRET_ACCESS_KEY": "testing",
+        "AWS_SESSION_TOKEN": "testing",
+        "AWS_REGION": "us-east-1",
+        "AWS_DEFAULT_REGION": "us-east-1",
+        "AWS_BUCKET_NAME": "test-bucket",
+        "AWS_EC2_METADATA_DISABLED": "true",
+        "ARTE_CHATBOT_DISABLE_DOTENV": "1",
+    }
+    required_test_roots = {"backend/tests", "backend/app/tests", "rag/tests"}
+    has_live_exclusion = (
+        any(
+            pytest_arguments[index : index + 2] == ["-m", "not live"]
+            for index in range(len(pytest_arguments) - 1)
+        )
+        or "-m=not live" in pytest_arguments
+    )
+
+    findings: list[str] = []
+    if (
+        not deterministic_job
+        or "lint" not in _job_needs(deterministic_job)
+        or _inline_step_command_arguments(
+            deterministic_job,
+            "Install test dependencies",
+            ["uv", "sync"],
+        )
+        != ["--frozen", "--group", "dev"]
+        or not required_test_roots.issubset(pytest_arguments)
+        or not has_live_exclusion
+        or any(
+            deterministic_env.get(name) != value
+            for name, value in required_environment.items()
+        )
+    ):
+        findings.append(
+            "deterministic test job must run all Python test roots offline with fake credentials"
+        )
+
+    if (
+        not lambda_package_job
+        or not {"lint", "test-deterministic"}.issubset(_job_needs(lambda_package_job))
+        or _job_mapping_value(lambda_package_job, "if") is not None
+    ):
+        findings.append("lambda package job must depend on the deterministic test gate")
+
     return findings
 
 
@@ -429,6 +493,153 @@ def _job_block(workflow: str, job_name: str) -> str:
     )
     match = pattern.search(workflow)
     return match.group(0) if match else ""
+
+
+def _inline_step_command_arguments(
+    job: str, step_name: str, command_prefix: list[str]
+) -> list[str]:
+    """Return arguments for one named, fail-fast, inline command step."""
+    step = _named_job_step(job, step_name)
+    if (
+        not step
+        or step.get("run-style") != "inline"
+        or "continue-on-error" in step
+        or "shell" in step
+    ):
+        return []
+
+    command = step.get("run", "")
+    if _has_forbidden_shell_syntax(command):
+        return []
+
+    tokens = _shell_tokens(command)
+    prefix_length = len(command_prefix)
+    if tokens[:prefix_length] != command_prefix:
+        return []
+    arguments = tokens[prefix_length:]
+    if any(
+        arguments[index : index + prefix_length] == command_prefix
+        for index in range(len(arguments) - prefix_length + 1)
+    ):
+        return []
+    return arguments
+
+
+def _job_steps(job: str) -> list[dict[str, str]]:
+    """Extract minimal top-level fields for each workflow step in one job."""
+    lines = job.splitlines()
+    steps: list[dict[str, str]] = []
+    current_step: dict[str, str] | None = None
+    index = 0
+    while index < len(lines):
+        step_match = re.match(
+            r"^      - (?P<key>[a-zA-Z0-9_-]+):\s*(?P<value>.*)$", lines[index]
+        )
+        if step_match:
+            if current_step is not None:
+                steps.append(current_step)
+            current_step = {
+                step_match.group("key"): _yaml_scalar(step_match.group("value"))
+            }
+            index += 1
+            continue
+
+        field_match = re.match(
+            r"^        (?P<key>[a-zA-Z0-9_-]+):\s*(?P<value>.*)$", lines[index]
+        )
+        if current_step is None or not field_match:
+            index += 1
+            continue
+
+        key = field_match.group("key")
+        value = field_match.group("value").strip()
+        if key == "run" and value in {"|", "|-", ">", ">-"}:
+            block_lines: list[str] = []
+            index += 1
+            while index < len(lines):
+                line = lines[index]
+                if line.strip() and len(line) - len(line.lstrip()) <= 8:
+                    break
+                block_lines.append(line.strip())
+                index += 1
+            separator = " " if value.startswith(">") else "\n"
+            current_step["run"] = separator.join(block_lines)
+            current_step["run-style"] = value
+            continue
+
+        current_step[key] = _yaml_scalar(value)
+        if key == "run":
+            current_step["run-style"] = "inline"
+        index += 1
+
+    if current_step is not None:
+        steps.append(current_step)
+    return steps
+
+
+def _named_job_step(job: str, step_name: str) -> dict[str, str]:
+    """Return one uniquely named step or an empty mapping."""
+    matches = [step for step in _job_steps(job) if step.get("name") == step_name]
+    return matches[0] if len(matches) == 1 else {}
+
+
+def _yaml_scalar(value: str) -> str:
+    """Normalize one simple uncommented YAML scalar."""
+    tokens = _shell_tokens(value)
+    return tokens[0] if len(tokens) == 1 else value.strip()
+
+
+def _has_forbidden_shell_syntax(command: str) -> bool:
+    """Reject shell composition; this guard intentionally accepts one command only."""
+    forbidden_tokens = ("\n", ";", "&", "|", "$(", "`")
+    return any(token in command for token in forbidden_tokens)
+
+
+def _shell_tokens(command: str) -> list[str]:
+    """Split executable shell text while discarding shell comments."""
+    try:
+        return shlex.split(command, comments=True, posix=True)
+    except ValueError:
+        return []
+
+
+def _job_environment(job: str) -> dict[str, str]:
+    """Return the job-level env mapping, excluding steps and comments."""
+    lines = job.splitlines()
+    for index, line in enumerate(lines):
+        if line != "    env:":
+            continue
+        environment: dict[str, str] = {}
+        for child in lines[index + 1 :]:
+            if child.strip() and len(child) - len(child.lstrip()) <= 4:
+                break
+            match = re.match(r"^      (?P<name>[A-Z0-9_]+):\s*(?P<value>.+)$", child)
+            if match:
+                tokens = _shell_tokens(match.group("value"))
+                if len(tokens) == 1:
+                    environment[match.group("name")] = tokens[0]
+        return environment
+    return {}
+
+
+def _job_mapping_value(job: str, key: str) -> str | None:
+    """Return one uncommented top-level job mapping value."""
+    match = re.search(
+        rf"^    {re.escape(key)}:\s*(?P<value>[^#\n]*?)(?:\s+#.*)?$",
+        job,
+        re.MULTILINE,
+    )
+    return match.group("value").strip() if match else None
+
+
+def _job_needs(job: str) -> set[str]:
+    """Return inline job dependencies as exact names."""
+    value = _job_mapping_value(job, "needs")
+    if not value:
+        return set()
+    if value.startswith("[") and value.endswith("]"):
+        return {dependency.strip() for dependency in value[1:-1].split(",")}
+    return {value}
 
 
 def _read(path: Path) -> str:


### PR DESCRIPTION
## ¿Qué hace este PR?

Amplía el gate de CI para ejecutar todas las pruebas deterministas de backend y RAG antes de empaquetar Lambda. Separa explícitamente las pruebas live y agrega un guard adversarial que evita que cambios futuros omitan suites o neutralicen la propagación de fallos.

## Issues relacionados

Closes #230

## Tipo de cambio

- [ ] 🆕 Nueva funcionalidad (feature)
- [ ] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [ ] 🧪 Tests
- [ ] 📄 Documentación / configuración
- [x] 🔧 Infra / CI

## Cambios principales

| Archivo | Cambio |
|---|---|
| `.github/workflows/ci.yml` | Agrega el job determinista y condiciona el empaquetado Lambda. |
| `backend/tests/test_chat.py` | Marca cuatro pruebas externas como `live`. |
| `pyproject.toml` | Registra el marker `live`. |
| `scripts/workflow_deploy_checks.py` | Valida semánticamente cobertura, aislamiento y propagación de fallos. |
| `scripts/tests/test_workflow_deploy_checks.py` | Agrega pruebas mutantes contra 25 bypasses históricos. |

## Checklist antes de pedir review

- [x] El código corre localmente sin errores y los tests pasan
- [x] Los criterios de aceptación del issue relacionado están cumplidos
- [x] No hay credenciales, API keys ni rutas absolutas hardcodeadas
- [x] No se agregaron dependencias nuevas
- [x] No se modificó el schema del endpoint
- [x] No se modificó el harness ni el dataset de evaluación

## Cómo probar este PR

1. `uv run pytest scripts/tests/test_workflow_deploy_checks.py` — esperado: 29 passed.
2. Ejecutar el comando del job `test-deterministic` — esperado: 462 passed, 4 deselected.
3. `uv run pytest backend/tests backend/app/tests rag/tests -m live --collect-only -p no:cacheprovider` — esperado: 4 tests recolectados, sin ejecutarlos.

## Evidencia local

| Validación | Resultado | Tiempo real |
|---|---:|---:|
| Guard del workflow | 29 passed | 0.31 s |
| Suite determinista | 462 passed, 4 deselected | 8.57 s |
| Colección live | 4/466, ninguno ejecutado | 1.16 s |
| Ruff / formato / YAML / diff check | PASS | — |

## Size exception

`size:exception` aprobado explícitamente por el maintainer. El cambio suma 424 líneas modificadas y se mantiene en un único PR porque el workflow, su checker y las pruebas mutantes forman un solo gate atómico: separarlos dejaría una ventana donde CI podría aceptar una configuración no protegida o tests sin integración efectiva.

## Notas para el reviewer

- Robustez certificada: alta, 9.5/10; 25/25 bypasses históricos rechazados.
- No se ejecutaron pruebas live, llamadas OpenAI/AWS ni deploys.
- No se incluyeron los cambios locales ajenos de `.kilo/package-lock.json` y `.kilocode/package-lock.json`.
- No se modificaron scripts shell; `shellcheck` no aplica al diff.