### PR TITLE
fix(catalog): preserve PDF extraction identity

### DIFF
--- a/openspec/changes/preserve-pdf-extraction-identity/apply-progress.md
+++ b/openspec/changes/preserve-pdf-extraction-identity/apply-progress.md
@@ -1,0 +1,89 @@
+# Apply Progress: Preserve PDF Extraction Identity
+
+## Batch
+
+- Mode: Strict TDD
+- Delivery: stacked-to-main
+- Current unit: Unit 1 implementation complete; PR separation pending
+- Scope: tasks 1.1–1.5 only
+- Verification status: PASS WITH WARNINGS
+- PR gate: split 633-line Unit 1 into PR 1A/1B/1C before commit or PR
+- Rollback boundary: each slice reverts independently
+
+## Required PR Separation
+
+Unit 1 is functionally complete and verified, but its 633 code+tests changed lines
+exceed the 400-line budget without `size:exception`. Before commit or PR, separate
+the existing work into these sequential `stacked-to-main` slices:
+
+1. PR 1A — closed extraction contract: `ClosedDTO`, extraction DTOs,
+   `TechnicalParameter`, and recursive/deep-extra tests.
+2. PR 1B — trusted identity reconciliation: `TrustedDocument`, opaque IDs,
+   exact set reconciliation, and order/anomaly tests. Start from `main` after 1A.
+3. PR 1C — review classification and trusted conversion: cardinality, mismatch,
+   conversion, and trusted routing. Start from `main` after 1B.
+
+Each slice targets `main` after the preceding slice is integrated, carries its
+tests, and has an autonomous rollback boundary. PR 2 starts from `main` after
+PR 1C; PR 3 starts from `main` after PR 2.
+
+## Completed Tasks
+
+- [x] 1.1 RED — Closed DTO, expected-ID uniqueness, and exact reconciliation tests.
+- [x] 1.2 GREEN — Typed DTOs, trusted records/map, exceptions, and reconciliation.
+- [x] 1.3 RED — Trusted routing, cardinality, variants, and mismatch tests.
+- [x] 1.4 GREEN — Review classification and trusted-only conversion.
+- [x] 1.5 REFACTOR — Consolidated typed helpers with behavior preserved.
+
+## TDD Cycle Evidence
+
+| Task | Test File | Layer | Safety Net | RED | GREEN | TRIANGULATE | REFACTOR |
+|---|---|---|---|---|---|---|---|
+| 1.1 | `scripts/tests/test_generate_index.py` | Unit | 30/30 baseline | ImportError for missing typed boundary; 0 collected | 9/9 identity tests passed in 1.2 | Exact and out-of-order success plus missing, extra/unknown, and duplicate failures | 14/14 Unit 1 tests passed after helper extraction |
+| 1.2 | `scripts/tests/test_generate_index.py` | Unit | 30/30 baseline | Tests from 1.1 preceded production code | 9/9 identity tests passed | Closed root/nested DTOs and multiple reconciliation branches | 14/14 Unit 1 tests passed after `_validate_identity_sets()` extraction |
+| 1.3 | `scripts/tests/test_generate_index.py` | Unit | 9/9 identity tests | 4 failed and 1 passed before classification/conversion | 5/5 classification/conversion tests passed in 1.4 | Normal variants, zero, multiple, mismatch, and trusted precedence | 14/14 Unit 1 tests passed after typed helper consolidation |
+| 1.4 | `scripts/tests/test_generate_index.py` | Unit | 9/9 identity tests | Tests from 1.3 preceded production code | 5/5 classification/conversion tests passed | Cardinality and routing mismatch take distinct paths | 14/14 Unit 1 tests passed after `_review_reasons()`/routing helper cleanup |
+| 1.5 | `scripts/tests/test_generate_index.py` | Unit/refactor | 44/44 approval baseline | N/A — behavior-preserving refactor | 14/14 focused tests passed | Existing 14-case Unit 1 matrix preserved | 44/44 final tests passed |
+
+## Verification
+
+- `uv run pytest scripts/tests/test_generate_index.py`: 44 passed.
+- Focused Unit 1 selection: 14 passed, 30 deselected.
+- `uv run ruff check scripts/generate_index.py scripts/tests/test_generate_index.py`:
+  unavailable through `uv` (`Failed to spawn: ruff`; no substitution used).
+
+## Deviations
+
+- `build_product_entry()` temporarily accepts the existing trusted discovery mapping
+  as well as `TrustedDocument` so Unit 1 remains autonomous before Units 2–3 replace
+  the transport/pipeline. Routing fields always come from that trusted argument.
+
+## Remaining
+
+- Separate completed Unit 1 into PR 1A/1B/1C before any commit or PR.
+- Unit 2 / tasks 2.1–2.5: Responses API and real File Inputs.
+- Unit 3 / tasks 3.1–3.4: fail-closed pipeline publication gate.
+
+## Verification Correction: Deep Structured Output Closure
+
+Fresh verification found that `dict[str, Any]` generated open technical-parameter
+objects. Unit 1 now represents dynamic parameters as closed typed `name`/`value`
+pairs and converts them to publication mappings only in `build_product_entry()`.
+
+### Additional TDD Cycle Evidence
+
+| Scope | Test File | Layer | Safety Net | RED | GREEN | TRIANGULATE | REFACTOR |
+|---|---|---|---|---|---|---|---|
+| Deep extraction-schema closure | `scripts/tests/test_generate_index.py` | Unit/schema contract | 44/44 fresh baseline | 4 failed, 5 passed: recursive schema check exposed `additionalProperties=true`; pair payloads and nested error locations failed | 14/14 focused DTO/classification/conversion tests passed | Root, document, product, variant, technical parameter, common/key parameter pairs, scalar string/number values, and zero variants covered | Extracted recursive schema assertion helper; 14/14 focused tests remained green |
+
+### Updated Verification
+
+- Recursive `ExtractionBatch.model_json_schema()` inspection: 5 object nodes;
+  root plus all `$defs` objects have `additionalProperties: false`.
+- `uv run pytest scripts/tests/test_generate_index.py`: 51 passed.
+- `uv run ruff check scripts/generate_index.py scripts/tests/test_generate_index.py`:
+  still unavailable through `uv` (`Failed to spawn: ruff`; no substitution used).
+- `git diff --check`: passed.
+- Current tracked code+tests diff: 615 additions + 18 deletions = 633 changed
+  lines. This exceeds 400 lines and has no `size:exception`; the orchestrator must
+  subdivide the approved `stacked-to-main` delivery before PR creation.

--- a/openspec/changes/preserve-pdf-extraction-identity/design.md
+++ b/openspec/changes/preserve-pdf-extraction-identity/design.md
@@ -1,0 +1,104 @@
+# Design: Preserve PDF Extraction Identity
+
+## Technical Approach
+
+Replace positional JSON-mode extraction with a typed, keyed batch boundary in
+`scripts/generate_index.py`. The application assigns every PDF an opaque identity,
+sends every uploaded PDF as a Responses API File Input, reconciles the parsed result
+against trusted inputs, converts only normal results, and validates the complete
+published catalog before any write. The spec was not present during design; this
+implements the proposal and exploration invariants.
+
+## Architecture Decisions
+
+| Decision | Choice and rationale | Rejected alternative |
+|---|---|---|
+| Separate contracts | Closed Pydantic v2 extraction DTOs (`ConfigDict(extra="forbid")`) model required fields and nullable metadata; `docs/schemas/catalog_index.schema.json` remains the publication contract. Its `allOf`/`if`/`then` composition is unsuitable as a strict Structured Output, and shape validation does not establish provenance. | Reusing the publication schema or loose `dict`/JSON mode. |
+| Trusted identity | Create a random opaque `document_id` (UUID hex is sufficient) per batch item and a `dict[str, TrustedDocument]` containing immutable `pdf_info`, `s3_key`, and uploaded `file_id`. Only this map supplies `ruta_s3`, `categoria`, and `subcategoria`. | File IDs, list positions, filenames, or model-echoed paths as authority. |
+| Exact reconciliation | Index parsed documents by ID; reject duplicate, missing, unknown, or extra IDs before converting anything. Set equality makes result order irrelevant. An echoed source/category assertion may only trigger review or protocol diagnostics. | `zip()` or partial batch acceptance. |
+| Outcome policy | `normal` requires exactly one product series with at least one variant. Zero products, unrelated multiple products, or suspicious source/content mismatch become `needs_review`; one series with several variants remains normal. Any review or protocol/transport failure blocks the whole run and all publication. | Fabricated fallback entries or publishing unaffected batch fragments. |
+
+## Data Flow
+
+```text
+PDF bytes -> upload -> trusted_map[document_id]
+                     -> Responses.parse(input_text ID + input_file pairs)
+                     -> typed envelope -> exact reconciliation
+                     -> normal DTO conversion -> catalog schema validation
+                     -> atomic local save / S3 upload
+```
+
+`extract_metadata_batch()` builds one user content list with repeated adjacent
+`{"type":"input_text","text":"document_id: ..."}` and
+`{"type":"input_file","file_id": ...}` items, then calls
+`client.responses.parse(model=model, instructions=EXTRACTION_SYSTEM_PROMPT,
+input=[...], text_format=ExtractionBatch)`. Uploaded Files are deleted in `finally`.
+
+## Interfaces / Contracts
+
+All types stay in `scripts/generate_index.py` to match the current single-script
+boundary:
+
+```python
+class ExtractionStatus(str, Enum):
+    NORMAL = "normal"
+    NEEDS_REVIEW = "needs_review"
+
+class DocumentExtraction(ClosedDTO):
+    document_id: str
+    status: ExtractionStatus
+    products: list[ExtractedProduct]
+    review_reasons: list[str]
+
+class ExtractionBatch(ClosedDTO):
+    documents: list[DocumentExtraction]
+
+@dataclass(frozen=True)
+class TrustedDocument:
+    s3_key: str
+    pdf_info: dict[str, Any]
+    file_id: str
+```
+
+`reconcile_batch(parsed, trusted_map) -> list[tuple[ExtractedProduct,
+TrustedDocument]]` either returns a complete normal batch or raises a typed
+`ExtractionProtocolError` / `ExtractionNeedsReview`. `build_product_entry()` accepts
+model-owned product fields plus the trusted document; it must never read routing
+fields from model output.
+
+Before reconciliation, reject any refusal content, `response.status != "completed"`
+(log `incomplete_details.reason`), missing `output_parsed`, Pydantic/schema failure,
+or OpenAI API error. `run_pipeline()` logs source IDs/keys, returns non-zero, and
+does not call `save_local()` or `upload_to_s3()`. Cleanup failure is warning-only.
+
+## File Changes
+
+| File | Action | Description |
+|---|---|---|
+| `scripts/generate_index.py` | Modify | DTOs, Responses File Inputs, trusted map, reconciliation, conversion, fail-closed orchestration |
+| `scripts/tests/test_generate_index.py` | Modify | DTO, request, reconciliation, failure, and publication-boundary tests |
+| `pyproject.toml`, `uv.lock` | Conditional | Raise OpenAI minimum only if the declared `>=1.68.0` lacks the verified helper |
+| `docs/schemas/catalog_index.schema.json` | None | Existing final validator |
+
+## Testing Strategy
+
+Unit tests cover closed DTO rejection; out-of-order success; missing, extra/unknown,
+and duplicate IDs; trusted routing-field precedence; normal series variants; and
+no-product, multi-product, and mismatch review. Mocked SDK tests assert real
+`input_file` items and refusal, incomplete, absent parsed output, API, and schema
+failures. Pipeline tests assert non-zero exit and zero local/S3 writes on every
+failure, plus conversion followed by successful full-schema validation.
+
+## Migration / Rollout
+
+Run against representative local PDFs with `--local-only` and a disposable output,
+then compare entries and enable S3 publication. The lock currently resolves OpenAI
+2.30.0/Pydantic 2.12.5, but `pyproject.toml` permits OpenAI 1.68.0; verify
+`responses.parse(..., text_format=...)` in the minimum environment and raise the
+constraint if incompatible. Roll back the code/dependency change and preserve the
+last valid index; one-PDF requests remain the operational fallback. No data
+migration is required.
+
+## Open Questions
+
+None.

--- a/openspec/changes/preserve-pdf-extraction-identity/exploration.md
+++ b/openspec/changes/preserve-pdf-extraction-identity/exploration.md
@@ -1,0 +1,192 @@
+## Exploration: preserve-pdf-extraction-identity
+
+### Current State
+
+`scripts/generate_index.py` discovers PDFs deterministically, downloads each batch,
+and calls `extract_metadata_batch()`. The extraction function returns an unkeyed
+`list[dict]`; `run_pipeline()` then associates results with source files through
+`zip(extracted, pdf_bytes_list)`. This creates two silent corruption modes:
+out-of-order results are assigned to the wrong PDF, while missing or extra results
+are truncated by `zip()` without detecting cardinality drift. `ruta_s3`, category,
+and subcategory are then copied from whichever positional `pdf_info` happened to
+be paired with the extraction.
+
+The current prompt asks for one JSON product per attached PDF and uses JSON mode
+(`response_format={"type": "json_object"}`), which guarantees JSON syntax but not
+schema adherence. The integration test explicitly mocks results in discovery
+order and has no out-of-order, missing-result, extra-result, duplicate-identity,
+or unknown-identity coverage.
+
+There are two adjacent integrity problems relevant to the scope:
+
+- Uploaded Files API IDs are mentioned in text, but the Chat Completions request
+  does not include file content items. Official OpenAI File Inputs documentation
+  requires each uploaded ID to be supplied as an actual `input_file` item (the
+  current Responses API form). The identity fix must not preserve this omission.
+- Batch extraction failures currently create basic fallback catalog entries;
+  catalog schema errors are logged and publication continues. Those behaviors
+  can turn uncertainty into apparently authoritative enterprise catalog data.
+
+OpenAI Structured Outputs is applicable, but it solves shape rather than
+provenance. Official documentation confirms schema adherence, native Pydantic
+parsing, required fields, `additionalProperties: false`, and explicit refusal and
+incomplete-response handling. It also states that structured values may still be
+semantically wrong. Therefore a schema-valid `source_s3_key` is not evidence that
+the metadata came from that PDF.
+
+The published `docs/schemas/catalog_index.schema.json` cannot be reused directly
+as a strict Structured Outputs schema: it contains unsupported composition and
+conditionals (`allOf`, `if`/`then`) and optional fields. A separate extraction DTO
+is needed, with all fields required, nullable fields where appropriate, closed
+objects, and category alternatives nested below an object root. The existing
+catalog schema remains the publication validator.
+
+### Affected Areas
+
+- `scripts/generate_index.py` — extraction request, typed response envelope,
+  deterministic reconciliation, refusal/incomplete handling, review policy, and
+  removal of positional `zip()` association.
+- `scripts/tests/test_generate_index.py` — keyed out-of-order success plus missing,
+  extra/unknown, and duplicate identity failures; refusal, incomplete, no-product,
+  and multi-product review behavior should also be covered at the reconciliation
+  boundary.
+- `docs/schemas/catalog_index.schema.json` — publication contract consulted after
+  reconciliation; no change is required for the narrow identity fix.
+- `pyproject.toml` / `uv.lock` — the repository already has Pydantic v2 and a
+  current OpenAI SDK lock, so native parsed Structured Outputs should not require
+  a new library; an SDK constraint change is only needed if implementation proves
+  the used Responses/Pydantic helper unavailable.
+
+### Approaches
+
+1. **Structured batch envelope plus deterministic identity reconciliation** —
+   Generate an application-owned opaque `document_id` for each batch input, keep
+   a trusted `document_id -> pdf_info` map, place the ID adjacent to each real
+   `input_file`, and require one typed document result per ID. Reconcile by exact
+   set equality and uniqueness, not order. Derive `ruta_s3` only from the trusted
+   map. If the model also echoes `source_s3_key`, treat it as an assertion that
+   must exactly match the map, never as the source of truth.
+   - Pros: directly eliminates positional coupling; accepts out-of-order output;
+     preserves batching economics; gives Pydantic/schema validation and explicit
+     per-source traceability; supports deterministic missing/extra/duplicate tests.
+   - Cons: cannot prove semantic attribution when a model places PDF A's content
+     under PDF B's valid ID; requires a separate strict extraction schema and
+     Responses API refusal/incomplete handling; batching still increases prompt
+     complexity.
+   - Effort: Medium
+
+2. **One PDF per Structured Outputs request** — Send exactly one `input_file` and
+   parse one typed extraction response; attach `pdf_info` in application code and
+   never ask the model to choose a source identity.
+   - Pros: strongest source isolation; no cross-document ordering/cardinality
+     problem; simplest semantic attribution and retry behavior.
+   - Cons: up to one request and schema processing path per PDF, increasing
+     latency, request count, cleanup operations, and likely cost; gives up the
+     existing batch-size optimization; the issue's batch anomaly tests become
+     reconciliation-unit tests rather than normal request behavior.
+   - Effort: Medium
+
+3. **Keyed JSON mode without Structured Outputs** — Keep the current API shape,
+   add `document_id` or `source_s3_key` to each JSON result, and manually validate
+   IDs/cardinality before building entries.
+   - Pros: smallest API migration and low implementation effort; fixes `zip()` if
+     validation is complete.
+   - Cons: JSON mode does not guarantee the required identity/status fields or
+     closed schema; more parsing/retry code; preserves the current missing File
+     Input attachment unless separately corrected; weaker foundation for an
+     enterprise data asset.
+   - Effort: Low
+
+4. **Structured batch with per-PDF retry on protocol anomaly** — Use Approach 1
+   normally, but reject an anomalous batch and retry each expected PDF through
+   Approach 2 before deciding the run outcome.
+   - Pros: keeps normal-case batching while obtaining source isolation when the
+     batch contract breaks; avoids publishing fallback metadata.
+   - Cons: more branches and tests; retries cannot detect a schema-valid semantic
+     swap that did not trigger a protocol anomaly; worst-case request count is
+     batch call plus one call per PDF.
+   - Effort: Medium-High
+
+### Recommendation
+
+Use **Approach 1 as the core fix**, with the failure policy from Approach 4 but
+without requiring automatic per-PDF retry in the first implementation. The
+essential invariant is: **one trusted source record enters reconciliation and
+exactly one uniquely keyed document envelope leaves it; order is irrelevant**.
+
+Recommended extraction boundary:
+
+- Application creates an opaque `document_id` for every PDF and stores its
+  `pdf_info`, OpenAI file ID, and source key in a trusted batch map.
+- The request includes each actual `input_file` next to text identifying its
+  `document_id`; the typed root contains `documents: list[DocumentExtraction]`.
+- Each document envelope has required fields such as `document_id`, `status`,
+  `products`, and `review_reasons`. Nullable values model optional metadata.
+- Reconciliation rejects duplicate IDs, unknown IDs, missing expected IDs, and
+  any echoed source key that differs from the trusted map. Extra results are
+  unknown IDs and are rejected. Out-of-order complete sets are accepted.
+- `ruta_s3`, category, and subcategory always come from the trusted batch map.
+  Model-extracted identity fields may support diagnostics but never overwrite
+  source metadata.
+- Refusal, incomplete response, missing parsed output, API failure, and strict
+  schema failure produce no catalog entries for the affected batch. They must not
+  fall back to fabricated basic entries.
+- Catalog publication occurs only after deterministic reconciliation and existing
+  catalog-schema validation; validation failure should stop publication rather
+  than continue with a warning for newly extracted data.
+
+`needs_review` policy for this change:
+
+- A PDF representing one product series with multiple models remains one normal
+  catalog product with multiple `variantes`; this is the established ADR-004
+  model and is not a cardinality anomaly.
+- A PDF containing multiple unrelated product series is one document envelope
+  with multiple candidate products and `status=needs_review`. Do not publish the
+  candidates automatically in this narrow fix because current IDs, idempotency,
+  and curation semantics assume a product-series datasheet.
+- A non-product PDF returns zero candidates with `status=needs_review`; do not
+  create an `Unknown`/empty-variants catalog entry.
+- Missing/extra/duplicate/unknown document identities are batch protocol failures,
+  not reviewable successful products. Fail the affected batch (and preferably the
+  run) or retry sources individually; never partially zip or publish it.
+- A schema-valid but suspicious semantic mismatch (for example filename/source
+  category versus extracted category/product) is `needs_review`, because
+  Structured Outputs cannot establish factual correspondence.
+- For the narrow issue, `needs_review` is an internal extraction/run outcome that
+  blocks catalog publication and is emitted with source-key/reason diagnostics.
+  A durable S3 review queue or catalog-schema status field is a follow-up design,
+  not part of the identity repair.
+
+In scope: real File Input attachment for this extraction call, strict extraction
+DTOs, explicit trusted identity mapping, deterministic reconciliation, fail-closed
+batch behavior, diagnostic traceability by source, and the requested tests.
+
+Out of scope: redesigning the published catalog schema, adding a durable review
+workflow/UI, automatic curation of multi-series PDFs, changing backend catalog
+search, broad prompt-quality improvements, proving semantic truth from schema
+validity, and migrating unrelated LLM calls.
+
+### Risks
+
+- A model can return the correct IDs with metadata semantically swapped between
+  PDFs; deterministic reconciliation prevents positional corruption but cannot
+  prove content provenance. One-PDF requests are the high-assurance fallback.
+- The strict extraction schema may diverge from the publication schema. Keep DTOs
+  intentionally separate, test conversion, and always run publication validation.
+- Existing catalog schema composition is not accepted by Structured Outputs;
+  trying to pass it unchanged will fail at the API boundary.
+- Refusal/incomplete behavior differs from ordinary parsed output and must be
+  tested explicitly or failures may re-enter generic fallback handling.
+- Fail-closed behavior changes operational expectations: a run may produce no new
+  catalog version until review/retry, which is safer but needs clear logs and a
+  non-zero result.
+- The complete fix may approach the 400-line review budget once DTOs and tests are
+  included. Keep extraction/reconciliation helpers focused; ask before splitting
+  because the configured chained-PR strategy is `ask-always`.
+
+### Ready for Proposal
+
+Yes. The proposal should adopt keyed batch reconciliation with Structured Outputs,
+state that source identity is application-owned rather than model-authored, make
+publication fail closed on protocol/schema anomalies, and keep durable review
+workflow plus automatic multi-product curation out of scope.

--- a/openspec/changes/preserve-pdf-extraction-identity/proposal.md
+++ b/openspec/changes/preserve-pdf-extraction-identity/proposal.md
@@ -1,0 +1,66 @@
+# Proposal: Preserve PDF Extraction Identity
+
+## Intent
+
+Prevent catalog corruption by preserving application-owned PDF identity through batched extraction and rejecting responses that cannot be reconciled exactly to trusted sources.
+
+## Scope
+
+### In Scope
+- Use closed Pydantic Structured Output DTOs and real PDF File Inputs.
+- Generate opaque `document_id` values mapped to `pdf_info`, S3 key, and OpenAI file ID.
+- Reconcile unique identities regardless of order; fail closed on identity anomalies and refusal, incomplete, parse/schema, or API failures.
+- Source `ruta_s3`, category, and subcategory only from the trusted map.
+- Mark no-product, multi-product, or suspicious mismatch outcomes `needs_review` and block publication.
+- Test reconciliation and failure policy.
+
+### Out of Scope
+- Durable `needs_review` storage, UI, or S3 queue.
+- Published schema redesign, automatic multi-product curation, backend search, or unrelated LLM calls.
+- One-PDF-per-request, retained as a fallback.
+
+## Capabilities
+
+### New Capabilities
+- `catalog-pdf-extraction-integrity`: Typed File Input extraction, trusted identity reconciliation, review classification, and fail-closed publication.
+
+### Modified Capabilities
+- None. Existing specs omit catalog generation requirements.
+
+## Approach
+
+Build a keyed extraction envelope. Place each opaque ID beside its `input_file`, parse with Structured Outputs, and require exact ID set equality plus uniqueness before conversion. Accept arbitrary order. Treat one series with variants as normal; classify multi-product, no-product, and suspicious mismatches as `needs_review`. Structured Outputs enforces shape, not truth; trusted fields never come from the model.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|---|---|---|
+| `scripts/generate_index.py` | Modified | DTOs, File Inputs, identity map, reconciliation, failure policy |
+| `scripts/tests/test_generate_index.py` | Modified | Reconciliation and review-boundary coverage |
+| `docs/schemas/catalog_index.schema.json` | Unchanged | Publication validator |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Schema-valid metadata is semantically swapped | Medium | Detect suspicious mismatches; block publication; retain single-PDF fallback |
+| Extraction DTO diverges from publication schema | Medium | Separate contracts; validate conversion before publication |
+| Fail-closed runs publish no update | Medium | Emit source-specific diagnostics and return failure |
+| Change exceeds 400 review lines | Medium | Keep helpers focused; ask before splitting |
+
+## Rollback Plan
+
+Revert the extraction/reconciliation change; never publish failed or partially reconciled output.
+
+## Dependencies
+
+- Approved exploration in `exploration.md`.
+- Existing Pydantic v2 and OpenAI SDK; constrain the SDK only if required.
+
+## Success Criteria
+
+- [ ] Complete keyed batches reconcile correctly in any order.
+- [ ] Missing, unknown/extra, and duplicate IDs produce no catalog entries.
+- [ ] Refusal, incomplete, parse/schema, and API failures produce no fallback entries.
+- [ ] Trusted source fields cannot be overwritten by model output.
+- [ ] Series PDFs publish normally; no-product and multi-product outcomes are blocked as `needs_review`.

--- a/openspec/changes/preserve-pdf-extraction-identity/specs/catalog-pdf-extraction-integrity/spec.md
+++ b/openspec/changes/preserve-pdf-extraction-identity/specs/catalog-pdf-extraction-integrity/spec.md
@@ -1,0 +1,115 @@
+# Catalog PDF Extraction Integrity Specification
+
+## Purpose
+
+Define trustworthy identity, reconciliation, review, and publication for PDF catalog extraction.
+
+## Requirements
+
+### Requirement: Trusted expected identities
+
+The system MUST establish exactly one unique, application-owned identity per source PDF. Source path, category, and subcategory MUST come only from trusted records, never model output.
+
+#### Scenario: Trusted source fields are preserved
+
+- GIVEN a source identity mapped to trusted source fields
+- WHEN schema-valid extraction claims different source fields
+- THEN the system MUST retain the trusted values
+
+#### Scenario: Expected identities are not unique
+
+- GIVEN two source PDFs assigned the same expected identity
+- WHEN extraction begins
+- THEN the run MUST fail closed
+- AND MUST publish no catalog output
+
+### Requirement: Order-independent source association
+
+The system MUST associate extracted products with sources by identity, independent of order.
+
+#### Scenario: Complete batch returned out of order
+
+- GIVEN distinct expected identities for a complete PDF batch
+- WHEN one valid result per identity arrives in a different order
+- THEN every result MUST reconcile to its matching trusted source
+- AND order alone MUST NOT change publication eligibility
+
+### Requirement: Exact identity reconciliation
+
+Before conversion or publication, returned identities MUST be unique and exactly equal the expected set.
+
+#### Scenario: Identity set matches exactly
+
+- GIVEN unique expected and returned identity sets
+- WHEN both sets contain the same identities
+- THEN reconciliation MUST succeed
+
+#### Scenario: Identity anomaly
+
+- GIVEN a response with a missing, extra, unknown, or duplicate identity
+- WHEN reconciliation runs
+- THEN the run MUST fail closed
+- AND MUST publish no partial or fallback entries
+
+### Requirement: Structured output trust boundary
+
+Structured Outputs MUST guarantee shape only, not semantic correspondence between content and source identity.
+
+#### Scenario: Schema-valid suspicious mismatch
+
+- GIVEN schema-valid extracted content whose product evidence conflicts suspiciously with its trusted source
+- WHEN semantic classification runs
+- THEN the source MUST be classified `needs_review`
+- AND MUST NOT be published
+
+### Requirement: Product cardinality classification
+
+A single series with variants MUST be normal success. Multi-product, non-product, or suspicious mismatch results MUST be `needs_review` and MUST NOT be published.
+
+#### Scenario: Series with variants
+
+- GIVEN a reconciled PDF describing one product series with multiple variants
+- WHEN its extraction is complete and valid
+- THEN it MUST be treated as a normal successful extraction
+
+#### Scenario: Review-only source
+
+- GIVEN a reconciled PDF classified as multi-product, non-product, or suspiciously mismatched
+- WHEN publication eligibility is evaluated
+- THEN it MUST remain `needs_review`
+- AND no entry from that source MUST be published
+
+### Requirement: Fail-closed extraction
+
+The system MUST fail closed on refusal, incomplete output, schema/parse failure, or API failure, without inferred, partial, stale, or fallback entries.
+
+#### Scenario: Model response cannot be accepted
+
+- GIVEN a refusal, incomplete response, or schema or parse failure
+- WHEN the batch is evaluated
+- THEN the run MUST fail
+- AND MUST publish no output from the batch
+
+#### Scenario: Extraction API fails
+
+- GIVEN the extraction API returns an error or no acceptable response
+- WHEN the batch is evaluated
+- THEN the run MUST fail closed
+- AND MUST publish no fallback output
+
+### Requirement: Publication gate
+
+The system MUST publish only after successful reconciliation, completeness checks, semantic classification, conversion, and validation. It MUST NOT publish `needs_review` sources.
+
+#### Scenario: Fully valid publication
+
+- GIVEN all identities reconcile exactly and every candidate is complete, eligible, converted, and valid
+- WHEN publication is requested
+- THEN only validated eligible entries MUST be published
+
+#### Scenario: Validation fails after reconciliation
+
+- GIVEN identities reconcile but conversion or publication validation fails
+- WHEN publication is requested
+- THEN the run MUST fail closed
+- AND MUST publish no invalid or partial output

--- a/openspec/changes/preserve-pdf-extraction-identity/tasks.md
+++ b/openspec/changes/preserve-pdf-extraction-identity/tasks.md
@@ -1,0 +1,47 @@
+# Tasks: Preserve PDF Extraction Identity
+
+## Review Workload Forecast
+
+| Field | Value |
+|---|---|
+| Estimated changed lines | Unit 1 verified: 633 code+tests; Units 2–3 pending |
+| Suggested split | PR 1A → PR 1B → PR 1C → PR 2 → PR 3 |
+| Delivery strategy | ask-on-risk resolved; no `size:exception` |
+
+Decision needed before apply: No
+Chained PRs recommended: Yes
+Chain strategy: stacked-to-main
+400-line budget risk: High
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Notes |
+|---|---|---|---|
+| 1A | Closed contract: `ClosedDTO`, extraction DTOs, `TechnicalParameter`, recursive/deep-extra tests | PR 1A | Target `main`; tests; autonomous rollback |
+| 1B | Trusted reconciliation: `TrustedDocument`, opaque IDs, exact sets, order/anomaly tests | PR 1B | `main` after 1A; tests; autonomous rollback |
+| 1C | Review classification and trusted conversion: cardinality, mismatch, conversion, routing | PR 1C | `main` after 1B; tests; autonomous rollback |
+| 2 | Responses API and File Inputs | PR 2 | `main` after 1C; tests; autonomous rollback |
+| 3 | Publication gate | PR 3 | `main` after PR 2; tests; autonomous rollback |
+
+## Phase 1: Typed Identity and Reconciliation (Unit 1)
+
+- [x] 1.1 RED — Test closed DTO rejection, duplicate expected IDs, order-independent exact matching, and returned-ID anomalies in `scripts/tests/test_generate_index.py`.
+- [x] 1.2 GREEN — Implement closed extraction DTOs, `TrustedDocument`, exceptions, opaque-ID trusted map, and exact reconciliation in `scripts/generate_index.py`.
+- [x] 1.3 RED — Test trusted routing precedence, variants, and `needs_review` for zero, unrelated, or mismatched products.
+- [x] 1.4 GREEN — Implement cardinality/mismatch classification and trusted-only `build_product_entry()` conversion in `scripts/generate_index.py`.
+- [x] 1.5 REFACTOR — Consolidate typed fixtures/helpers while preserving focused reconciliation tests in both files.
+
+## Phase 2: File Inputs and Responses API (Unit 2)
+
+- [ ] 2.1 RED — Mock `client.files` and `client.responses.parse` to require adjacent opaque-ID `input_text` plus real `input_file` content and order-independent parsed output.
+- [ ] 2.2 GREEN — Replace Chat Completions JSON mode in `extract_metadata_batch()` with uploads, trusted map, `responses.parse(..., text_format=ExtractionBatch)`, reconciliation, and `finally` cleanup.
+- [ ] 2.3 RED — Cover refusal, incomplete status/reason, absent parsed output, schema/parse error, API error, and warning-only cleanup failure.
+- [ ] 2.4 GREEN — Fail closed with source-specific diagnostics for every unacceptable response; never synthesize fallback entries.
+- [ ] 2.5 REFACTOR — Verify the minimum OpenAI constraint; update `pyproject.toml` and `uv.lock` only if `responses.parse` requires it.
+
+## Phase 3: Publication Gate (Unit 3)
+
+- [ ] 3.1 RED — Add pipeline tests proving `needs_review`, download/extraction/protocol, conversion, and schema-validation failures return non-zero and call neither `save_local()` nor `upload_to_s3()`.
+- [ ] 3.2 GREEN — Update `run_pipeline()` to accumulate only complete normal batches, validate the full catalog, and publish atomically only after every gate succeeds.
+- [ ] 3.3 RED/GREEN — Adapt the successful local pipeline test to keyed results and prove only validated eligible entries publish with trusted routing fields.
+- [ ] 3.4 REFACTOR — Run `uv run pytest scripts/tests/test_generate_index.py` and `uv run ruff check scripts/generate_index.py scripts/tests/test_generate_index.py`; remove positional/fallback paths.

--- a/scripts/generate_index.py
+++ b/scripts/generate_index.py
@@ -24,12 +24,17 @@ import logging
 import os
 import re
 import sys
+import uuid
+from collections import Counter
+from dataclasses import dataclass
 from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 import boto3
 from botocore.exceptions import ClientError, NoCredentialsError
+from pydantic import BaseModel, ConfigDict, Field
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +54,231 @@ SUPPORTED_EXTENSIONS = {".pdf", ".PDF"}
 
 # Valid top-level categories
 VALID_CATEGORIES = {"paneles", "inversores", "controladores", "baterias"}
+
+
+# ---------------------------------------------------------------------------
+# Typed extraction boundary
+# ---------------------------------------------------------------------------
+
+
+class ClosedDTO(BaseModel):
+    """Base model for closed Structured Output contracts."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ExtractionStatus(str, Enum):
+    """Eligibility declared for a document extraction."""
+
+    NORMAL = "normal"
+    NEEDS_REVIEW = "needs_review"
+
+
+class TechnicalParameter(ClosedDTO):
+    """One closed, dynamically named technical parameter."""
+
+    name: str = Field(min_length=1)
+    value: str | int | float | bool
+
+
+class ExtractedVariant(ClosedDTO):
+    """One model variant extracted from a product-series PDF."""
+
+    modelo: str
+    parametros_clave: list[TechnicalParameter]
+
+
+class ExtractedProduct(ClosedDTO):
+    """Model-owned product metadata, including untrusted routing assertions."""
+
+    nombre_comercial: str
+    fabricante: str
+    descripcion: Optional[str]
+    url_fabricante: Optional[str]
+    version_ficha: Optional[str]
+    categoria: Optional[str]
+    subcategoria: Optional[str]
+    ruta_s3: Optional[str]
+    parametros_comunes: list[TechnicalParameter]
+    variantes: list[ExtractedVariant]
+
+
+class DocumentExtraction(ClosedDTO):
+    """Typed extraction result associated with one application-owned identity."""
+
+    document_id: str = Field(min_length=1)
+    status: ExtractionStatus
+    products: list[ExtractedProduct]
+    review_reasons: list[str]
+
+
+class ExtractionBatch(ClosedDTO):
+    """Typed result envelope for a complete extraction batch."""
+
+    documents: list[DocumentExtraction]
+
+
+@dataclass(frozen=True)
+class TrustedDocument:
+    """Application-owned source metadata for one uploaded PDF."""
+
+    s3_key: str
+    pdf_info: dict[str, Any]
+    file_id: str
+
+
+class ExtractionProtocolError(RuntimeError):
+    """Raised when extraction identities cannot be reconciled exactly."""
+
+
+class ExtractionNeedsReview(RuntimeError):
+    """Raised when reconciled content is not eligible for publication."""
+
+
+ReconciledProduct = tuple[ExtractedProduct, TrustedDocument]
+
+
+def build_trusted_map(
+    documents: list[TrustedDocument],
+    document_id_factory: Optional[Callable[[], str]] = None,
+) -> dict[str, TrustedDocument]:
+    """Assign one unique opaque identity to every trusted document.
+
+    Args:
+        documents: Uploaded documents carrying trusted source metadata.
+        document_id_factory: Optional injectable identity generator for tests.
+
+    Returns:
+        Trusted documents keyed by application-owned opaque identities.
+
+    Raises:
+        ExtractionProtocolError: If the identity generator returns a duplicate.
+    """
+    create_document_id = document_id_factory or (lambda: uuid.uuid4().hex)
+    trusted_map: dict[str, TrustedDocument] = {}
+
+    for document in documents:
+        document_id = create_document_id()
+        if document_id in trusted_map:
+            raise ExtractionProtocolError(
+                f"duplicate expected document_id: {document_id}"
+            )
+        trusted_map[document_id] = document
+
+    return trusted_map
+
+
+def reconcile_batch(
+    parsed: ExtractionBatch,
+    trusted_map: dict[str, TrustedDocument],
+) -> list[ReconciledProduct]:
+    """Reconcile a typed batch against trusted identities without using position.
+
+    Args:
+        parsed: Schema-validated extraction envelope.
+        trusted_map: Application-owned source records keyed by opaque identity.
+
+    Returns:
+        Product/source pairs in response order.
+
+    Raises:
+        ExtractionProtocolError: If expected and returned identities differ.
+    """
+    _validate_identity_sets(parsed, trusted_map)
+
+    reconciled: list[ReconciledProduct] = []
+    review_findings: list[str] = []
+    for document in parsed.documents:
+        trusted = trusted_map[document.document_id]
+        reasons = _review_reasons(document, trusted)
+        if reasons:
+            review_findings.append(
+                f"{document.document_id} ({trusted.s3_key}): {', '.join(reasons)}"
+            )
+            continue
+        reconciled.append((document.products[0], trusted))
+
+    if review_findings:
+        raise ExtractionNeedsReview("; ".join(review_findings))
+
+    return reconciled
+
+
+def _validate_identity_sets(
+    parsed: ExtractionBatch,
+    trusted_map: dict[str, TrustedDocument],
+) -> None:
+    """Reject duplicate or non-exact returned identity sets."""
+    returned_ids = [document.document_id for document in parsed.documents]
+    duplicate_ids = sorted(
+        document_id
+        for document_id, count in Counter(returned_ids).items()
+        if count > 1
+    )
+    if duplicate_ids:
+        raise ExtractionProtocolError(
+            f"duplicate returned document_id values: {duplicate_ids}"
+        )
+
+    expected_ids = set(trusted_map)
+    actual_ids = set(returned_ids)
+    missing_ids = sorted(expected_ids - actual_ids)
+    unknown_ids = sorted(actual_ids - expected_ids)
+    if missing_ids or unknown_ids:
+        raise ExtractionProtocolError(
+            "identity set mismatch: "
+            f"missing={missing_ids}, unknown/extra={unknown_ids}"
+        )
+
+
+def _review_reasons(
+    document: DocumentExtraction,
+    trusted: TrustedDocument,
+) -> list[str]:
+    """Classify review-only extraction outcomes for one trusted source."""
+    reasons = list(document.review_reasons)
+    if document.status == ExtractionStatus.NEEDS_REVIEW and not reasons:
+        reasons.append("model marked needs_review")
+
+    product_count = len(document.products)
+    if product_count == 0:
+        reasons.append("zero products")
+        return reasons
+    if product_count > 1:
+        reasons.append("multiple products")
+        return reasons
+
+    product = document.products[0]
+    if not product.variantes:
+        reasons.append("product has zero variants")
+
+    mismatched_fields = _routing_mismatches(product, trusted)
+    if mismatched_fields:
+        reasons.append(f"routing mismatch: {mismatched_fields}")
+
+    return reasons
+
+
+def _routing_mismatches(
+    product: ExtractedProduct,
+    trusted: TrustedDocument,
+) -> list[str]:
+    """Return model routing assertions that conflict with trusted source data."""
+    trusted_routing = {
+        "ruta_s3": trusted.s3_key,
+        "categoria": trusted.pdf_info.get("categoria"),
+        "subcategoria": trusted.pdf_info.get("subcategoria"),
+    }
+    model_routing = {
+        "ruta_s3": product.ruta_s3,
+        "categoria": product.categoria,
+        "subcategoria": product.subcategoria,
+    }
+    return sorted(
+        field
+        for field, asserted_value in model_routing.items()
+        if asserted_value is not None and asserted_value != trusted_routing[field]
+    )
 
 # ---------------------------------------------------------------------------
 # System prompt for AI extraction
@@ -443,27 +673,49 @@ def extract_metadata_batch(
 
 
 def build_product_entry(
-    extracted: dict[str, Any],
-    pdf_info: dict[str, str],
+    extracted: ExtractedProduct | dict[str, Any],
+    trusted: TrustedDocument | dict[str, Any],
 ) -> dict[str, Any]:
-    """Build a complete product entry combining extracted metadata and S3 info.
+    """Build a catalog entry using routing fields only from trusted source data.
 
     Args:
-        extracted: Metadata extracted by the LLM.
-        pdf_info: Info from S3 discovery (s3_key, categoria, subcategoria, etc.).
+        extracted: Model-owned product metadata.
+        trusted: Application-owned source record. Discovery mappings remain
+            supported until the transport boundary adopts ``TrustedDocument``.
 
     Returns:
         A product dict conforming to the catalog_index schema.
     """
-    nombre_comercial = extracted.get("nombre_comercial", pdf_info["nombre_comercial"])
+    if isinstance(extracted, ExtractedProduct):
+        extracted_data = extracted.model_dump()
+        extracted_data["parametros_comunes"] = _technical_parameters_to_mapping(
+            extracted.parametros_comunes
+        )
+        extracted_data["variantes"] = [
+            {
+                "modelo": variant.modelo,
+                "parametros_clave": _technical_parameters_to_mapping(
+                    variant.parametros_clave
+                ),
+            }
+            for variant in extracted.variantes
+        ]
+    else:
+        extracted_data = extracted
+    pdf_info = trusted.pdf_info if isinstance(trusted, TrustedDocument) else trusted
+    s3_key = trusted.s3_key if isinstance(trusted, TrustedDocument) else pdf_info["s3_key"]
+
+    nombre_comercial = extracted_data.get(
+        "nombre_comercial", pdf_info["nombre_comercial"]
+    )
     producto_id = _slugify(nombre_comercial)
 
     entry: dict[str, Any] = {
         "id": producto_id,
         "nombre_comercial": nombre_comercial,
         "categoria": pdf_info["categoria"],
-        "fabricante": extracted.get("fabricante", "Desconocido"),
-        "ruta_s3": pdf_info["s3_key"],
+        "fabricante": extracted_data.get("fabricante", "Desconocido"),
+        "ruta_s3": s3_key,
         "fecha_ingesta": datetime.now(timezone.utc).isoformat(),
     }
 
@@ -471,23 +723,30 @@ def build_product_entry(
     if pdf_info.get("subcategoria"):
         entry["subcategoria"] = pdf_info["subcategoria"]
 
-    if extracted.get("descripcion"):
-        entry["descripcion"] = extracted["descripcion"]
+    if extracted_data.get("descripcion"):
+        entry["descripcion"] = extracted_data["descripcion"]
 
-    if extracted.get("url_fabricante"):
-        entry["url_fabricante"] = extracted["url_fabricante"]
+    if extracted_data.get("url_fabricante"):
+        entry["url_fabricante"] = extracted_data["url_fabricante"]
 
-    if extracted.get("version_ficha"):
-        entry["version_ficha"] = extracted["version_ficha"]
+    if extracted_data.get("version_ficha"):
+        entry["version_ficha"] = extracted_data["version_ficha"]
 
     # Add parametros_comunes
-    if extracted.get("parametros_comunes"):
-        entry["parametros_comunes"] = extracted["parametros_comunes"]
+    if extracted_data.get("parametros_comunes"):
+        entry["parametros_comunes"] = extracted_data["parametros_comunes"]
 
     # Add variantes
-    entry["variantes"] = extracted.get("variantes", [])
+    entry["variantes"] = extracted_data.get("variantes", [])
 
     return entry
+
+
+def _technical_parameters_to_mapping(
+    parameters: list[TechnicalParameter],
+) -> dict[str, str | int | float | bool]:
+    """Convert closed extraction pairs to the publication mapping shape."""
+    return {parameter.name: parameter.value for parameter in parameters}
 
 
 def build_catalog_index(

--- a/scripts/tests/test_generate_index.py
+++ b/scripts/tests/test_generate_index.py
@@ -8,6 +8,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 # Add scripts directory to path for import
 import sys
@@ -15,13 +16,22 @@ import sys
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from generate_index import (
+    DocumentExtraction,
+    ExtractedProduct,
+    ExtractionBatch,
+    ExtractionNeedsReview,
+    ExtractionProtocolError,
+    ExtractionStatus,
     MAX_BATCH_SIZE,
+    TrustedDocument,
     _parse_s3_key,
     _slugify,
     build_catalog_index,
     build_product_entry,
+    build_trusted_map,
     filter_new_pdfs,
     list_local_pdfs,
+    reconcile_batch,
     save_local,
     validate_index,
 )
@@ -168,6 +178,334 @@ def schema_path() -> str:
     if schema.exists():
         return str(schema)
     pytest.skip("Schema file not found")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: typed extraction identity and reconciliation
+# ---------------------------------------------------------------------------
+
+
+def _extracted_product(name: str = "Jinko Tiger Pro") -> ExtractedProduct:
+    return ExtractedProduct(
+        nombre_comercial=name,
+        fabricante="Jinko",
+        descripcion=None,
+        url_fabricante=None,
+        version_ficha=None,
+        categoria="paneles",
+        subcategoria=None,
+        ruta_s3=f"raw/paneles/{name}.pdf",
+        parametros_comunes=[
+            {"name": "tipo_celda", "value": "monocristalino"}
+        ],
+        variantes=[
+            {
+                "modelo": "Tiger Pro 460W",
+                "parametros_clave": [{"name": "potencia_w", "value": 460}],
+            }
+        ],
+    )
+
+
+def _document_extraction(
+    document_id: str,
+    product_name: str = "Jinko Tiger Pro",
+) -> DocumentExtraction:
+    return DocumentExtraction(
+        document_id=document_id,
+        status=ExtractionStatus.NORMAL,
+        products=[_extracted_product(product_name)],
+        review_reasons=[],
+    )
+
+
+def _trusted_document(name: str) -> TrustedDocument:
+    s3_key = f"raw/paneles/{name}.pdf"
+    return TrustedDocument(
+        s3_key=s3_key,
+        pdf_info={
+            "s3_key": s3_key,
+            "filename": name,
+            "categoria": "paneles",
+            "subcategoria": None,
+            "nombre_comercial": name,
+        },
+        file_id=f"file-{name.lower().replace(' ', '-')}",
+    )
+
+
+def _assert_schema_objects_closed(node: Any, path: str = "$") -> None:
+    """Assert recursively that every JSON Schema object forbids extra fields."""
+    if isinstance(node, dict):
+        if node.get("type") == "object":
+            assert node.get("additionalProperties") is False, path
+        for key, value in node.items():
+            _assert_schema_objects_closed(value, f"{path}.{key}")
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            _assert_schema_objects_closed(value, f"{path}[{index}]")
+
+
+class TestExtractionDtos:
+    def test_generated_schema_closes_every_object_node(self) -> None:
+        _assert_schema_objects_closed(ExtractionBatch.model_json_schema())
+
+    def test_batch_rejects_unknown_fields(self) -> None:
+        with pytest.raises(ValidationError):
+            ExtractionBatch.model_validate({"documents": [], "unexpected": True})
+
+    def test_document_rejects_unknown_fields(self) -> None:
+        payload = _document_extraction("doc-a").model_dump()
+        payload["unexpected"] = True
+
+        with pytest.raises(ValidationError):
+            DocumentExtraction.model_validate(payload)
+
+    def test_nested_product_rejects_unknown_fields(self) -> None:
+        payload = _extracted_product().model_dump()
+        payload["invented"] = "not allowed"
+
+        with pytest.raises(ValidationError):
+            ExtractedProduct.model_validate(payload)
+
+    def test_variant_rejects_unknown_fields(self) -> None:
+        payload = _extracted_product().variantes[0].model_dump()
+        payload["unexpected"] = True
+
+        with pytest.raises(ValidationError):
+            type(_extracted_product().variantes[0]).model_validate(payload)
+
+    def test_accepts_typed_technical_parameter_pairs(self) -> None:
+        payload = _extracted_product().model_dump()
+        payload["parametros_comunes"] = [
+            {"name": "tipo_celda", "value": "monocristalino"}
+        ]
+        payload["variantes"][0]["parametros_clave"] = [
+            {"name": "potencia_w", "value": 460}
+        ]
+
+        product = ExtractedProduct.model_validate(payload)
+
+        assert product.parametros_comunes[0].name == "tipo_celda"
+        assert product.parametros_comunes[0].value == "monocristalino"
+        assert product.variantes[0].parametros_clave[0].name == "potencia_w"
+        assert product.variantes[0].parametros_clave[0].value == 460
+
+    @pytest.mark.parametrize(
+        ("field", "expected_location"),
+        [
+            ("parametros_comunes", ("parametros_comunes", 0, "unexpected")),
+            (
+                "parametros_clave",
+                ("variantes", 0, "parametros_clave", 0, "unexpected"),
+            ),
+        ],
+    )
+    def test_technical_parameter_rejects_unknown_fields(
+        self,
+        field: str,
+        expected_location: tuple[str | int, ...],
+    ) -> None:
+        payload = _extracted_product().model_dump()
+        parameter = {"name": "rating", "value": 460, "unexpected": True}
+        if field == "parametros_comunes":
+            payload[field] = [parameter]
+        else:
+            payload["variantes"][0][field] = [parameter]
+
+        with pytest.raises(ValidationError) as error:
+            ExtractedProduct.model_validate(payload)
+
+        assert error.value.errors()[0]["loc"] == expected_location
+
+
+class TestTrustedMap:
+    def test_duplicate_expected_ids_fail_closed(self) -> None:
+        documents = [_trusted_document("Series A"), _trusted_document("Series B")]
+
+        with pytest.raises(ExtractionProtocolError, match="duplicate expected"):
+            build_trusted_map(documents, document_id_factory=lambda: "same-id")
+
+
+class TestReconcileBatch:
+    def test_exact_identity_set_reconciles(self) -> None:
+        trusted_map = {"doc-a": _trusted_document("Jinko Tiger Pro")}
+        parsed = ExtractionBatch(documents=[_document_extraction("doc-a")])
+
+        reconciled = reconcile_batch(parsed, trusted_map)
+
+        assert reconciled == [
+            (parsed.documents[0].products[0], trusted_map["doc-a"])
+        ]
+
+    def test_complete_out_of_order_batch_reconciles_by_identity(self) -> None:
+        trusted_map = {
+            "doc-a": _trusted_document("Series A"),
+            "doc-b": _trusted_document("Series B"),
+        }
+        parsed = ExtractionBatch(
+            documents=[
+                _document_extraction("doc-b", "Series B"),
+                _document_extraction("doc-a", "Series A"),
+            ]
+        )
+
+        reconciled = reconcile_batch(parsed, trusted_map)
+
+        assert [trusted.s3_key for _, trusted in reconciled] == [
+            "raw/paneles/Series B.pdf",
+            "raw/paneles/Series A.pdf",
+        ]
+
+    @pytest.mark.parametrize(
+        ("expected_ids", "returned_ids", "message"),
+        [
+            (("doc-a", "doc-b"), ("doc-a",), "missing"),
+            (("doc-a",), ("doc-a", "doc-extra"), "extra"),
+            (("doc-a", "doc-b"), ("doc-a", "doc-unknown"), "unknown"),
+        ],
+    )
+    def test_identity_set_anomalies_fail_closed(
+        self,
+        expected_ids: tuple[str, ...],
+        returned_ids: tuple[str, ...],
+        message: str,
+    ) -> None:
+        trusted_map = {
+            document_id: _trusted_document(f"Series {index}")
+            for index, document_id in enumerate(expected_ids)
+        }
+        parsed = ExtractionBatch(
+            documents=[_document_extraction(document_id) for document_id in returned_ids]
+        )
+
+        with pytest.raises(ExtractionProtocolError, match=message):
+            reconcile_batch(parsed, trusted_map)
+
+    def test_duplicate_returned_id_fails_closed(self) -> None:
+        trusted_map = {"doc-a": _trusted_document("Series A")}
+        parsed = ExtractionBatch(
+            documents=[
+                _document_extraction("doc-a"),
+                _document_extraction("doc-a"),
+            ]
+        )
+
+        with pytest.raises(ExtractionProtocolError, match="duplicate returned"):
+            reconcile_batch(parsed, trusted_map)
+
+
+class TestExtractionClassification:
+    def test_one_series_with_multiple_variants_is_normal(self) -> None:
+        product = ExtractedProduct.model_validate(
+            {
+                **_extracted_product().model_dump(),
+                "variantes": [
+                    {
+                        "modelo": "Tiger Pro 460W",
+                        "parametros_clave": [
+                            {"name": "potencia_w", "value": 460}
+                        ],
+                    },
+                    {
+                        "modelo": "Tiger Pro 470W",
+                        "parametros_clave": [
+                            {"name": "potencia_w", "value": 470}
+                        ],
+                    },
+                ],
+            }
+        )
+        document = _document_extraction("doc-a").model_copy(
+            update={"products": [product]}
+        )
+        trusted = _trusted_document("Jinko Tiger Pro")
+
+        reconciled = reconcile_batch(
+            ExtractionBatch(documents=[document]), {"doc-a": trusted}
+        )
+
+        assert [variant.modelo for variant in reconciled[0][0].variantes] == [
+            "Tiger Pro 460W",
+            "Tiger Pro 470W",
+        ]
+
+    def test_zero_products_needs_review(self) -> None:
+        document = _document_extraction("doc-a").model_copy(update={"products": []})
+
+        with pytest.raises(ExtractionNeedsReview, match="zero products"):
+            reconcile_batch(
+                ExtractionBatch(documents=[document]),
+                {"doc-a": _trusted_document("Jinko Tiger Pro")},
+            )
+
+    def test_product_with_zero_variants_needs_review(self) -> None:
+        product = _extracted_product().model_copy(update={"variantes": []})
+        document = _document_extraction("doc-a").model_copy(
+            update={"products": [product]}
+        )
+
+        with pytest.raises(ExtractionNeedsReview, match="zero variants"):
+            reconcile_batch(
+                ExtractionBatch(documents=[document]),
+                {"doc-a": _trusted_document("Jinko Tiger Pro")},
+            )
+
+    def test_multiple_unrelated_products_need_review(self) -> None:
+        document = _document_extraction("doc-a").model_copy(
+            update={
+                "products": [
+                    _extracted_product("Jinko Tiger Pro"),
+                    _extracted_product("Unrelated Series"),
+                ]
+            }
+        )
+
+        with pytest.raises(ExtractionNeedsReview, match="multiple products"):
+            reconcile_batch(
+                ExtractionBatch(documents=[document]),
+                {"doc-a": _trusted_document("Jinko Tiger Pro")},
+            )
+
+    def test_suspicious_routing_mismatch_needs_review(self) -> None:
+        product = _extracted_product().model_copy(
+            update={
+                "categoria": "baterias",
+                "subcategoria": "litio",
+                "ruta_s3": "raw/baterias/litio/Other.pdf",
+            }
+        )
+        document = _document_extraction("doc-a").model_copy(
+            update={"products": [product]}
+        )
+
+        with pytest.raises(ExtractionNeedsReview, match="routing mismatch"):
+            reconcile_batch(
+                ExtractionBatch(documents=[document]),
+                {"doc-a": _trusted_document("Jinko Tiger Pro")},
+            )
+
+
+class TestTrustedProductConversion:
+    def test_trusted_routing_fields_override_model_claims(self) -> None:
+        extracted = _extracted_product().model_copy(
+            update={
+                "categoria": "baterias",
+                "subcategoria": "litio",
+                "ruta_s3": "raw/baterias/litio/Other.pdf",
+            }
+        )
+        trusted = _trusted_document("Jinko Tiger Pro")
+
+        entry = build_product_entry(extracted, trusted)
+
+        assert entry["ruta_s3"] == "raw/paneles/Jinko Tiger Pro.pdf"
+        assert entry["categoria"] == "paneles"
+        assert "subcategoria" not in entry
+        assert entry["parametros_comunes"] == {
+            "tipo_celda": "monocristalino"
+        }
+        assert entry["variantes"][0]["parametros_clave"] == {"potencia_w": 460}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #227

## Summary
- Introduce closed Pydantic extraction DTOs and typed technical parameters.
- Reconcile model results with application-owned PDF identities instead of response order.
- Preserve trusted routing fields and classify ambiguous extraction results for review.

## Changes
| File | Change |
|---|---|
| `scripts/generate_index.py` | Add typed extraction contracts, trusted identities, exact reconciliation, review classification, and trusted conversion. |
| `scripts/tests/test_generate_index.py` | Add strict-TDD coverage for closed schemas, identity anomalies, trusted routing, and cardinality. |
| `openspec/changes/preserve-pdf-extraction-identity/` | Add approved SDD exploration, proposal, spec, design, tasks, and apply evidence. |

## Test plan
- [x] `uv run pytest scripts/tests/test_generate_index.py` — 51 passed.
- [x] Unit 1 focused verification — 21 passed.
- [x] `git diff --check`.
- [ ] Ruff unavailable through `uv` in the current environment.

## Chain context
```text
📍 PR 1 — typed identity and deterministic reconciliation
   PR 2 — Responses API and real File Inputs
   PR 3 — fail-closed publication gate
```

This PR targets `main`. PR 2 starts from updated `main` only after this PR merges.

## Size exception
Maintainer-approved `size:exception`: the PR includes 633 code/test changed lines plus traceable OpenSpec artifacts. Splitting the tightly coupled strict schema, reconciliation, conversion, and TDD evidence would weaken reviewability.

## Checklist
- [x] Linked approved issue #227.
- [x] Exactly one `type:*` label will be applied.
- [x] Conventional commit used; no AI attribution.
- [x] Tests remain with the behavior they verify.
- [x] Unrelated package-lock changes excluded.