### PR TITLE
feat(context): select complete history by token budget

### DIFF
--- a/backend/app/context_budget.py
+++ b/backend/app/context_budget.py
@@ -1,0 +1,200 @@
+"""Conservative, fail-closed token selection for complete history turns."""
+
+import json
+import logging
+import math
+from dataclasses import dataclass
+from typing import Any, Protocol, Sequence
+
+from backend.app.context_budget_config import ContextBudgetConfig
+from backend.app.model_capabilities import get_model_capabilities
+from backend.app.token_counter import (
+    TOKEN_COUNTER_LOAD_ERRORS,
+    TiktokenTokenCounter,
+    TokenCounter,
+)
+
+logger = logging.getLogger(__name__)
+
+_REQUEST_FRAMING_TOKENS = 16
+_TURN_FRAMING_TOKENS = 8
+_TURN_SEPARATOR = "\n\n"
+
+
+class HistoryTurn(Protocol):
+    """Minimum stored-turn shape required by the selector."""
+
+    @property
+    def question(self) -> str: ...
+
+    @property
+    def answer(self) -> str: ...
+
+    @property
+    def source_documents(self) -> Sequence[str]: ...
+
+
+@dataclass(frozen=True)
+class ContextBudgetDecision:
+    """PII-free metrics produced by one history selection."""
+
+    model: str
+    history_budget_tokens: int
+    known_overhead_tokens: int
+    applied_non_history_reserve_tokens: int
+    selected_history_tokens: int
+    selected_turns: int
+    available_turns: int
+    was_truncated: bool
+    stop_reason: str
+    registry_version: str | None
+
+
+@dataclass(frozen=True)
+class SelectedContext:
+    """Selected complete turns, formatted context, and decision metrics."""
+
+    turns: tuple[HistoryTurn, ...]
+    context: str
+    decision: ContextBudgetDecision
+
+
+def format_turn(turn: HistoryTurn, number: int) -> str:
+    """Serialize one complete user/assistant turn with optional sources."""
+    parts = [
+        f"Turno {number}:",
+        f"Usuario: {turn.question}",
+        f"Asistente: {turn.answer}",
+    ]
+    if turn.source_documents:
+        parts.append(f"Fuentes: {', '.join(turn.source_documents)}")
+    return "\n".join(parts)
+
+
+def format_turns(turns: Sequence[HistoryTurn]) -> str:
+    """Serialize turns chronologically without splitting them."""
+    return _TURN_SEPARATOR.join(
+        format_turn(turn, number) for number, turn in enumerate(turns, 1)
+    )
+
+
+def estimate_text_request_tokens(
+    counter: TokenCounter,
+    system_prompt: str,
+    tools: Sequence[dict[str, Any]],
+    current_message: str,
+    history_context: str = "",
+) -> int:
+    """Estimate textual request tokens with deterministic framing overhead."""
+    serialized_tools = json.dumps(
+        tools, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    )
+    return _REQUEST_FRAMING_TOKENS + sum(
+        counter.count(text)
+        for text in (
+            system_prompt,
+            serialized_tools,
+            current_message,
+            history_context,
+        )
+    )
+
+
+def select_history(
+    *,
+    turns: Sequence[HistoryTurn],
+    model: str,
+    config: ContextBudgetConfig,
+    system_prompt: str,
+    tools: Sequence[dict[str, Any]],
+    current_message: str,
+    token_counter: TokenCounter | None = None,
+) -> SelectedContext:
+    """Select the newest contiguous suffix of complete turns that fits."""
+    capabilities = get_model_capabilities(model)
+    if capabilities is None:
+        return _closed_decision(model, len(turns), "unknown_model")
+
+    try:
+        counter = token_counter or TiktokenTokenCounter(capabilities.encoding)
+    except TOKEN_COUNTER_LOAD_ERRORS:
+        return _closed_decision(
+            model,
+            len(turns),
+            "unknown_tokenizer",
+            capabilities.registry_version,
+        )
+
+    known_overhead = estimate_text_request_tokens(
+        counter, system_prompt, tools, current_message
+    )
+    applied_reserve = max(config.non_history_reserve_tokens, known_overhead)
+    gross_budget = min(
+        config.hard_cap_tokens,
+        math.floor(capabilities.context_window_tokens * config.ratio),
+    )
+    history_budget = max(
+        0, gross_budget - config.output_reserve_tokens - applied_reserve
+    )
+    candidates = turns[-config.max_turns :]
+    selected_reversed: list[HistoryTurn] = []
+    selected_tokens = 0
+    stop_reason = "all_candidates_fit"
+
+    for turn in reversed(candidates):
+        turn_tokens = counter.count(format_turn(turn, 1)) + _TURN_FRAMING_TOKENS
+        if selected_reversed:
+            turn_tokens += counter.count(_TURN_SEPARATOR)
+        if selected_tokens + turn_tokens > history_budget:
+            stop_reason = "turn_exceeds_remaining_budget"
+            break
+        selected_reversed.append(turn)
+        selected_tokens += turn_tokens
+
+    selected = tuple(reversed(selected_reversed))
+    was_truncated = len(selected) < len(turns)
+    if not was_truncated and stop_reason == "all_candidates_fit":
+        stop_reason = "all_history_fit"
+    elif len(turns) > config.max_turns and len(selected) == len(candidates):
+        stop_reason = "max_turns_ceiling"
+
+    decision = ContextBudgetDecision(
+        model=model,
+        history_budget_tokens=history_budget,
+        known_overhead_tokens=known_overhead,
+        applied_non_history_reserve_tokens=applied_reserve,
+        selected_history_tokens=selected_tokens,
+        selected_turns=len(selected),
+        available_turns=len(turns),
+        was_truncated=was_truncated,
+        stop_reason=stop_reason,
+        registry_version=capabilities.registry_version,
+    )
+    _log_decision(decision)
+    return SelectedContext(selected, format_turns(selected), decision)
+
+
+def _closed_decision(
+    model: str,
+    available_turns: int,
+    reason: str,
+    registry_version: str | None = None,
+) -> SelectedContext:
+    decision = ContextBudgetDecision(
+        model=model,
+        history_budget_tokens=0,
+        known_overhead_tokens=0,
+        applied_non_history_reserve_tokens=0,
+        selected_history_tokens=0,
+        selected_turns=0,
+        available_turns=available_turns,
+        was_truncated=available_turns > 0,
+        stop_reason=reason,
+        registry_version=registry_version,
+    )
+    _log_decision(decision)
+    return SelectedContext((), "", decision)
+
+
+def _log_decision(decision: ContextBudgetDecision) -> None:
+    logger.info("Context budget decision: %s", decision)

--- a/backend/tests/test_context_budget.py
+++ b/backend/tests/test_context_budget.py
@@ -1,0 +1,197 @@
+"""Tests for model-aware, complete-turn history selection."""
+
+import logging
+from dataclasses import dataclass
+from unittest.mock import patch
+
+from backend.app.context_budget import format_turn, select_history
+from backend.app.context_budget_config import ContextBudgetConfig
+
+
+@dataclass(frozen=True)
+class Turn:
+    question: str
+    answer: str = "respuesta"
+    source_documents: tuple[str, ...] = ()
+
+
+class CharacterTokenCounter:
+    def count(self, text: str) -> int:
+        return len(text)
+
+
+def _config(history_budget: int, max_turns: int = 20) -> ContextBudgetConfig:
+    # Character counting sees 16 request-framing tokens plus two for serialized tools.
+    return ContextBudgetConfig(1.0, history_budget + 18, 0, 0, max_turns)
+
+
+def _select(turns: list[Turn], history_budget: int = 10_000, max_turns: int = 20):
+    return select_history(
+        turns=turns,
+        model="gpt-5.4-nano",
+        config=_config(history_budget, max_turns),
+        system_prompt="",
+        tools=[],
+        current_message="",
+        token_counter=CharacterTokenCounter(),
+    )
+
+
+def _turn_cost(turn: Turn) -> int:
+    return len(format_turn(turn, 1)) + 8
+
+
+def test_short_history_is_returned_chronologically() -> None:
+    turns = [Turn("uno"), Turn("dos")]
+    selected = _select(turns)
+
+    assert selected.turns == tuple(turns)
+    assert selected.context.index("Usuario: uno") < selected.context.index(
+        "Usuario: dos"
+    )
+    assert selected.decision.stop_reason == "all_history_fit"
+
+
+def test_budget_selects_newest_contiguous_suffix_in_order() -> None:
+    turns = [Turn("antigua"), Turn("media"), Turn("nueva")]
+    budget = _turn_cost(turns[1]) + _turn_cost(turns[2]) + len("\n\n")
+
+    selected = _select(turns, budget)
+
+    assert selected.turns == tuple(turns[1:])
+    assert selected.decision.was_truncated is True
+
+
+def test_oversized_newest_turn_stops_without_skipping_it() -> None:
+    selected = _select([Turn("corta"), Turn("larga", "x" * 500)], 100)
+
+    assert selected.turns == ()
+    assert selected.decision.stop_reason == "turn_exceeds_remaining_budget"
+
+
+def test_exact_budget_boundary_includes_turn() -> None:
+    turn = Turn("límite", "exacto")
+    exact_cost = _turn_cost(turn)
+
+    assert _select([turn], exact_cost).turns == (turn,)
+    assert _select([turn], exact_cost - 1).turns == ()
+
+
+def test_spanish_unicode_turn_is_counted_and_preserved() -> None:
+    turn = Turn(
+        "¿Qué batería rinde mejor con días nublados? ☀️",
+        "La batería de litio conserva más ciclos y energía útil.",
+    )
+
+    selected = _select([turn])
+
+    assert selected.turns == (turn,)
+    assert "¿Qué batería" in selected.context
+    assert selected.decision.selected_history_tokens > 0
+
+
+def test_sources_are_included_in_context_and_token_cost() -> None:
+    plain = Turn("pregunta")
+    sourced = Turn("pregunta", source_documents=("raw/paneles/a.pdf", "raw/b/b.pdf"))
+
+    plain_selection = _select([plain])
+    sourced_selection = _select([sourced])
+
+    assert sourced_selection.decision.selected_history_tokens > (
+        plain_selection.decision.selected_history_tokens
+    )
+    assert "Fuentes: raw/paneles/a.pdf, raw/b/b.pdf" in sourced_selection.context
+
+
+def test_unknown_model_fails_closed_without_logging_content(caplog) -> None:
+    secret = "correo@example.com pregunta privada"
+    caplog.set_level(logging.INFO, logger="backend.app.context_budget")
+
+    selected = select_history(
+        turns=[Turn(secret)],
+        model="unknown-model",
+        config=_config(10_000),
+        system_prompt=secret,
+        tools=[],
+        current_message=secret,
+        token_counter=CharacterTokenCounter(),
+    )
+
+    assert selected.turns == ()
+    assert selected.decision.stop_reason == "unknown_model"
+    assert secret not in caplog.text
+
+
+def test_unknown_tokenizer_fails_closed() -> None:
+    with patch(
+        "backend.app.context_budget.TiktokenTokenCounter",
+        side_effect=ValueError("encoding unavailable"),
+    ):
+        selected = select_history(
+            turns=[Turn("pregunta")],
+            model="gpt-5.4-nano",
+            config=_config(10_000),
+            system_prompt="",
+            tools=[],
+            current_message="",
+        )
+
+    assert selected.turns == ()
+    assert selected.decision.stop_reason == "unknown_tokenizer"
+
+
+def test_cold_cache_failure_fails_closed_without_pii(caplog) -> None:
+    secret = "cliente@example.com necesita una batería"
+    caplog.set_level(logging.INFO, logger="backend.app.context_budget")
+
+    with patch(
+        "backend.app.token_counter.tiktoken.get_encoding",
+        side_effect=OSError("simulated offline cold cache"),
+    ):
+        selected = select_history(
+            turns=[Turn(secret)],
+            model="gpt-5.4-nano",
+            config=_config(10_000),
+            system_prompt=secret,
+            tools=[],
+            current_message=secret,
+        )
+
+    assert selected.decision.stop_reason == "unknown_tokenizer"
+    assert secret not in caplog.text
+
+
+def test_known_overhead_uses_greater_configured_reserve() -> None:
+    config = ContextBudgetConfig(0.10, 32_000, 2_000, 12_000, 20)
+
+    selected = select_history(
+        turns=[],
+        model="gpt-5.4-nano",
+        config=config,
+        system_prompt="short",
+        tools=[],
+        current_message="short",
+        token_counter=CharacterTokenCounter(),
+    )
+
+    assert selected.decision.known_overhead_tokens == 28
+    assert selected.decision.applied_non_history_reserve_tokens == 12_000
+    assert selected.decision.history_budget_tokens == 18_000
+
+
+def test_max_turns_is_a_secondary_ceiling() -> None:
+    selected = _select([Turn(str(number)) for number in range(3)], max_turns=2)
+
+    assert [turn.question for turn in selected.turns] == ["1", "2"]
+    assert selected.decision.stop_reason == "max_turns_ceiling"
+
+
+def test_success_logs_metrics_without_turn_content(caplog) -> None:
+    secret = "dato-privado@example.com"
+    caplog.set_level(logging.INFO, logger="backend.app.context_budget")
+
+    _select([Turn(secret)])
+
+    assert "selected_turns=1" in caplog.text
+    assert "stop_reason='all_history_fit'" in caplog.text
+    assert secret not in caplog.text


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega el selector puro que conserva el sufijo más reciente de turnos completos dentro del presupuesto model-aware. Falla cerrado ante modelos/tokenizers desconocidos y emite únicamente métricas sin contenido ni PII.

## Issues relacionados

Part of #262

## Tipo de cambio

- [x] 🆕 Nueva funcionalidad (feature)
- [ ] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [ ] 🧪 Tests
- [ ] 📄 Documentación / configuración
- [ ] 🔧 Infra / CI

## Chain context

```text
main
 ├─ ✅ #271 registry
 ├─ ✅ #281 counter
 ├─ ✅ #285 settings
 └─ 📍 PR 4: pure history selector
     └─ PR 5+: runtime wiring, File Input preflight and evidence
```

**Fuera de alcance:** integración en `/chat`, File Inputs y simulación.

## Checklist antes de pedir review

- [x] Tests focalizados pasan
- [x] Criterios del slice cumplidos
- [x] Sin secretos/PII
- [x] Sin dependencias nuevas
- [x] Sin schema HTTP
- [x] Sin harness

## Cómo probar este PR

1. `uv run pytest backend/tests/test_context_budget.py -q`
2. `uv run ruff check backend/app/context_budget.py backend/tests/test_context_budget.py`
3. `uv run mypy backend/app/context_budget.py backend/tests/test_context_budget.py`

Resultado esperado: 12 tests.

## Notas para el reviewer

Revisar el recorrido newest-to-oldest y la detención frente al primer turno oversized. Presupuesto: 397 líneas.
