### PR TITLE
feat(context): add model-aware budget settings

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -15,6 +15,9 @@ from typing import Annotated, Any, Optional
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
+from backend.app.context_budget_config import ContextBudgetConfig
+from backend.app.model_capabilities import get_model_capabilities
+
 
 LOCAL_CORS_ORIGINS = [
     "http://localhost:3000",
@@ -57,6 +60,42 @@ class Settings(BaseSettings):
     # OpenAI
     openai_api_key: Optional[str] = Field(default=None, description="OpenAI API key")
     llm_model: str = Field(default="gpt-5.4-nano", description="LLM model identifier")
+    llm_max_output_tokens: int = Field(
+        default=2000,
+        ge=1,
+        description="Maximum output tokens requested from the LLM",
+    )
+    context_budget_ratio: float = Field(
+        default=0.10,
+        gt=0.0,
+        le=1.0,
+        description="Preliminary share of model context considered for requests",
+    )
+    context_hard_cap_tokens: int = Field(
+        default=32_000,
+        ge=1,
+        description="Preliminary absolute cap for each LLM request",
+    )
+    context_output_reserve_tokens: int = Field(
+        default=2_000,
+        ge=1,
+        description="Tokens reserved for the configured LLM response limit",
+    )
+    context_non_history_reserve_tokens: int = Field(
+        default=12_000,
+        ge=0,
+        description="Reserve for system, tools, current input, and agent iterations",
+    )
+    context_file_input_max_bytes: int = Field(
+        default=5 * 1024 * 1024,
+        ge=1024,
+        description="Guaranteed byte cap for PDFs sent in File Input requests",
+    )
+    context_max_turns: int = Field(
+        default=20,
+        ge=1,
+        description="Secondary ceiling on complete history turns",
+    )
     openai_timeout_seconds: float = Field(
         default=30.0,
         ge=1.0,
@@ -306,6 +345,42 @@ class Settings(BaseSettings):
                 f"msg_delay_max_ms ({self.msg_delay_max_ms})"
             )
         return self
+
+    @model_validator(mode="after")
+    def _validate_context_reserves(self) -> "Settings":
+        """Keep output generation within model and request budget limits."""
+        if self.context_output_reserve_tokens >= self.context_hard_cap_tokens:
+            raise ValueError(
+                "CONTEXT_OUTPUT_RESERVE_TOKENS must be less than "
+                "CONTEXT_HARD_CAP_TOKENS"
+            )
+        if self.llm_max_output_tokens > self.context_output_reserve_tokens:
+            raise ValueError(
+                "LLM_MAX_OUTPUT_TOKENS must not exceed CONTEXT_OUTPUT_RESERVE_TOKENS"
+            )
+        capabilities = get_model_capabilities(self.llm_model)
+        if (
+            capabilities is not None
+            and self.llm_max_output_tokens > capabilities.max_output_tokens
+        ):
+            raise ValueError(
+                "LLM_MAX_OUTPUT_TOKENS exceeds the registered model output limit"
+            )
+        if self.context_file_input_max_bytes > self.max_pdf_bytes:
+            raise ValueError(
+                "CONTEXT_FILE_INPUT_MAX_BYTES must not exceed MAX_PDF_BYTES"
+            )
+        return self
+
+    def context_budget_config(self) -> ContextBudgetConfig:
+        """Build the shared immutable context budget configuration."""
+        return ContextBudgetConfig(
+            ratio=self.context_budget_ratio,
+            hard_cap_tokens=self.context_hard_cap_tokens,
+            output_reserve_tokens=self.context_output_reserve_tokens,
+            non_history_reserve_tokens=self.context_non_history_reserve_tokens,
+            max_turns=self.context_max_turns,
+        )
 
     @model_validator(mode="after")
     def _validate_state_backend(self) -> "Settings":

--- a/backend/app/context_budget_config.py
+++ b/backend/app/context_budget_config.py
@@ -1,0 +1,14 @@
+"""Stable runtime configuration contract for context budgeting."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ContextBudgetConfig:
+    """Validated runtime controls consumed by context budget policies."""
+
+    ratio: float
+    hard_cap_tokens: int
+    output_reserve_tokens: int
+    non_history_reserve_tokens: int
+    max_turns: int

--- a/backend/app/llm_client.py
+++ b/backend/app/llm_client.py
@@ -230,7 +230,7 @@ class LLMClient:
                 instructions=instructions,
                 input=user_input,
                 tools=tools,
-                max_output_tokens=2000,
+                max_output_tokens=settings.llm_max_output_tokens,
                 reasoning={"effort": "medium"},
                 prompt_cache_key=session_id,
             )
@@ -324,7 +324,7 @@ class LLMClient:
                         ],
                     }
                 ],
-                max_output_tokens=2000,
+                max_output_tokens=settings.llm_max_output_tokens,
                 reasoning={"effort": "medium"},
                 prompt_cache_key=session_id,
             )

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -10,6 +10,7 @@ import pytest
 from pydantic import ValidationError
 
 from backend.app.config import Settings
+from backend.app.context_budget_config import ContextBudgetConfig
 
 
 class TestDotenvIsolationConfig:
@@ -68,6 +69,100 @@ class TestConversationLoggingConfig:
         with patch.dict(os.environ, env, clear=True):
             settings = Settings()
             assert settings.git_commit_hash == "abc1234"
+
+
+class TestContextBudgetConfig:
+    """Tests for preliminary model-aware context budget settings."""
+
+    def test_context_budget_preliminary_defaults(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            settings = Settings()
+
+        assert settings.context_budget_ratio == 0.10
+        assert settings.context_hard_cap_tokens == 32_000
+        assert settings.llm_max_output_tokens == 2_000
+        assert settings.context_output_reserve_tokens == 2_000
+        assert settings.context_non_history_reserve_tokens == 12_000
+        assert settings.context_file_input_max_bytes == 5 * 1024 * 1024
+        assert settings.context_max_turns == 20
+
+    def test_context_budget_fields_are_configurable(self) -> None:
+        env = {
+            "CONTEXT_BUDGET_RATIO": "0.2",
+            "CONTEXT_HARD_CAP_TOKENS": "64000",
+            "LLM_MAX_OUTPUT_TOKENS": "4000",
+            "CONTEXT_OUTPUT_RESERVE_TOKENS": "5000",
+            "CONTEXT_NON_HISTORY_RESERVE_TOKENS": "16000",
+            "CONTEXT_FILE_INPUT_MAX_BYTES": "4194304",
+            "CONTEXT_MAX_TURNS": "12",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            settings = Settings()
+
+        assert settings.context_budget_ratio == 0.2
+        assert settings.context_hard_cap_tokens == 64_000
+        assert settings.llm_max_output_tokens == 4_000
+        assert settings.context_output_reserve_tokens == 5_000
+        assert settings.context_non_history_reserve_tokens == 16_000
+        assert settings.context_file_input_max_bytes == 4_194_304
+        assert settings.context_max_turns == 12
+
+    def test_output_reserve_must_be_below_hard_cap(self) -> None:
+        env = {
+            "CONTEXT_HARD_CAP_TOKENS": "2000",
+            "CONTEXT_OUTPUT_RESERVE_TOKENS": "2000",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValidationError, match="CONTEXT_OUTPUT_RESERVE_TOKENS"):
+                Settings()
+
+    def test_max_output_must_fit_reserved_output_budget(self) -> None:
+        env = {
+            "LLM_MAX_OUTPUT_TOKENS": "2001",
+            "CONTEXT_OUTPUT_RESERVE_TOKENS": "2000",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValidationError, match="LLM_MAX_OUTPUT_TOKENS"):
+                Settings()
+
+    def test_output_reserve_respects_known_model_capability(self) -> None:
+        env = {
+            "LLM_MODEL": "gpt-5.4-nano",
+            "CONTEXT_HARD_CAP_TOKENS": "200000",
+            "LLM_MAX_OUTPUT_TOKENS": "128001",
+            "CONTEXT_OUTPUT_RESERVE_TOKENS": "128001",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValidationError, match="registered model output"):
+                Settings()
+
+    def test_file_input_byte_cap_cannot_exceed_upload_cap(self) -> None:
+        env = {
+            "MAX_PDF_BYTES": "1048576",
+            "CONTEXT_FILE_INPUT_MAX_BYTES": "1048577",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValidationError, match="CONTEXT_FILE_INPUT_MAX_BYTES"):
+                Settings()
+
+    def test_context_budget_config_uses_validated_runtime_values(self) -> None:
+        env = {
+            "CONTEXT_BUDGET_RATIO": "0.25",
+            "CONTEXT_HARD_CAP_TOKENS": "48000",
+            "CONTEXT_OUTPUT_RESERVE_TOKENS": "3000",
+            "CONTEXT_NON_HISTORY_RESERVE_TOKENS": "9000",
+            "CONTEXT_MAX_TURNS": "8",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = Settings().context_budget_config()
+
+        assert config == ContextBudgetConfig(
+            ratio=0.25,
+            hard_cap_tokens=48_000,
+            output_reserve_tokens=3_000,
+            non_history_reserve_tokens=9_000,
+            max_turns=8,
+        )
 
 
 class TestRuntimeCorsConfig:

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -191,6 +191,33 @@ class TestLLMClientWithTools:
         assert "instructions" in call_kwargs
         assert call_kwargs["instructions"] == ARTE_SYSTEM_PROMPT
 
+    @patch.dict(
+        os.environ,
+        {"LLM_MAX_OUTPUT_TOKENS": "3210", "CONTEXT_OUTPUT_RESERVE_TOKENS": "3210"},
+        clear=True,
+    )
+    @patch("backend.app.llm_client.OpenAI")
+    def test_get_llm_response_with_tools_uses_configured_output_limit(
+        self, mock_openai_class: MagicMock
+    ) -> None:
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_client.responses.create.return_value = MagicMock(
+            output_text="Test",
+            output=[MagicMock(type="message")],
+            usage=None,
+        )
+        client = LLMClient(api_key="sk-test-key")
+
+        client.get_llm_response_with_tools(
+            message="Test",
+            session_id="test-session",
+        )
+
+        assert (
+            mock_client.responses.create.call_args.kwargs["max_output_tokens"] == 3210
+        )
+
     def test_get_llm_response_with_tools_raises_without_api_key(self) -> None:
         """Test get_llm_response_with_tools raises error without API key."""
         client = LLMClient(api_key="")
@@ -294,6 +321,33 @@ class TestLLMClientWithToolsReturnsLLMResponse:
 
 class TestLLMClientWithFile:
     """Tests for get_llm_response_with_file method."""
+
+    @patch.dict(
+        os.environ,
+        {"LLM_MAX_OUTPUT_TOKENS": "3210", "CONTEXT_OUTPUT_RESERVE_TOKENS": "3210"},
+        clear=True,
+    )
+    @patch("backend.app.llm_client.OpenAI")
+    def test_get_llm_response_with_file_uses_configured_output_limit(
+        self, mock_openai_class: MagicMock
+    ) -> None:
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_client.responses.create.return_value = MagicMock(
+            output_text="Test",
+            usage=None,
+        )
+        client = LLMClient(api_key="sk-test-key")
+
+        client.get_llm_response_with_file(
+            message="Test",
+            file_id="file-123",
+            session_id="test-session",
+        )
+
+        assert (
+            mock_client.responses.create.call_args.kwargs["max_output_tokens"] == 3210
+        )
 
     @patch("backend.app.llm_client.OpenAI")
     def test_get_llm_response_with_file_sends_message(


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega settings validados para ratio, hard cap, reservas, techo de turnos, tamaño de File Inputs y máximo de salida. Los dos flujos del cliente LLM consumen el mismo `LLM_MAX_OUTPUT_TOKENS`, validado contra el registry para modelos conocidos.

## Issues relacionados

Part of #262

## Tipo de cambio

- [x] 🆕 Nueva funcionalidad (feature)
- [ ] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [ ] 🧪 Tests
- [ ] 📄 Documentación / configuración
- [ ] 🔧 Infra / CI

## Chain context

```text
main
 ├─ ✅ PR #271: model registry
 ├─ ✅ PR #281: token counter
 └─ 📍 PR 3: model-aware budget settings
     └─ PR 4+: history selection, runtime wiring, File Input preflight and evidence
```

**Fuera de alcance:** selección de historial, wiring, preflight exacto de PDF y simulación.

## Checklist antes de pedir review

- [x] Tests focalizados pasan
- [x] Criterios del slice cumplidos
- [x] Sin credenciales ni rutas absolutas
- [x] Sin dependencias nuevas
- [x] Sin cambios de schema HTTP
- [x] Sin cambios de harness

## Cómo probar este PR

1. `uv run pytest backend/tests/test_config.py backend/tests/test_llm_client.py -q`
2. `uv run ruff check backend/app/config.py backend/app/context_budget_config.py backend/app/llm_client.py backend/tests/test_config.py backend/tests/test_llm_client.py`
3. Confirmar configuración válida y propagación de output en ambos flujos.

## Notas para el reviewer

Revisar primero las validaciones en `backend/app/config.py`. Diff: 242 líneas.
