### PR TITLE
fix(state): enforce local pending consume-once semantics

### DIFF
--- a/backend/app/message_buffer.py
+++ b/backend/app/message_buffer.py
@@ -12,6 +12,7 @@ flush due buffers instead of relying on ``asyncio.create_task`` after response.
 import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
+from threading import RLock
 from typing import Awaitable, Callable, Optional
 
 from backend.app.state_repository import ChatbotStateRepository
@@ -34,6 +35,10 @@ _pending_chat_responses: dict[str, tuple[str, datetime]] = {}
 
 # Sessions whose buffer was flushed and are being processed in background
 _processing_sessions: dict[str, datetime] = {}
+
+# Pending delivery and processing state share one lock so consumption and marker
+# cleanup are one in-process operation.
+_pending_state_lock = RLock()
 
 
 def set_state_repository(
@@ -86,8 +91,8 @@ async def add_to_buffer(
 async def flush_buffer(session_id: str) -> Optional[str]:
     """Flush buffer and return joined message. None if empty.
 
-    Also stores the result in _pending_results so callers can retrieve it
-    after the async window expiration callback fires.
+    Local mode clears stale pending delivery state before returning the joined
+    value to its caller. Repository mode stores the joined value for polling.
 
     Args:
         session_id: The session identifier.
@@ -106,19 +111,20 @@ async def flush_buffer(session_id: str) -> Optional[str]:
         _state_repository.clear_processing(session_id)
         return joined
 
-    messages = _buffer.pop(session_id, [])
+    buffered_entries = _buffer.pop(session_id, [])
     task = _buffer_tasks.pop(session_id, None)
     current_task = asyncio.current_task()
     if task and task is not current_task and not task.done():
         task.cancel()
-    if not messages:
+    if not buffered_entries:
         return None
-    joined = "\n".join(msg for msg, _ in messages)
+    joined = "\n".join(msg for msg, _ in buffered_entries)
     # Clean up stale state from previous flushes to prevent memory leaks
     # and avoid false "not_found" responses while background processing runs.
-    _pending_results.pop(session_id, None)
-    _pending_chat_responses.pop(session_id, None)
-    _processing_sessions.pop(session_id, None)
+    with _pending_state_lock:
+        _pending_results.pop(session_id, None)
+        _pending_chat_responses.pop(session_id, None)
+        _processing_sessions.pop(session_id, None)
     return joined
 
 
@@ -168,6 +174,9 @@ def clear_buffer(session_id: str) -> None:
     task = _buffer_tasks.pop(session_id, None)
     if task and not task.done():
         task.cancel()
+    with _pending_state_lock:
+        _pending_results.pop(session_id, None)
+        _processing_sessions.pop(session_id, None)
 
 
 def pop_pending_result(session_id: str) -> Optional[str]:
@@ -185,10 +194,21 @@ def pop_pending_result(session_id: str) -> Optional[str]:
     if _state_repository is not None:
         return _state_repository.pop_pending_result(session_id)
 
-    result = _pending_results.pop(session_id, None)
-    if result:
-        return result[0]
-    return None
+    with _pending_state_lock:
+        result = _pending_results.pop(session_id, None)
+        return result[0] if result is not None else None
+
+
+def set_pending_result(session_id: str, joined_message: str) -> None:
+    """Store a joined buffer result for consume-once polling."""
+    if _state_repository is not None:
+        _state_repository.set_pending_result(session_id, joined_message)
+        return
+    with _pending_state_lock:
+        _pending_results[session_id] = (
+            joined_message,
+            datetime.now(timezone.utc),
+        )
 
 
 def set_pending_chat_response(session_id: str, response_json: str) -> None:
@@ -201,7 +221,11 @@ def set_pending_chat_response(session_id: str, response_json: str) -> None:
     if _state_repository is not None:
         _state_repository.set_pending_chat_response(session_id, response_json)
         return
-    _pending_chat_responses[session_id] = (response_json, datetime.now(timezone.utc))
+    with _pending_state_lock:
+        _pending_chat_responses[session_id] = (
+            response_json,
+            datetime.now(timezone.utc),
+        )
 
 
 def pop_pending_chat_response(session_id: str) -> Optional[str]:
@@ -216,10 +240,12 @@ def pop_pending_chat_response(session_id: str) -> Optional[str]:
     if _state_repository is not None:
         return _state_repository.pop_pending_chat_response(session_id)
 
-    result = _pending_chat_responses.pop(session_id, None)
-    if result:
+    with _pending_state_lock:
+        result = _pending_chat_responses.pop(session_id, None)
+        if result is None:
+            return None
+        _processing_sessions.pop(session_id, None)
         return result[0]
-    return None
 
 
 def clear_pending_chat_response(session_id: str) -> None:
@@ -233,8 +259,9 @@ def clear_pending_chat_response(session_id: str) -> None:
         _state_repository.clear_processing(session_id)
         return
 
-    _pending_chat_responses.pop(session_id, None)
-    _processing_sessions.pop(session_id, None)
+    with _pending_state_lock:
+        _pending_chat_responses.pop(session_id, None)
+        _processing_sessions.pop(session_id, None)
 
 
 def set_processing(session_id: str) -> None:
@@ -246,7 +273,8 @@ def set_processing(session_id: str) -> None:
     if _state_repository is not None:
         _state_repository.set_processing(session_id)
         return
-    _processing_sessions[session_id] = datetime.now(timezone.utc)
+    with _pending_state_lock:
+        _processing_sessions[session_id] = datetime.now(timezone.utc)
 
 
 def clear_processing(session_id: str) -> None:
@@ -258,7 +286,8 @@ def clear_processing(session_id: str) -> None:
     if _state_repository is not None:
         _state_repository.clear_processing(session_id)
         return
-    _processing_sessions.pop(session_id, None)
+    with _pending_state_lock:
+        _processing_sessions.pop(session_id, None)
 
 
 def is_processing(session_id: str) -> bool:
@@ -275,7 +304,8 @@ def is_processing(session_id: str) -> bool:
             _state_repository.get_buffer_state(session_id).processing_started_at
             is not None
         )
-    return session_id in _processing_sessions
+    with _pending_state_lock:
+        return session_id in _processing_sessions
 
 
 def is_buffer_ready_to_flush(
@@ -297,10 +327,10 @@ def is_buffer_ready_to_flush(
         last_message_at = _to_utc(messages[-1].timestamp)
         return current_time >= last_message_at + timedelta(seconds=window_seconds)
 
-    messages = _buffer.get(session_id, [])
-    if not messages:
+    buffered_entries = _buffer.get(session_id, [])
+    if not buffered_entries:
         return False
-    last_message_at = _to_utc(messages[-1][1])
+    last_message_at = _to_utc(buffered_entries[-1][1])
     return current_time >= last_message_at + timedelta(seconds=window_seconds)
 
 

--- a/backend/app/state_repository.py
+++ b/backend/app/state_repository.py
@@ -118,13 +118,23 @@ class ChatbotStateRepository(Protocol):
         """Persist a joined buffer result for polling."""
 
     def pop_pending_result(self, session_id: str) -> Optional[str]:
-        """Atomically consume a pending joined buffer result."""
+        """Consume a stored string once; return None when none is pending.
+
+        At most one concurrent caller receives the value. An empty string is a
+        pending value rather than absence.
+        """
 
     def set_pending_chat_response(self, session_id: str, response_json: str) -> None:
         """Persist a processed chat response for polling."""
 
     def pop_pending_chat_response(self, session_id: str) -> Optional[str]:
-        """Atomically consume a pending chat response."""
+        """Consume a stored string once and clear its processing marker.
+
+        At most one concurrent caller receives the stored string. An empty string
+        is a pending value; ``None`` means that no string was available. The
+        winning consume removes the marker in the same operation; an absent
+        response leaves the marker unchanged.
+        """
 
     def set_processing(self, session_id: str) -> None:
         """Mark a flushed session as being processed."""

--- a/backend/app/tests/test_message_buffer.py
+++ b/backend/app/tests/test_message_buffer.py
@@ -7,7 +7,9 @@ Strict TDD: tests written BEFORE implementation.
 """
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
+from threading import Barrier
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -50,6 +52,9 @@ def _clean_buffer_state() -> None:
 
         message_buffer._buffer.clear()
         message_buffer._buffer_tasks.clear()
+        message_buffer._pending_results.clear()
+        message_buffer._pending_chat_responses.clear()
+        message_buffer._processing_sessions.clear()
     except ImportError:
         pass
     yield
@@ -58,6 +63,9 @@ def _clean_buffer_state() -> None:
 
         message_buffer._buffer.clear()
         message_buffer._buffer_tasks.clear()
+        message_buffer._pending_results.clear()
+        message_buffer._pending_chat_responses.clear()
+        message_buffer._processing_sessions.clear()
     except ImportError:
         pass
 
@@ -450,6 +458,65 @@ class TestDurableBufferState:
         assert repo.pop_pending_chat_response("s1") == '{"response":"ok"}'
         assert repo.pop_pending_chat_response("s1") is None
         assert repo.get_buffer_state("s1").processing_started_at is None
+
+
+class TestLocalPendingState:
+    """Local pending delivery matches the durable consume-once contract."""
+
+    @pytest.mark.parametrize("value", ["ready", ""])
+    def test_pending_result_is_consumed_once(self, value: str) -> None:
+        from backend.app import message_buffer
+
+        message_buffer.set_pending_result("s1", value)
+
+        assert message_buffer.pop_pending_result("s1") == value
+        assert message_buffer.pop_pending_result("s1") is None
+
+    @pytest.mark.parametrize("value", ['{"response":"ok"}', ""])
+    def test_pending_chat_response_is_consumed_once_and_clears_processing(
+        self, value: str
+    ) -> None:
+        from backend.app import message_buffer
+
+        message_buffer.set_processing("s1")
+        message_buffer.set_pending_chat_response("s1", value)
+
+        assert message_buffer.pop_pending_chat_response("s1") == value
+        assert message_buffer.is_processing("s1") is False
+        assert message_buffer.pop_pending_chat_response("s1") is None
+
+    def test_missing_chat_response_does_not_clear_processing(self) -> None:
+        from backend.app import message_buffer
+
+        message_buffer.set_processing("s1")
+
+        assert message_buffer.pop_pending_chat_response("s1") is None
+        assert message_buffer.is_processing("s1") is True
+
+    @pytest.mark.parametrize(
+        ("setter_name", "popper_name"),
+        [
+            ("set_pending_result", "pop_pending_result"),
+            ("set_pending_chat_response", "pop_pending_chat_response"),
+        ],
+    )
+    def test_concurrent_consumers_have_exactly_one_winner(
+        self, setter_name: str, popper_name: str
+    ) -> None:
+        from backend.app import message_buffer
+
+        getattr(message_buffer, setter_name)("s1", "ready")
+        barrier = Barrier(8)
+
+        def consume() -> str | None:
+            barrier.wait()
+            return getattr(message_buffer, popper_name)("s1")
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            results = list(executor.map(lambda _: consume(), range(8)))
+
+        assert results.count("ready") == 1
+        assert results.count(None) == 7
 
 
 # ===========================================================================

--- a/backend/main.py
+++ b/backend/main.py
@@ -1759,7 +1759,7 @@ async def get_buffer_result(
     bind_or_validate_session(session_id, principal, is_new=False)
 
     chat_response_json = pop_pending_chat_response(session_id)
-    if chat_response_json:
+    if chat_response_json is not None:
         return BufferResultResponse(
             status="ready",
             session_id=session_id,
@@ -1775,7 +1775,7 @@ async def get_buffer_result(
             if joined_message:
                 await _on_buffer_window_expired(session_id, joined_message)
                 chat_response_json = pop_pending_chat_response(session_id)
-                if chat_response_json:
+                if chat_response_json is not None:
                     return BufferResultResponse(
                         status="ready",
                         session_id=session_id,

--- a/backend/tests/test_security_hardening.py
+++ b/backend/tests/test_security_hardening.py
@@ -50,7 +50,7 @@ def test_buffer_result_returns_owned_pending_response(monkeypatch) -> None:
     session_id = "session-owned-ready"
     principal = api_key_principal("test-secret")
     session_manager.bind_session(session_id, principal)
-    set_pending_chat_response(session_id, '{"response":"ok"}')
+    set_pending_chat_response(session_id, "")
 
     response = client.get(
         f"/buffer-result/{session_id}",
@@ -59,7 +59,7 @@ def test_buffer_result_returns_owned_pending_response(monkeypatch) -> None:
 
     assert response.status_code == 200
     assert response.json()["status"] == "ready"
-    assert response.json()["result"] == '{"response":"ok"}'
+    assert response.json()["result"] == ""
 
 
 def test_chat_rejects_unknown_client_session_id(monkeypatch) -> None:


### PR DESCRIPTION
## ¿Qué hace este PR?

Garantiza consumo único de resultados y respuestas pendientes en el repositorio local. Serializa set, pop y limpieza bajo un mismo `RLock`, preserva la diferencia entre ausencia y string vacío, y alinea los callers con ese contrato.

## Issues relacionados

Closes #233

## Tipo de cambio

- [ ] 🆕 Nueva funcionalidad (feature)
- [x] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [ ] 🧪 Tests
- [ ] 📄 Documentación / configuración
- [ ] 🔧 Infra / CI

## Checklist antes de pedir review

- [x] El código corre localmente sin errores (`uvicorn` levanta, tests pasan)
- [x] Los criterios de aceptación correspondientes a esta unidad están cumplidos
- [x] No hay credenciales, API keys ni rutas absolutas hardcodeadas
- [x] No se agregaron dependencias nuevas
- [x] No se modificó el schema del endpoint
- [x] No se modificó el harness ni el dataset

## Cómo probar este PR

1. Ejecutar `OPENAI_API_KEY=test CHAT_API_KEY=test uv run pytest -q backend/app/tests/test_message_buffer.py backend/tests/test_security_hardening.py`.
2. Verificar que consumidores concurrentes obtengan exactamente un valor y el resto `None`.
3. Verificar que `""` se entregue una vez y no se confunda con ausencia.

## Chain Context

Estrategia: stacked-to-main. Presupuesto: **167 líneas cambiadas**.

```text
📍 PR 1: local consume-once → main
   PR 2: DynamoDB atomic consume → PR 1; retarget a main después del merge de PR 1
   PR 3: preserve pending state → PR 2; retarget a main después del merge de PR 2
```

- Inicio: comportamiento local previo sin sección crítica compartida.
- Fin: consumo único local y contrato explícito.
- Dependencias previas: ninguna.
- Siguiente unidad: consumo atómico DynamoDB.
- Fuera de alcance: escritores DynamoDB de `BUFFER`, cubiertos por PR 2 y PR 3.

## Notas para el reviewer

Este PR es la primera unidad de una cadena de tres. Los tests permanecen junto al comportamiento que verifican.