### PR TITLE
feat(chat): apply token-budgeted conversation history

### DIFF
--- a/backend/app/session.py
+++ b/backend/app/session.py
@@ -9,11 +9,15 @@ from typing import Dict, List, Optional
 
 from pydantic import BaseModel
 
+from backend.app.config import settings
+from backend.app.context_budget import SelectedContext, select_history
+from backend.app.context_budget_config import ContextBudgetConfig
 from backend.app.state_repository import (
     ChatbotStateRepository,
     ChatTurn as RepositoryChatTurn,
     TokenTotals as RepositoryTokenTotals,
 )
+from backend.app.token_counter import TokenCounter
 
 
 class ChatTurn(BaseModel):
@@ -181,6 +185,32 @@ class SessionManager:
 
         return "\n".join(context_parts).strip()
 
+    def get_budgeted_context(
+        self,
+        *,
+        session_id: str,
+        model: str,
+        config: ContextBudgetConfig,
+        system_prompt: str,
+        tools: list[dict[str, object]],
+        current_message: str,
+        token_counter: Optional[TokenCounter] = None,
+    ) -> SelectedContext:
+        """Return the newest complete history turns that fit the token budget."""
+        return select_history(
+            turns=self.get_context_candidates(session_id),
+            model=model,
+            config=config,
+            system_prompt=system_prompt,
+            tools=tools,
+            current_message=current_message,
+            token_counter=token_counter,
+        )
+
+    def get_context_candidates(self, session_id: str) -> List[ChatTurn]:
+        """Return chronological candidates bounded by the configured turn ceiling."""
+        return self.get_history(session_id)[-self.max_turns :]
+
     def clear_session(self, session_id: str) -> None:
         """
         Elimina una sesión.
@@ -294,4 +324,4 @@ class SessionManager:
 
 
 # Instancia global del gestor de sesiones
-session_manager = SessionManager()
+session_manager = SessionManager(max_turns=settings.context_max_turns)

--- a/backend/main.py
+++ b/backend/main.py
@@ -980,6 +980,26 @@ async def _process_chat_message(
 
     source_docs: list[SourceDocument] = []
 
+    context_selection = session_manager.get_budgeted_context(
+        session_id=session_id,
+        model=llm_client.model,
+        config=settings.context_budget_config(),
+        system_prompt=system_prompt_with_profile,
+        tools=get_tool_definitions(),
+        current_message=expanded_query,
+    )
+    context_string = context_selection.context
+    decision = context_selection.decision
+    logger.info(
+        "Chat history selected: model=%s selected_turns=%d "
+        "selected_history_tokens=%d was_truncated=%s stop_reason=%s",
+        decision.model,
+        decision.selected_turns,
+        decision.selected_history_tokens,
+        decision.was_truncated,
+        decision.stop_reason,
+    )
+
     try:
         iteration = 0
         tool_results_summary = ""
@@ -997,15 +1017,9 @@ async def _process_chat_message(
                 session_id,
             )
 
-            context_string = session_manager.get_context_string(session_id)
-
             if iteration == 1:
                 user_input = expanded_query
-                if context_string:
-                    user_input = (
-                        f"Contexto de la conversación:\n{context_string}\n\n"
-                        f"Pregunta actual: {expanded_query}"
-                    )
+                request_context = context_string
             else:
                 user_input = (
                     f"Resultados de las herramientas invocadas anteriormente:\n"
@@ -1013,6 +1027,7 @@ async def _process_chat_message(
                     f"Pregunta original: {expanded_query}\n"
                     f"Considera los resultados anteriores y proporciona una respuesta final."
                 )
+                request_context = ""
 
             logger.debug(
                 "Calling LLM with tools: request_id=%s, session_id=%s, "
@@ -1027,7 +1042,7 @@ async def _process_chat_message(
                 message=user_input,
                 session_id=session_id,
                 system_prompt=system_prompt_with_profile,
-                context=context_string,
+                context=request_context,
             )
 
             last_output_text = llm_response.text

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -198,9 +198,8 @@ class TestChatEndpointUnit:
         """Test that the chat endpoint uses session context."""
         # Configurar mocks
         mock_llm.return_value = make_llm_response(text="Mocked LLM Response")
-        mock_session_manager.get_context_string.return_value = (
-            "Turno 1:\nUsuario: Pregunta anterior\nAsistente: Respuesta anterior"
-        )
+        context = "Turno 1:\nUsuario: Pregunta anterior\nAsistente: Respuesta anterior"
+        mock_session_manager.get_budgeted_context.return_value.context = context
         mock_session_manager.get_user_profile.return_value = None
         _bind_test_session("test-session-123")
 
@@ -217,11 +216,12 @@ class TestChatEndpointUnit:
         # Verificar que se llamó al LLM con el contexto
         mock_llm.assert_called_once()
         args, kwargs = mock_llm.call_args
-        # Message includes context when session context exists
-        assert "¿Y cuánto cuesta?" in kwargs["message"]
+        # The client owns request composition, so message and context stay separate.
+        assert kwargs["message"] == "¿Y cuánto cuesta?"
         assert kwargs["session_id"] == "test-session-123"
-        assert kwargs["context"] == mock_session_manager.get_context_string.return_value
+        assert kwargs["context"] == context
         assert "Pregunta anterior" in kwargs["context"]
+        assert "Pregunta anterior" not in kwargs["message"]
 
         # Verificar que se guardó el turno en la sesión
         mock_session_manager.add_turn.assert_called_once()
@@ -912,13 +912,19 @@ class TestAgenticLoopBehavior:
     @patch("backend.main.logger.warning")
     @patch("backend.main.get_catalog")
     @patch("backend.main.llm_client.get_llm_response_with_tools")
+    @patch("backend.main.session_manager")
     def test_agentic_loop_respects_max_iterations(
         self,
+        mock_session_manager: MagicMock,
         mock_llm: MagicMock,
         mock_get_catalog: MagicMock,
         mock_warning: MagicMock,
     ) -> None:
         """Verify the loop stops after reaching MAX_AGENTIC_ITERATIONS."""
+
+        mock_session_manager.get_user_profile.return_value = None
+        mock_session_manager.get_history.return_value = []
+        mock_session_manager.get_budgeted_context.return_value.context = "history"
 
         looping_response = make_llm_response(
             text="Sigo buscando opciones",
@@ -955,6 +961,11 @@ class TestAgenticLoopBehavior:
         assert "límite de iteraciones" in data["response"].lower()
         # Should have called LLM at least twice (iteration 1 and 2)
         assert mock_llm.call_count >= 2
+        assert [call.kwargs["context"] for call in mock_llm.call_args_list] == [
+            "history",
+            "",
+        ]
+        mock_session_manager.get_budgeted_context.assert_called_once()
         mock_catalog.search.assert_called()
         mock_warning.assert_called_once()
 

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -218,6 +218,32 @@ class TestLLMClientWithTools:
             mock_client.responses.create.call_args.kwargs["max_output_tokens"] == 3210
         )
 
+    @patch("backend.app.llm_client.OpenAI")
+    def test_context_is_injected_once_in_request_payload(
+        self, mock_openai_class: MagicMock
+    ) -> None:
+        """History has one composition owner and is not duplicated in input."""
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_response = MagicMock(
+            output_text="respuesta",
+            output=[MagicMock(type="message")],
+            usage=None,
+        )
+        mock_client.responses.create.return_value = mock_response
+        client = LLMClient(api_key="sk-test-key")
+
+        client.get_llm_response_with_tools(
+            message="pregunta actual",
+            session_id="test-session",
+            context="Usuario: pregunta anterior\nAsistente: respuesta anterior",
+        )
+
+        payload = mock_client.responses.create.call_args.kwargs["input"]
+        assert payload.count("Contexto de la conversación:") == 1
+        assert payload.count("pregunta anterior") == 1
+        assert payload.count("pregunta actual") == 1
+
     def test_get_llm_response_with_tools_raises_without_api_key(self) -> None:
         """Test get_llm_response_with_tools raises error without API key."""
         client = LLMClient(api_key="")

--- a/backend/tests/test_session.py
+++ b/backend/tests/test_session.py
@@ -4,11 +4,13 @@ Unit tests for the session management service.
 
 import threading
 from datetime import datetime
+from unittest.mock import patch
 
 import pytest
 
 from backend.app.dynamodb_state_repository import DynamoDBStateRepository
-from backend.app.session import SessionManager
+from backend.app.config import settings
+from backend.app.session import SessionManager, session_manager
 from backend.app.state_repository import ChatTurn, TokenTotals
 from backend.tests.test_state_repository import FakeDynamoDBTable
 
@@ -32,6 +34,32 @@ def test_session_manager_rejects_non_positive_max_turns(max_turns: int):
     """Test that SessionManager rejects invalid history limits."""
     with pytest.raises(ValueError, match="max_turns must be greater than zero"):
         SessionManager(max_turns=max_turns)
+
+
+def test_global_session_manager_uses_configured_context_turn_ceiling() -> None:
+    """Configured context turns cannot exceed globally retained history."""
+    assert session_manager.max_turns == settings.context_max_turns
+
+
+@patch("backend.app.session.select_history")
+def test_budgeted_context_uses_ordered_ceiling_candidates(mock_select) -> None:
+    manager = SessionManager(max_turns=2)
+    for number in range(3):
+        manager.add_turn("session", str(number), "respuesta")
+
+    manager.get_budgeted_context(
+        session_id="session",
+        model="gpt-5.4-nano",
+        config=settings.context_budget_config(),
+        system_prompt="system",
+        tools=[],
+        current_message="actual",
+    )
+
+    assert [turn.question for turn in mock_select.call_args.kwargs["turns"]] == [
+        "1",
+        "2",
+    ]
 
 
 def test_add_turn_creates_new_session():


### PR DESCRIPTION
## ¿Qué hace este PR?

Integra el selector por tokens en `/chat`, conserva el techo secundario de turnos y evita enviar el historial dos veces. El historial aparece únicamente en la primera iteración del loop; las iteraciones de tools no lo duplican.

## Issues relacionados

Part of #262

## Tipo de cambio

- [x] 🆕 Nueva funcionalidad (feature)
- [ ] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [ ] 🧪 Tests
- [ ] 📄 Documentación / configuración
- [ ] 🔧 Infra / CI

## Chain context

```text
main
 ├─ ✅ #271 registry
 ├─ ✅ #281 counter
 ├─ ✅ #285 settings
 ├─ ✅ #286 selector
 └─ 📍 PR 5: runtime history wiring
     └─ PR 6+: File Input preflight and evidence
```

**Fuera de alcance:** File Input budget y simulación.

## Cómo probar este PR

1. `uv run pytest backend/tests/test_session.py backend/tests/test_chat.py backend/tests/test_llm_client.py -q`
2. `uv run ruff check backend/app/session.py backend/main.py backend/tests/test_session.py backend/tests/test_chat.py backend/tests/test_llm_client.py`

Resultado staged: 112 passed, 3 skipped.

## Notas para el reviewer

Revisar primero la composición del request en `backend/main.py`. Diff: 142 líneas.
