### PR TITLE
fix(catalog): use structured PDF file inputs

### DIFF
--- a/openspec/changes/preserve-pdf-extraction-identity/apply-progress.md
+++ b/openspec/changes/preserve-pdf-extraction-identity/apply-progress.md
@@ -4,10 +4,10 @@
 
 - Mode: Strict TDD
 - Delivery: stacked-to-main
-- Current unit: Unit 1 implementation complete; PR separation pending
-- Scope: tasks 1.1–1.5 only
-- Verification status: PASS WITH WARNINGS
-- PR gate: split 633-line Unit 1 into PR 1A/1B/1C before commit or PR
+- Current unit: Unit 2 verification corrections complete
+- Scope: cumulative tasks 1.1–2.5; active slice tasks 2.1–2.5
+- Verification status: PASS WITH RUFF UNAVAILABLE
+- PR gate: Unit 2 autonomous at 400 changed lines; no `size:exception`
 - Rollback boundary: each slice reverts independently
 
 ## Required PR Separation
@@ -34,6 +34,11 @@ PR 1C; PR 3 starts from `main` after PR 2.
 - [x] 1.3 RED — Trusted routing, cardinality, variants, and mismatch tests.
 - [x] 1.4 GREEN — Review classification and trusted-only conversion.
 - [x] 1.5 REFACTOR — Consolidated typed helpers with behavior preserved.
+- [x] 2.1 RED — Mocked adjacent opaque-ID/File Input request pairs and out-of-order output.
+- [x] 2.2 GREEN — Migrated extraction to Files uploads and Responses Structured Outputs.
+- [x] 2.3 RED — Covered refusal, incomplete, absent parsed output, parse/API, and cleanup failures.
+- [x] 2.4 GREEN — Added source-specific fail-closed response validation without fallbacks.
+- [x] 2.5 REFACTOR — Verified OpenAI 1.68.0 supports `responses.parse(text_format=...)`.
 
 ## TDD Cycle Evidence
 
@@ -44,6 +49,11 @@ PR 1C; PR 3 starts from `main` after PR 2.
 | 1.3 | `scripts/tests/test_generate_index.py` | Unit | 9/9 identity tests | 4 failed and 1 passed before classification/conversion | 5/5 classification/conversion tests passed in 1.4 | Normal variants, zero, multiple, mismatch, and trusted precedence | 14/14 Unit 1 tests passed after typed helper consolidation |
 | 1.4 | `scripts/tests/test_generate_index.py` | Unit | 9/9 identity tests | Tests from 1.3 preceded production code | 5/5 classification/conversion tests passed | Cardinality and routing mismatch take distinct paths | 14/14 Unit 1 tests passed after `_review_reasons()`/routing helper cleanup |
 | 1.5 | `scripts/tests/test_generate_index.py` | Unit/refactor | 44/44 approval baseline | N/A — behavior-preserving refactor | 14/14 focused tests passed | Existing 14-case Unit 1 matrix preserved | 44/44 final tests passed |
+| 2.1 | `scripts/tests/test_generate_index.py` | Unit/SDK request | 51/51 baseline | Initial transport RED plus correction RED (8 failed, 1 passed) preceded fixes | Upload bytes/purpose, no Chat Completions, adjacent opaque pairs, and reversed output pass | Two uploads and partial-upload cleanup covered | 9/9 focused tests passed |
+| 2.2 | `scripts/tests/test_generate_index.py` | Unit/transport | 51/51 baseline | Real pipeline probe reproduced tuple caller failure and `Desconocido` fallback | Typed reconciliation converts internally to input-ordered legacy mappings | Reversed model output and realistic caller probe pass | 9/9 focused tests passed |
+| 2.3 | `scripts/tests/test_generate_index.py` | Unit/failure policy | Original failure matrix | Central-policy RED: 10 failed, 2 passed; incomplete reason, returned IDs, and external classes leaked | Central `DiagnosticCode` policy emits only application codes and trusted S3 keys | Refusal/incomplete/output/API/upload/parse/cleanup sentinels covered | 19/19 focused tests passed |
+| 2.4 | `scripts/tests/test_generate_index.py` | Unit/fail closed | Focused transport safety net | Sensitive returned IDs and external details appeared in exceptions/logs | Identity/review/transport failures use stable application codes | No model output or external message/class is observable | 58/58 script tests passed |
+| 2.5 | `scripts/tests/test_generate_index.py` | Unit/refactor/compatibility | OpenAI 1.68.0 probe | N/A — behavior-preserving refactor | Minimum SDK and safe legacy caller contract preserved | Full project regression passes | 617 passed, 3 skipped |
 
 ## Verification
 
@@ -60,8 +70,6 @@ PR 1C; PR 3 starts from `main` after PR 2.
 
 ## Remaining
 
-- Separate completed Unit 1 into PR 1A/1B/1C before any commit or PR.
-- Unit 2 / tasks 2.1–2.5: Responses API and real File Inputs.
 - Unit 3 / tasks 3.1–3.4: fail-closed pipeline publication gate.
 
 ## Verification Correction: Deep Structured Output Closure

--- a/openspec/changes/preserve-pdf-extraction-identity/tasks.md
+++ b/openspec/changes/preserve-pdf-extraction-identity/tasks.md
@@ -33,11 +33,11 @@ Chain strategy: stacked-to-main
 
 ## Phase 2: File Inputs and Responses API (Unit 2)
 
-- [ ] 2.1 RED — Mock `client.files` and `client.responses.parse` to require adjacent opaque-ID `input_text` plus real `input_file` content and order-independent parsed output.
-- [ ] 2.2 GREEN — Replace Chat Completions JSON mode in `extract_metadata_batch()` with uploads, trusted map, `responses.parse(..., text_format=ExtractionBatch)`, reconciliation, and `finally` cleanup.
-- [ ] 2.3 RED — Cover refusal, incomplete status/reason, absent parsed output, schema/parse error, API error, and warning-only cleanup failure.
-- [ ] 2.4 GREEN — Fail closed with source-specific diagnostics for every unacceptable response; never synthesize fallback entries.
-- [ ] 2.5 REFACTOR — Verify the minimum OpenAI constraint; update `pyproject.toml` and `uv.lock` only if `responses.parse` requires it.
+- [x] 2.1 RED — Mock `client.files` and `client.responses.parse` to require adjacent opaque-ID `input_text` plus real `input_file` content and order-independent parsed output.
+- [x] 2.2 GREEN — Replace Chat Completions JSON mode in `extract_metadata_batch()` with uploads, trusted map, `responses.parse(..., text_format=ExtractionBatch)`, reconciliation, and `finally` cleanup.
+- [x] 2.3 RED — Cover refusal, incomplete status/reason, absent parsed output, schema/parse error, API error, and warning-only cleanup failure.
+- [x] 2.4 GREEN — Fail closed with source-specific diagnostics for every unacceptable response; never synthesize fallback entries.
+- [x] 2.5 REFACTOR — Verify the minimum OpenAI constraint; update `pyproject.toml` and `uv.lock` only if `responses.parse` requires it.
 
 ## Phase 3: Publication Gate (Unit 3)
 

--- a/scripts/generate_index.py
+++ b/scripts/generate_index.py
@@ -135,6 +135,23 @@ class ExtractionNeedsReview(RuntimeError):
     """Raised when reconciled content is not eligible for publication."""
 
 
+_DIAGNOSTIC_VALUES = (
+    "duplicate_expected_identity duplicate_identity identity_set_mismatch "
+    "model_marked_needs_review product_count_zero product_count_multiple zero_variants "
+    "routing_mismatch model_refusal response_incomplete missing_output_parsed "
+    "upload_failed response_parse_failed extraction_failed cleanup_failed"
+).split()
+DiagnosticCode = Enum(
+    "DiagnosticCode", {value.upper(): value for value in _DIAGNOSTIC_VALUES}, type=str
+)
+
+
+def _diagnostic(codes: DiagnosticCode | list[DiagnosticCode], sources: tuple[str, ...] = ()) -> str:
+    safe_codes = [codes] if isinstance(codes, DiagnosticCode) else codes
+    message = ",".join(code.value for code in safe_codes)
+    return f"{message}; sources={','.join(sources)}" if sources else message
+
+
 ReconciledProduct = tuple[ExtractedProduct, TrustedDocument]
 
 
@@ -160,9 +177,7 @@ def build_trusted_map(
     for document in documents:
         document_id = create_document_id()
         if document_id in trusted_map:
-            raise ExtractionProtocolError(
-                f"duplicate expected document_id: {document_id}"
-            )
+            raise ExtractionProtocolError(_diagnostic(DiagnosticCode.DUPLICATE_EXPECTED_IDENTITY))
         trusted_map[document_id] = document
 
     return trusted_map
@@ -187,20 +202,12 @@ def reconcile_batch(
     _validate_identity_sets(parsed, trusted_map)
 
     reconciled: list[ReconciledProduct] = []
-    review_findings: list[str] = []
     for document in parsed.documents:
         trusted = trusted_map[document.document_id]
         reasons = _review_reasons(document, trusted)
         if reasons:
-            review_findings.append(
-                f"{document.document_id} ({trusted.s3_key}): {', '.join(reasons)}"
-            )
-            continue
+            raise ExtractionNeedsReview(_diagnostic(reasons, (trusted.s3_key,)))
         reconciled.append((document.products[0], trusted))
-
-    if review_findings:
-        raise ExtractionNeedsReview("; ".join(review_findings))
-
     return reconciled
 
 
@@ -216,9 +223,7 @@ def _validate_identity_sets(
         if count > 1
     )
     if duplicate_ids:
-        raise ExtractionProtocolError(
-            f"duplicate returned document_id values: {duplicate_ids}"
-        )
+        raise ExtractionProtocolError(_diagnostic(DiagnosticCode.DUPLICATE_IDENTITY))
 
     expected_ids = set(trusted_map)
     actual_ids = set(returned_ids)
@@ -226,35 +231,32 @@ def _validate_identity_sets(
     unknown_ids = sorted(actual_ids - expected_ids)
     if missing_ids or unknown_ids:
         raise ExtractionProtocolError(
-            "identity set mismatch: "
-            f"missing={missing_ids}, unknown/extra={unknown_ids}"
+            _diagnostic(DiagnosticCode.IDENTITY_SET_MISMATCH)
         )
 
 
 def _review_reasons(
     document: DocumentExtraction,
     trusted: TrustedDocument,
-) -> list[str]:
+) -> list[DiagnosticCode]:
     """Classify review-only extraction outcomes for one trusted source."""
-    reasons = list(document.review_reasons)
-    if document.status == ExtractionStatus.NEEDS_REVIEW and not reasons:
-        reasons.append("model marked needs_review")
+    reasons: list[DiagnosticCode] = []
+    if document.status == ExtractionStatus.NEEDS_REVIEW or document.review_reasons:
+        reasons.append(DiagnosticCode.MODEL_MARKED_NEEDS_REVIEW)
 
-    product_count = len(document.products)
-    if product_count == 0:
-        reasons.append("zero products")
+    if not document.products:
+        reasons.append(DiagnosticCode.PRODUCT_COUNT_ZERO)
         return reasons
-    if product_count > 1:
-        reasons.append("multiple products")
+    if len(document.products) > 1:
+        reasons.append(DiagnosticCode.PRODUCT_COUNT_MULTIPLE)
         return reasons
 
     product = document.products[0]
     if not product.variantes:
-        reasons.append("product has zero variants")
+        reasons.append(DiagnosticCode.ZERO_VARIANTS)
 
-    mismatched_fields = _routing_mismatches(product, trusted)
-    if mismatched_fields:
-        reasons.append(f"routing mismatch: {mismatched_fields}")
+    if _routing_mismatches(product, trusted):
+        reasons.append(DiagnosticCode.ROUTING_MISMATCH)
 
     return reasons
 
@@ -589,7 +591,7 @@ def filter_new_pdfs(
 
 
 def extract_metadata_batch(
-    pdf_bytes_list: list[tuple[str, bytes, dict[str, str]]],
+    pdf_bytes_list: list[tuple[str, bytes, dict[str, Any]]],
     api_key: str,
     model: str = "gpt-4o",
 ) -> list[dict[str, Any]]:
@@ -601,70 +603,73 @@ def extract_metadata_batch(
         model: Model to use for extraction.
 
     Returns:
-        List of extracted product metadata dicts.
+        Publication-shaped product mappings with trusted source fields.
     """
     from openai import OpenAI
-
     client = OpenAI(api_key=api_key)
     file_ids: list[str] = []
-    s3_key_map: dict[str, str] = {}  # file_id -> s3_key
-
+    trusted_sources = tuple(source[0] for source in pdf_bytes_list)
+    error = lambda code: ExtractionProtocolError(_diagnostic(code, trusted_sources))  # noqa: E731
     try:
-        # Upload PDFs to OpenAI Files API
+        trusted_documents: list[TrustedDocument] = []
         for s3_key, pdf_bytes, pdf_info in pdf_bytes_list:
             file_obj = io.BytesIO(pdf_bytes)
             file_obj.name = pdf_info.get("nombre_comercial", "document") + ".pdf"
-
-            response = client.files.create(file=file_obj, purpose="user_data")
-            file_ids.append(response.id)
-            s3_key_map[response.id] = s3_key
-
-        # Build the user message with file references
-        user_message_parts = [
-            "Analiza las siguientes fichas técnicas PDF y extrae los metadatos "
-            "estructurados según el schema proporcionado en el system prompt.\n"
+            try:
+                uploaded = client.files.create(file=file_obj, purpose="user_data")
+            except Exception:
+                raise error(DiagnosticCode.UPLOAD_FAILED) from None
+            file_ids.append(uploaded.id)
+            trusted_documents.append(TrustedDocument(s3_key, pdf_info, uploaded.id))
+        trusted_map = build_trusted_map(trusted_documents)
+        content: list[dict[str, str]] = []
+        for document_id, trusted in trusted_map.items():
+            content += [
+                {"type": "input_text", "text": f"document_id: {document_id}"},
+                {"type": "input_file", "file_id": trusted.file_id},
+            ]
+        try:
+            response = client.responses.parse(
+                model=model,
+                instructions=EXTRACTION_SYSTEM_PROMPT,
+                input=[{"role": "user", "content": content}],
+                text_format=ExtractionBatch,
+            )
+        except Exception:
+            raise error(DiagnosticCode.RESPONSE_PARSE_FAILED) from None
+        if _response_has_refusal(response):
+            raise error(DiagnosticCode.MODEL_REFUSAL)
+        if response.status != "completed":
+            raise error(DiagnosticCode.RESPONSE_INCOMPLETE)
+        if response.output_parsed is None:
+            raise error(DiagnosticCode.MISSING_OUTPUT_PARSED)
+        products = {
+            trusted.file_id: product
+            for product, trusted in reconcile_batch(
+                response.output_parsed, trusted_map
+            )
+        }
+        return [
+            build_product_entry(products[trusted.file_id], trusted)
+            for trusted in trusted_map.values()
         ]
-
-        for file_id, s3_key in s3_key_map.items():
-            pdf_info = next((p for p in pdf_bytes_list if p[0] == s3_key), None)
-            if pdf_info:
-                info = pdf_info[2]
-                user_message_parts.append(
-                    f"- File ID: {file_id}\n"
-                    f"  Categoría: {info['categoria']}\n"
-                    f"  Subcategoría: {info.get('subcategoria') or 'N/A'}\n"
-                    f"  Nombre comercial (del archivo): {info['nombre_comercial']}"
-                )
-
-        user_message = "\n".join(user_message_parts)
-
-        # Build content list with file references
-        content: list[dict[str, Any]] = [{"type": "text", "text": user_message}]
-
-        # Call the LLM
-        response = client.chat.completions.create(
-            model=model,
-            messages=[
-                {"role": "system", "content": EXTRACTION_SYSTEM_PROMPT},
-                {"role": "user", "content": content},
-            ],
-            temperature=0,
-            response_format={"type": "json_object"},
-        )
-
-        result_text = response.choices[0].message.content
-        result = json.loads(result_text)
-
-        return result.get("productos", [])
-
+    except (ExtractionNeedsReview, ExtractionProtocolError):
+        raise
+    except Exception:
+        raise error(DiagnosticCode.EXTRACTION_FAILED) from None
     finally:
         # Cleanup: delete uploaded files from OpenAI
         for file_id in file_ids:
             try:
                 client.files.delete(file_id)
-                logger.debug("Deleted OpenAI file: %s", file_id)
-            except Exception as e:
-                logger.warning("Failed to delete OpenAI file %s: %s", file_id, e)
+            except Exception:
+                logger.warning(_diagnostic(DiagnosticCode.CLEANUP_FAILED, trusted_sources))
+def _response_has_refusal(response: Any) -> bool:
+    for output in getattr(response, "output", None) or []:
+        for content in getattr(output, "content", None) or []:
+            if getattr(content, "type", None) == "refusal":
+                return True
+    return False
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_generate_index.py
+++ b/scripts/tests/test_generate_index.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from pydantic import ValidationError
@@ -29,6 +29,7 @@ from generate_index import (
     build_catalog_index,
     build_product_entry,
     build_trusted_map,
+    extract_metadata_batch,
     filter_new_pdfs,
     list_local_pdfs,
     reconcile_batch,
@@ -323,7 +324,7 @@ class TestTrustedMap:
     def test_duplicate_expected_ids_fail_closed(self) -> None:
         documents = [_trusted_document("Series A"), _trusted_document("Series B")]
 
-        with pytest.raises(ExtractionProtocolError, match="duplicate expected"):
+        with pytest.raises(ExtractionProtocolError, match="duplicate_expected_identity"):
             build_trusted_map(documents, document_id_factory=lambda: "same-id")
 
 
@@ -358,18 +359,18 @@ class TestReconcileBatch:
         ]
 
     @pytest.mark.parametrize(
-        ("expected_ids", "returned_ids", "message"),
+        ("expected_ids", "returned_ids"),
         [
-            (("doc-a", "doc-b"), ("doc-a",), "missing"),
-            (("doc-a",), ("doc-a", "doc-extra"), "extra"),
-            (("doc-a", "doc-b"), ("doc-a", "doc-unknown"), "unknown"),
+            (("doc-a", "doc-b"), ("doc-a",)),
+            (("doc-a",), ("doc-a", "PRIVATE EXTRA ID")),
+            (("doc-a", "doc-b"), ("doc-a", "PRIVATE UNKNOWN ID")),
         ],
     )
     def test_identity_set_anomalies_fail_closed(
         self,
         expected_ids: tuple[str, ...],
         returned_ids: tuple[str, ...],
-        message: str,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         trusted_map = {
             document_id: _trusted_document(f"Series {index}")
@@ -379,8 +380,14 @@ class TestReconcileBatch:
             documents=[_document_extraction(document_id) for document_id in returned_ids]
         )
 
-        with pytest.raises(ExtractionProtocolError, match=message):
+        with pytest.raises(ExtractionProtocolError) as raised:
             reconcile_batch(parsed, trusted_map)
+
+        diagnostics = str(raised.value) + caplog.text
+        assert "identity_set_mismatch" in diagnostics
+        assert all(
+            value not in diagnostics for value in set(returned_ids) - set(expected_ids)
+        )
 
     def test_duplicate_returned_id_fails_closed(self) -> None:
         trusted_map = {"doc-a": _trusted_document("Series A")}
@@ -391,7 +398,7 @@ class TestReconcileBatch:
             ]
         )
 
-        with pytest.raises(ExtractionProtocolError, match="duplicate returned"):
+        with pytest.raises(ExtractionProtocolError, match="duplicate_identity"):
             reconcile_batch(parsed, trusted_map)
 
 
@@ -430,14 +437,22 @@ class TestExtractionClassification:
             "Tiger Pro 470W",
         ]
 
-    def test_zero_products_needs_review(self) -> None:
-        document = _document_extraction("doc-a").model_copy(update={"products": []})
-
-        with pytest.raises(ExtractionNeedsReview, match="zero products"):
+    def test_model_review_text_is_safe(self, caplog: pytest.LogCaptureFixture) -> None:
+        document = _document_extraction("doc-a").model_copy(
+            update={
+                "status": ExtractionStatus.NEEDS_REVIEW, "products": [],
+                "review_reasons": ["PRIVATE MODEL MESSAGE"],
+            }
+        )
+        with pytest.raises(ExtractionNeedsReview) as raised:
             reconcile_batch(
                 ExtractionBatch(documents=[document]),
                 {"doc-a": _trusted_document("Jinko Tiger Pro")},
             )
+        diagnostic = str(raised.value) + caplog.text
+        assert "model_marked_needs_review" in diagnostic
+        assert "product_count_zero" in diagnostic
+        assert "PRIVATE MODEL MESSAGE" not in diagnostic
 
     def test_product_with_zero_variants_needs_review(self) -> None:
         product = _extracted_product().model_copy(update={"variantes": []})
@@ -445,7 +460,7 @@ class TestExtractionClassification:
             update={"products": [product]}
         )
 
-        with pytest.raises(ExtractionNeedsReview, match="zero variants"):
+        with pytest.raises(ExtractionNeedsReview, match="zero_variants"):
             reconcile_batch(
                 ExtractionBatch(documents=[document]),
                 {"doc-a": _trusted_document("Jinko Tiger Pro")},
@@ -461,7 +476,7 @@ class TestExtractionClassification:
             }
         )
 
-        with pytest.raises(ExtractionNeedsReview, match="multiple products"):
+        with pytest.raises(ExtractionNeedsReview, match="product_count_multiple"):
             reconcile_batch(
                 ExtractionBatch(documents=[document]),
                 {"doc-a": _trusted_document("Jinko Tiger Pro")},
@@ -479,7 +494,7 @@ class TestExtractionClassification:
             update={"products": [product]}
         )
 
-        with pytest.raises(ExtractionNeedsReview, match="routing mismatch"):
+        with pytest.raises(ExtractionNeedsReview, match="routing_mismatch"):
             reconcile_batch(
                 ExtractionBatch(documents=[document]),
                 {"doc-a": _trusted_document("Jinko Tiger Pro")},
@@ -506,6 +521,162 @@ class TestTrustedProductConversion:
             "tipo_celda": "monocristalino"
         }
         assert entry["variantes"][0]["parametros_clave"] == {"potencia_w": 460}
+
+
+class TestExtractMetadataBatch:
+    @staticmethod
+    def _sources(*names: str) -> list[tuple[str, bytes, dict[str, Any]]]:
+        return [
+            (document.s3_key, f"%PDF-{name}".encode(), document.pdf_info)
+            for name in names
+            for document in [_trusted_document(name)]
+        ]
+    @classmethod
+    def _response(
+        cls, kwargs: dict[str, Any], failure: str = "", sensitive: str = "",
+        reverse: bool = False,
+    ) -> MagicMock:
+        document_ids = cls._document_ids(kwargs)
+        documents = [
+            _document_extraction(value, f"Series {chr(65 + index)}")
+            for index, value in enumerate(document_ids)
+        ]
+        if reverse:
+            documents.reverse()
+        response = MagicMock(
+            status="incomplete" if failure == "incomplete" else "completed",
+            output_parsed=ExtractionBatch(documents=documents),
+            output=(
+                [object(), MagicMock(content=[MagicMock(type="refusal", refusal=sensitive)])]
+                if failure == "refusal"
+                else []
+            ),
+            incomplete_details=MagicMock(reason=sensitive),
+        )
+        if failure == "missing_parsed":
+            response.output_parsed = None
+        return response
+    @staticmethod
+    def _document_ids(kwargs: dict[str, Any]) -> list[str]:
+        return [
+            item["text"].removeprefix("document_id: ")
+            for item in kwargs["input"][0]["content"][::2]
+        ]
+    @patch("openai.OpenAI")
+    def test_file_inputs_and_pipeline_contract(
+        self, openai_factory: MagicMock
+    ) -> None:
+        client = openai_factory.return_value
+        client.files.create.side_effect = [
+            MagicMock(id="file-series-a"),
+            MagicMock(id="file-series-b"),
+        ]
+        client.responses.parse.side_effect = lambda **kwargs: self._response(
+            kwargs, reverse=True
+        )
+        extracted = extract_metadata_batch(
+            self._sources("Series A", "Series B"), "test-key", "gpt-4o"
+        )
+        content = client.responses.parse.call_args.kwargs["input"][0]["content"]
+        pairs = list(zip(content[::2], content[1::2]))
+        assert all(
+            text["type"] == "input_text"
+            and text["text"].startswith("document_id: ")
+            and "Series" not in text["text"]
+            for text, _ in pairs
+        )
+        assert [item for _, item in pairs] == [
+            {"type": "input_file", "file_id": "file-series-a"},
+            {"type": "input_file", "file_id": "file-series-b"},
+        ]
+        assert [entry["ruta_s3"] for entry in extracted] == [
+            "raw/paneles/Series A.pdf",
+            "raw/paneles/Series B.pdf",
+        ]
+        assert client.responses.parse.call_args.kwargs["text_format"] is ExtractionBatch
+        assert client.chat.completions.create.call_count == 0
+        assert [
+            (upload.kwargs["file"].getvalue(), upload.kwargs["purpose"])
+            for upload in client.files.create.call_args_list
+        ] == [(b"%PDF-Series A", "user_data"), (b"%PDF-Series B", "user_data")]
+        assert client.files.delete.call_args_list == [
+            call("file-series-a"), call("file-series-b")
+        ]
+        client.files.create.side_effect = None
+        client.files.create.return_value = MagicMock(id="file-series-a")
+        with (
+            patch("generate_index.list_local_pdfs", return_value=[self._sources("Series A")[0][2]]),
+            patch("generate_index.download_local_pdf", return_value=b"%PDF-A"),
+            patch("generate_index.save_local") as save,
+        ):
+            from generate_index import run_pipeline
+            result = run_pipeline(
+                None, "source", "raw/", "output", "index", "schema", 1,
+                True, False, True, "test-key", "gpt-4o"
+            )
+        catalog = save.call_args.args[0]
+        assert result == 0 and catalog["productos"][0]["fabricante"] == "Jinko"
+    @pytest.mark.parametrize(
+        ("failure", "diagnostic", "sensitive"),
+        [
+            ("refusal", "model_refusal", "private refusal payload"),
+            ("incomplete", "response_incomplete", "PRIVATE INCOMPLETE REASON"),
+            ("missing_parsed", "missing_output_parsed", ""),
+            ("parse", "response_parse_failed", "private schema payload"),
+            ("api", "response_parse_failed", "private API payload"),
+        ],
+    )
+    @patch("openai.OpenAI")
+    def test_response_failures_are_safe(
+        self,
+        openai_factory: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+        failure: str, diagnostic: str, sensitive: str,
+    ) -> None:
+        client = openai_factory.return_value
+        client.files.create.return_value = MagicMock(id="file-series-a")
+        if failure in {"parse", "api"}:
+            error_type = type(f"PRIVATE_{failure.upper()}_ERROR", (Exception,), {})
+            client.responses.parse.side_effect = error_type(sensitive)
+        else:
+            client.responses.parse.side_effect = lambda **kwargs: self._response(
+                kwargs, failure, sensitive
+            )
+        with pytest.raises(ExtractionProtocolError) as raised:
+            extract_metadata_batch(self._sources("Series A"), "test-key")
+        diagnostics = str(raised.value) + caplog.text
+        assert "raw/paneles/Series A.pdf" in diagnostics and diagnostic in diagnostics
+        assert not sensitive or sensitive not in diagnostics
+        assert "PRIVATE_" not in diagnostics
+        client.files.delete.assert_called_once_with("file-series-a")
+    @patch("openai.OpenAI")
+    def test_external_failures_use_stable_codes_and_preserve_cleanup(
+        self, openai_factory: MagicMock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        client = openai_factory.return_value
+        error_type = type("PRIVATE_UPLOAD_ERROR", (Exception,), {})
+        client.files.create.side_effect = [
+            MagicMock(id="file-series-a"),
+            error_type("private upload payload"),
+        ]
+        with pytest.raises(ExtractionProtocolError, match="upload_failed") as raised:
+            extract_metadata_batch(self._sources("Series A", "Series B"), "test-key")
+        client.files.delete.assert_called_once_with("file-series-a")
+        assert "PRIVATE_" not in str(raised.value) + caplog.text
+        assert "private upload payload" not in str(raised.value) + caplog.text
+        client.files.create.side_effect = None
+        client.responses.parse.side_effect = error_type("private primary payload")
+        client.files.delete.side_effect = error_type("private cleanup payload")
+        with pytest.raises(ExtractionProtocolError, match="response_parse_failed") as raised:
+            extract_metadata_batch(self._sources("Series A"), "test-key")
+        diagnostics = str(raised.value) + caplog.text
+        assert "private primary payload" not in diagnostics
+        assert "private cleanup payload" not in diagnostics
+        assert "cleanup_failed" in caplog.text and "PRIVATE_" not in diagnostics
+        client.responses.parse.side_effect = lambda **kwargs: self._response(kwargs)
+        assert extract_metadata_batch(self._sources("Series A"), "test-key")[0][
+            "fabricante"
+        ] == "Jinko"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #227

## Summary
- Upload each catalog PDF as a real OpenAI File Input with an application-owned document ID.
- Parse a closed `ExtractionBatch` through the Responses API and reconcile results independently of response order.
- Fail closed with application-owned diagnostic codes while cleaning up partial uploads safely.

## Changes
| File | Change |
|---|---|
| `scripts/generate_index.py` | Replace legacy Chat Completions JSON transport with Files + Responses parsing and safe diagnostics. |
| `scripts/tests/test_generate_index.py` | Cover upload bytes, request shape, out-of-order results, refusals, incomplete responses, partial cleanup, and diagnostic containment. |
| `openspec/changes/preserve-pdf-extraction-identity/` | Record Unit 2 completion and Strict TDD evidence. |

## Test plan
- [x] `uv run pytest` — 617 passed, 3 skipped.
- [x] `uv run pytest scripts/tests/test_generate_index.py` — 58 passed.
- [x] Adversarial diagnostic probes — 13/13 passed.
- [x] `git diff --check`.
- [ ] Ruff unavailable through `uv` in the current environment.

## Chain context
```text
PR #270 — typed identity and deterministic reconciliation ✅
📍 PR 2 — Responses API and real File Inputs
   PR 3 — fail-closed publication gate
```

This PR targets updated `main` after #270. PR 3 will start from `main` only after this PR merges.

## Review budget
Exactly 400 changed lines; no `size:exception`.

## Checklist
- [x] Linked approved issue #227.
- [x] Exactly one `type:*` label will be applied.
- [x] Conventional commit; no AI attribution.
- [x] Tests stay with the behavior they verify.
- [x] Unrelated package-lock changes excluded.