### PR TITLE
fix(state): mirror processing lease semantics in memory

### DIFF
--- a/backend/app/message_buffer.py
+++ b/backend/app/message_buffer.py
@@ -14,8 +14,15 @@ import logging
 from datetime import datetime, timedelta, timezone
 from threading import RLock
 from typing import Awaitable, Callable, Optional
+from uuid import uuid4
 
-from backend.app.state_repository import ChatbotStateRepository
+from backend.app.config import settings
+from backend.app.state_repository import (
+    ChatbotStateRepository,
+    ProcessingLease,
+    ProcessingLeaseReleaseResult,
+    ProcessingLeaseResult,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +46,10 @@ _processing_sessions: dict[str, datetime] = {}
 # Pending delivery and processing state share one lock so consumption and marker
 # cleanup are one in-process operation.
 _pending_state_lock = RLock()
+
+# Tokenized leases are isolated until callers migrate in Work Unit 3.
+_processing_leases: dict[str, ProcessingLease] = {}
+_state_lock = RLock()
 
 
 def set_state_repository(
@@ -73,9 +84,10 @@ async def add_to_buffer(
             return await flush_buffer(session_id)
         return None
 
-    if session_id not in _buffer:
-        _buffer[session_id] = []
-    _buffer[session_id].append((message, datetime.now(timezone.utc)))
+    with _state_lock:
+        if session_id not in _buffer:
+            _buffer[session_id] = []
+        _buffer[session_id].append((message, datetime.now(timezone.utc)))
 
     if len(_buffer[session_id]) >= max_messages:
         # Overflow: flush immediately
@@ -102,10 +114,10 @@ async def flush_buffer(session_id: str) -> Optional[str]:
     """
     if _state_repository is not None:
         state = _state_repository.get_buffer_state(session_id)
-        messages = state.messages
-        if not messages:
+        buffer_messages = state.messages
+        if not buffer_messages:
             return None
-        joined = "\n".join(message.message for message in messages)
+        joined = "\n".join(message.message for message in buffer_messages)
         _state_repository.clear_buffer_messages(session_id)
         _state_repository.set_pending_result(session_id, joined)
         _state_repository.clear_processing(session_id)
@@ -290,6 +302,60 @@ def clear_processing(session_id: str) -> None:
         _processing_sessions.pop(session_id, None)
 
 
+def acquire_processing_lease(
+    session_id: str,
+    *,
+    now: Optional[datetime] = None,
+    token: Optional[str] = None,
+) -> ProcessingLeaseResult:
+    """Try to claim processing ownership with deterministic test inputs."""
+    current_time = _to_utc(now if now is not None else datetime.now(timezone.utc))
+    lease = ProcessingLease(
+        token=token if token is not None else uuid4().hex,
+        expires_at=current_time
+        + timedelta(seconds=settings.buffer_processing_lease_seconds),
+    )
+    if _state_repository is not None:
+        return _state_repository.try_acquire_processing_lease(
+            session_id, now=current_time, lease=lease
+        )
+    return try_acquire_local_processing_lease(session_id, now=current_time, lease=lease)
+
+
+def try_acquire_local_processing_lease(
+    session_id: str, *, now: datetime, lease: ProcessingLease
+) -> ProcessingLeaseResult:
+    """Atomically acquire an absent or expired local processing lease."""
+    current_time = _to_utc(now)
+    with _state_lock:
+        current = _processing_leases.get(session_id)
+        if current is not None and current_time < _to_utc(current.expires_at):
+            return ProcessingLeaseResult(acquired=False)
+        _processing_leases[session_id] = lease
+        return ProcessingLeaseResult(acquired=True, lease=lease)
+
+
+def release_processing_lease(
+    session_id: str, token: str
+) -> ProcessingLeaseReleaseResult:
+    """Release processing ownership only for the current token."""
+    if _state_repository is not None:
+        return _state_repository.release_processing_lease(session_id, token)
+    return release_local_processing_lease(session_id, token)
+
+
+def release_local_processing_lease(
+    session_id: str, token: str
+) -> ProcessingLeaseReleaseResult:
+    """Atomically release local processing ownership for the caller's token."""
+    with _state_lock:
+        current = _processing_leases.get(session_id)
+        if current is None or current.token != token:
+            return ProcessingLeaseReleaseResult(released=False)
+        del _processing_leases[session_id]
+        return ProcessingLeaseReleaseResult(released=True)
+
+
 def is_processing(session_id: str) -> bool:
     """Check if a session is currently being processed after a flush.
 
@@ -321,10 +387,10 @@ def is_buffer_ready_to_flush(
     """
     current_time = _to_utc(now or datetime.now(timezone.utc))
     if _state_repository is not None:
-        messages = _state_repository.get_buffer_state(session_id).messages
-        if not messages:
+        buffer_messages = _state_repository.get_buffer_state(session_id).messages
+        if not buffer_messages:
             return False
-        last_message_at = _to_utc(messages[-1].timestamp)
+        last_message_at = _to_utc(buffer_messages[-1].timestamp)
         return current_time >= last_message_at + timedelta(seconds=window_seconds)
 
     buffered_entries = _buffer.get(session_id, [])

--- a/backend/app/tests/test_message_buffer.py
+++ b/backend/app/tests/test_message_buffer.py
@@ -8,8 +8,9 @@ Strict TDD: tests written BEFORE implementation.
 
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from threading import Barrier
+from typing import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -45,7 +46,7 @@ def _require_message_buffer() -> None:
 
 
 @pytest.fixture(autouse=True)
-def _clean_buffer_state() -> None:
+def _clean_buffer_state() -> Generator[None, None, None]:
     """Ensure clean buffer state between tests."""
     try:
         from backend.app import message_buffer
@@ -54,6 +55,7 @@ def _clean_buffer_state() -> None:
         message_buffer._buffer_tasks.clear()
         message_buffer._pending_results.clear()
         message_buffer._pending_chat_responses.clear()
+        message_buffer._processing_leases.clear()
         message_buffer._processing_sessions.clear()
     except ImportError:
         pass
@@ -65,6 +67,7 @@ def _clean_buffer_state() -> None:
         message_buffer._buffer_tasks.clear()
         message_buffer._pending_results.clear()
         message_buffer._pending_chat_responses.clear()
+        message_buffer._processing_leases.clear()
         message_buffer._processing_sessions.clear()
     except ImportError:
         pass
@@ -152,6 +155,7 @@ class TestFlushBuffer:
         await add_to_buffer("s1", "primer mensaje")
         await add_to_buffer("s1", "segundo mensaje")
         result = await flush_buffer("s1")
+        assert result is not None
         lines = result.split("\n")
         assert lines[0] == "primer mensaje"
         assert lines[1] == "segundo mensaje"
@@ -373,6 +377,122 @@ class TestLambdaSafeDebounce:
             message_buffer.set_state_repository(None)
 
 
+class TestLocalProcessingLease:
+    """Test local-memory parity with the repository lease contract."""
+
+    def test_contention_exact_expiry_and_token_protected_release(self) -> None:
+        from backend.app.message_buffer import (
+            release_local_processing_lease,
+            try_acquire_local_processing_lease,
+        )
+        from backend.app.state_repository import ProcessingLease
+
+        now = datetime(2026, 7, 29, tzinfo=timezone.utc)
+        first_lease = ProcessingLease(
+            token="first", expires_at=now + timedelta(seconds=60)
+        )
+        replacement_lease = ProcessingLease(
+            token="replacement", expires_at=now + timedelta(seconds=120)
+        )
+
+        first = try_acquire_local_processing_lease("s1", now=now, lease=first_lease)
+        blocked = try_acquire_local_processing_lease(
+            "s1", now=now, lease=replacement_lease
+        )
+        replacement = try_acquire_local_processing_lease(
+            "s1", now=first_lease.expires_at, lease=replacement_lease
+        )
+
+        assert first.acquired and first.lease == first_lease
+        assert not blocked.acquired and blocked.lease is None
+        assert replacement.acquired and replacement.lease == replacement_lease
+        assert not release_local_processing_lease("s1", "first").released
+        assert not release_local_processing_lease("missing", "first").released
+        assert release_local_processing_lease("s1", "replacement").released
+
+    def test_competing_acquisitions_have_exactly_one_winner(self) -> None:
+        from backend.app.message_buffer import try_acquire_local_processing_lease
+        from backend.app.state_repository import ProcessingLease
+
+        now = datetime(2026, 7, 29, tzinfo=timezone.utc)
+        barrier = Barrier(2)
+
+        def acquire(token: str) -> bool:
+            lease = ProcessingLease(token=token, expires_at=now + timedelta(seconds=60))
+            barrier.wait()
+            return try_acquire_local_processing_lease(
+                "shared", now=now, lease=lease
+            ).acquired
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            outcomes = list(executor.map(acquire, ("worker-a", "worker-b")))
+
+        assert sorted(outcomes) == [False, True]
+
+    def test_facade_has_equivalent_local_and_repository_outcomes(self) -> None:
+        from backend.app import message_buffer
+        from backend.app.dynamodb_state_repository import DynamoDBStateRepository
+        from backend.app.message_buffer import (
+            acquire_processing_lease,
+            release_processing_lease,
+        )
+        from backend.tests.test_state_repository import FakeDynamoDBTable
+
+        now = datetime(2026, 7, 29, tzinfo=timezone.utc)
+
+        def exercise() -> list[bool]:
+            first = acquire_processing_lease("parity", now=now, token="first")
+            blocked = acquire_processing_lease("parity", now=now, token="blocked")
+            assert first.lease is not None
+            replacement = acquire_processing_lease(
+                "parity", now=first.lease.expires_at, token="replacement"
+            )
+            stale = release_processing_lease("parity", "first")
+            owner = release_processing_lease("parity", "replacement")
+            return [
+                first.acquired,
+                blocked.acquired,
+                replacement.acquired,
+                stale.released,
+                owner.released,
+            ]
+
+        local_outcomes = exercise()
+        message_buffer.set_state_repository(
+            DynamoDBStateRepository(table=FakeDynamoDBTable())
+        )
+        try:
+            repository_outcomes = exercise()
+        finally:
+            message_buffer.set_state_repository(None)
+
+        assert local_outcomes == repository_outcomes == [True, False, True, False, True]
+
+    def test_legacy_processing_markers_remain_isolated_from_leases(self) -> None:
+        from backend.app import message_buffer
+        from backend.app.message_buffer import (
+            acquire_processing_lease,
+            clear_processing,
+            is_processing,
+            release_processing_lease,
+            set_processing,
+        )
+
+        now = datetime(2026, 7, 29, tzinfo=timezone.utc)
+        acquired = acquire_processing_lease("legacy", now=now, token="owner")
+        set_processing("legacy")
+
+        assert acquired.acquired
+        assert is_processing("legacy")
+        assert "legacy" in message_buffer._processing_leases
+
+        clear_processing("legacy")
+
+        assert not is_processing("legacy")
+        assert not acquire_processing_lease("legacy", now=now, token="blocked").acquired
+        assert release_processing_lease("legacy", "owner").released
+
+
 # ===========================================================================
 # Task 5.5 — Overflow: max_messages triggers immediate flush
 # ===========================================================================
@@ -405,6 +525,7 @@ class TestOverflow:
             await add_to_buffer("s1", msg, max_messages=5)
 
         result = await add_to_buffer("s1", messages[4], max_messages=5)
+        assert result is not None
         for msg in messages:
             assert msg in result
         # Check newline separation


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega leases tokenizados y expirables al backend en memoria con las mismas reglas que DynamoDB: un único ganador, takeover exacto al vencer y release protegido por token. Mantiene separados los marcadores legacy y preserva las garantías consume-once incorporadas recientemente.

## Issues relacionados

Closes #283
Part of #232
Depends on #279 (merged)

## Tipo de cambio

- [ ] 🆕 Nueva funcionalidad (feature)
- [x] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [ ] 🧪 Tests
- [ ] 📄 Documentación / configuración
- [ ] 🔧 Infra / CI

## Checklist antes de pedir review

- [x] El código corre localmente sin errores (`uv run pytest backend -q`: 510 passed, 3 skipped)
- [x] Los criterios de aceptación del issue relacionado están cumplidos
- [x] No hay credenciales, API keys ni rutas absolutas hardcodeadas
- [x] No se agregaron dependencias nuevas
- [x] No se modificó el schema del endpoint
- [x] No se modificó el harness ni el dataset

## Cómo probar este PR

1. Ejecutar los tests focalizados de state/config/message-buffer; deben pasar 96 tests.
2. Ejecutar `uv run pytest backend -q`; deben pasar 510 tests y omitirse 3 checks live-server.
3. Ejecutar `uv run ruff check backend/ rag/ && uv run ruff format --check backend/ rag/`.

## Contexto de la cadena

```text
main
 ├── PR #276: append DynamoDB atómico ✅
 ├── PR #279: lease DynamoDB ✅
 └── WU2B: paridad local-memory 📍
      └── WU3: flujo lease-first
```

- Inicio: `main` con PR #279 y cambios consume-once integrados.
- Fin: backend local con lease parity completa.
- Siguiente dependencia: WU3 parte de main después de integrar esta PR.
- Fuera de alcance: migración de callers, `backend/main.py` y orchestration lease-first.
- Presupuesto: 211 líneas funcionales de 400.
- Rollback: revertir este commit elimina las nuevas APIs locales sin afectar leases DynamoDB ni marcadores legacy.

## Notas para el reviewer

`_pending_state_lock` y `_state_lock` protegen dominios separados y nunca se anidan. Las APIs legacy no adquieren ni liberan leases tokenizados; esa migración pertenece a WU3. La suite incluye stress de contención y paridad local/DynamoDB.