### PR TITLE
feat(context): guard file input uploads

### DIFF
--- a/backend/app/file_input_budget.py
+++ b/backend/app/file_input_budget.py
@@ -1,0 +1,32 @@
+"""Conservative byte guard for File Input requests."""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class ContextBudgetError(ValueError):
+    """Raised before a File Input request that cannot fit its budget."""
+
+
+def validate_file_input_size(
+    *,
+    file_size_bytes: int,
+    max_file_size_bytes: int,
+) -> None:
+    """Reject files above the configured pre-upload byte ceiling."""
+    is_accepted = file_size_bytes <= max_file_size_bytes
+    reason = "accepted" if is_accepted else "file_size_exceeds_limit"
+    logger.info(
+        "File Input byte guard: file_size_bytes=%d max_file_size_bytes=%d "
+        "is_accepted=%s reason=%s",
+        file_size_bytes,
+        max_file_size_bytes,
+        is_accepted,
+        reason,
+    )
+    if not is_accepted:
+        raise ContextBudgetError(
+            "File Input request rejected by context budget: "
+            "file_size_exceeds_limit"
+        )

--- a/backend/app/file_input_budget.py
+++ b/backend/app/file_input_budget.py
@@ -27,6 +27,5 @@ def validate_file_input_size(
     )
     if not is_accepted:
         raise ContextBudgetError(
-            "File Input request rejected by context budget: "
-            "file_size_exceeds_limit"
+            "File Input request rejected by context budget: file_size_exceeds_limit"
         )

--- a/backend/app/file_inputs.py
+++ b/backend/app/file_inputs.py
@@ -84,11 +84,9 @@ class FileInputsClient:
 
         try:
             logger.debug(
-                "File upload initiated: filename=%s, size_bytes=%d",
-                filename,
+                "File Input upload initiated: size_bytes=%d",
                 len(pdf_bytes),
             )
-            logger.info("Uploading PDF to OpenAI Files API: %s", filename)
 
             # Create a file-like object from bytes
             file_obj = io.BytesIO(pdf_bytes)
@@ -101,26 +99,27 @@ class FileInputsClient:
             )
 
             file_id = response.id
-            logger.debug(
-                "File upload complete: file_id=%s, filename=%s",
-                file_id,
-                filename,
-            )
-            logger.info("Successfully uploaded file with ID: %s", file_id)
+            logger.info("File Input upload completed: size_bytes=%d", len(pdf_bytes))
             return file_id
 
         except AuthenticationError as e:
-            logger.error("OpenAI authentication error: %s", e)
+            logger.error("OpenAI authentication error during File Input upload")
             raise FileUploadError("Invalid OpenAI API key") from e
         except BadRequestError as e:
-            logger.error("OpenAI bad request error: %s", e)
-            raise FileUploadError(f"Invalid file format or request: {e}") from e
+            logger.error("OpenAI rejected File Input upload")
+            raise FileUploadError("Invalid file format or request") from e
         except APIError as e:
-            logger.error("OpenAI API error: %s", e)
-            raise FileUploadError(f"OpenAI API error: {e}") from e
+            logger.error(
+                "OpenAI File Input upload failed: error_type=%s",
+                type(e).__name__,
+            )
+            raise FileUploadError("OpenAI API error during File Input upload") from e
         except Exception as e:
-            logger.exception("Unexpected error uploading file: %s", e)
-            raise FileUploadError(f"Unexpected error: {e}") from e
+            logger.error(
+                "Unexpected File Input upload failure: error_type=%s",
+                type(e).__name__,
+            )
+            raise FileUploadError("Unexpected File Input upload failure") from e
 
     def delete_file(self, file_id: str) -> None:
         """Delete a file from OpenAI Files API.
@@ -135,17 +134,21 @@ class FileInputsClient:
             raise FileUploadError("OpenAI API key not configured")
 
         try:
-            logger.debug("File deletion initiated: file_id=%s", file_id)
-            logger.info("Deleting OpenAI file: %s", file_id)
+            logger.debug("File Input deletion initiated")
             self.client.files.delete(file_id)
-            logger.debug("File deletion complete: file_id=%s", file_id)
-            logger.info("Successfully deleted file: %s", file_id)
+            logger.info("File Input deletion completed")
         except AuthenticationError as e:
-            logger.error("OpenAI authentication error: %s", e)
+            logger.error("OpenAI authentication error during File Input deletion")
             raise FileUploadError("Invalid OpenAI API key") from e
         except APIError as e:
-            logger.error("OpenAI API error deleting file: %s", e)
-            raise FileUploadError(f"Error deleting file: {e}") from e
+            logger.error(
+                "OpenAI File Input deletion failed: error_type=%s",
+                type(e).__name__,
+            )
+            raise FileUploadError("Error deleting file") from e
         except Exception as e:
-            logger.exception("Unexpected error deleting file: %s", e)
-            raise FileUploadError(f"Unexpected error: {e}") from e
+            logger.error(
+                "Unexpected File Input deletion failure: error_type=%s",
+                type(e).__name__,
+            )
+            raise FileUploadError("Unexpected File Input deletion failure") from e

--- a/backend/main.py
+++ b/backend/main.py
@@ -51,6 +51,7 @@ from backend.app.conversation_logger import (
     redact_text,
 )
 from backend.app.dynamodb_state_repository import DynamoDBStateRepository
+from backend.app.file_input_budget import validate_file_input_size
 from backend.app.file_inputs import FileInputsClient, FileUploadError
 from backend.app.greeting import maybe_prepend_greeting
 from backend.app.llm_client import (
@@ -687,9 +688,9 @@ async def _process_leer_ficha_tecnica(
             catalog = get_catalog()
         except CatalogError as e:
             logger.error(
-                "Catalog unavailable while validating ruta_s3: session_id=%s, error=%s",
-                session_id,
-                e,
+                "File Input catalog validation failed: "
+                "reason=catalog_unavailable error_type=%s",
+                type(e).__name__,
             )
             raise ValueError("No pude validar la ficha técnica en el catálogo") from e
 
@@ -697,25 +698,22 @@ async def _process_leer_ficha_tecnica(
             raise ValueError("Requested datasheet is not declared in the catalog")
 
     logger.debug(
-        "Tool call parameters: function=%s, ruta_s3=%s, categoria=%s, "
-        "fabricante=%s, modelo=%s, session_id=%s",
-        function_name,
-        ruta_s3,
-        categoria,
-        fabricante,
-        modelo,
-        session_id,
+        "File Input tool parameters: has_route=%s has_category=%s "
+        "has_manufacturer=%s has_model=%s",
+        bool(ruta_s3),
+        bool(categoria),
+        bool(fabricante),
+        bool(modelo),
     )
 
     # If ruta_s3 is not provided, try to find it via catalog search
     if not ruta_s3:
         logger.info(
-            "No ruta_s3 provided, searching catalog: categoria=%s, "
-            "fabricante=%s, modelo=%s, session_id=%s",
-            categoria,
-            fabricante,
-            modelo,
-            session_id,
+            "File Input catalog lookup started: reason=route_missing "
+            "has_category=%s has_manufacturer=%s has_model=%s",
+            bool(categoria),
+            bool(fabricante),
+            bool(modelo),
         )
 
         if not categoria:
@@ -746,29 +744,22 @@ async def _process_leer_ficha_tecnica(
                 ruta_s3 = results[0].ruta_s3
                 validate_s3_path(ruta_s3)
                 logger.info(
-                    "Found single product, using ruta_s3=%s, session_id=%s",
-                    ruta_s3,
-                    session_id,
+                    "File Input catalog lookup resolved: matches=1 selection=single"
                 )
             else:
                 # Multiple products found - select first one deterministically
                 ruta_s3 = results[0].ruta_s3
                 validate_s3_path(ruta_s3)
                 logger.warning(
-                    "Multiple products found when resolving ruta_s3, selecting first: "
-                    "ruta_s3=%s, session_id=%s, available=%d, products=%s",
-                    ruta_s3,
-                    session_id,
+                    "File Input catalog lookup resolved: matches=%d selection=first",
                     len(results),
-                    [p.nombre_comercial for p in results],
                 )
         except CatalogError as e:
             logger.error(
-                "Catalog error when resolving ruta_s3: session_id=%s, error=%s",
-                session_id,
-                e,
+                "File Input catalog lookup failed: reason=search_failed error_type=%s",
+                type(e).__name__,
             )
-            raise ValueError(f"Failed to search catalog: {e}") from e
+            raise ValueError("Failed to search catalog") from e
 
     # Download PDF from S3
     try:
@@ -776,13 +767,11 @@ async def _process_leer_ficha_tecnica(
     except S3DownloadError:
         # Fallback: if direct download fails, search catalog using other parameters
         logger.info(
-            "Direct download failed for ruta_s3=%s, trying catalog fallback: "
-            "categoria=%s, fabricante=%s, modelo=%s, session_id=%s",
-            ruta_s3,
-            categoria,
-            fabricante,
-            modelo,
-            session_id,
+            "File Input download retry: reason=direct_download_failed "
+            "has_category=%s has_manufacturer=%s has_model=%s",
+            bool(categoria),
+            bool(fabricante),
+            bool(modelo),
         )
 
         if categoria:
@@ -799,9 +788,7 @@ async def _process_leer_ficha_tecnica(
                 ruta_s3 = results[0].ruta_s3
                 validate_s3_path(ruta_s3)
                 logger.info(
-                    "Fallback successful, using ruta_s3=%s, session_id=%s",
-                    ruta_s3,
-                    session_id,
+                    "File Input download fallback resolved: matches=1 selection=single"
                 )
                 pdf_bytes = await asyncio.to_thread(s3_client.download_pdf, ruta_s3)
             elif len(results) > 1:
@@ -809,10 +796,7 @@ async def _process_leer_ficha_tecnica(
                 ruta_s3 = results[0].ruta_s3
                 validate_s3_path(ruta_s3)
                 logger.warning(
-                    "Multiple products found during fallback, selecting first: "
-                    "ruta_s3=%s, session_id=%s, available_products=%d",
-                    ruta_s3,
-                    session_id,
+                    "File Input download fallback resolved: matches=%d selection=first",
                     len(results),
                 )
                 pdf_bytes = await asyncio.to_thread(s3_client.download_pdf, ruta_s3)
@@ -828,6 +812,11 @@ async def _process_leer_ficha_tecnica(
 
     # Generate filename from ruta_s3
     filename = ruta_s3.split("/")[-1] if "/" in ruta_s3 else ruta_s3
+
+    validate_file_input_size(
+        file_size_bytes=len(pdf_bytes),
+        max_file_size_bytes=settings.context_file_input_max_bytes,
+    )
 
     # Upload PDF to OpenAI
     file_id = await asyncio.to_thread(
@@ -850,10 +839,8 @@ async def _process_leer_ficha_tecnica(
             await asyncio.to_thread(file_inputs_client.delete_file, file_id)
         except Exception as e:
             logger.warning(
-                "Failed to delete file: file_id=%s, session_id=%s, error=%s",
-                file_id,
-                session_id,
-                e,
+                "Failed to delete uploaded File Input: error_type=%s",
+                type(e).__name__,
             )
 
 
@@ -1291,12 +1278,10 @@ async def _process_chat_message(
                         )
                 except S3DownloadError as e:
                     logger.error(
-                        "S3 download error in tool call: request_id=%s, "
-                        "session_id=%s, function=%s, error=%s",
-                        request_id,
-                        session_id,
+                        "Tool call failed: function=%s reason=s3_download_error "
+                        "error_type=%s",
                         function_name,
-                        e,
+                        type(e).__name__,
                     )
                     tool_results.append(
                         {
@@ -1313,12 +1298,10 @@ async def _process_chat_message(
                     )
                 except FileUploadError as e:
                     logger.error(
-                        "File upload error in tool call: request_id=%s, "
-                        "session_id=%s, function=%s, error=%s",
-                        request_id,
-                        session_id,
+                        "Tool call failed: function=%s reason=file_upload_error "
+                        "error_type=%s",
                         function_name,
-                        e,
+                        type(e).__name__,
                     )
                     tool_results.append(
                         {
@@ -1333,12 +1316,10 @@ async def _process_chat_message(
                     )
                 except ValueError as e:
                     logger.warning(
-                        "ValueError in tool call: request_id=%s, session_id=%s, "
-                        "function=%s, error=%s",
-                        request_id,
-                        session_id,
+                        "Tool call failed: function=%s reason=validation_error "
+                        "error_type=%s",
                         function_name,
-                        e,
+                        type(e).__name__,
                     )
                     tool_results.append(
                         {
@@ -1349,13 +1330,11 @@ async def _process_chat_message(
                         }
                     )
                 except Exception as e:
-                    logger.exception(
-                        "Error processing tool call: request_id=%s, session_id=%s, "
-                        "function=%s, error=%s",
-                        request_id,
-                        session_id,
+                    logger.error(
+                        "Tool call failed: function=%s reason=unexpected_error "
+                        "error_type=%s",
                         function_name,
-                        e,
+                        type(e).__name__,
                     )
                     tool_results.append(
                         {

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -1203,17 +1203,30 @@ class TestProcessToolCall:
         mock_file_inputs: MagicMock,
         mock_s3: MagicMock,
         mock_get_catalog: MagicMock,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Test _process_leer_ficha_tecnica handles successful execution."""
+        from backend.app.catalog import CatalogError
         from backend.main import _process_leer_ficha_tecnica
 
+        caplog.set_level("DEBUG", logger="backend.main")
         # Mock S3 download
         mock_s3.download_pdf.return_value = b"%PDF-1.4 test"
 
         # Mock file upload
-        mock_file_inputs.upload_pdf.return_value = "file-xyz789"
+        mock_file_inputs.upload_pdf.return_value = "file-secret-xyz789"
+        mock_file_inputs.delete_file.side_effect = RuntimeError("exception-secret")
         mock_catalog = MagicMock()
-        mock_catalog.contains_ruta_s3.return_value = True
+        mock_catalog.search.return_value = [
+            MagicMock(
+                ruta_s3="raw/paneles/route-secret-a.pdf",
+                nombre_comercial="product-secret-a",
+            ),
+            MagicMock(
+                ruta_s3="raw/paneles/route-secret-b.pdf",
+                nombre_comercial="product-secret-b",
+            ),
+        ]
         mock_get_catalog.return_value = mock_catalog
 
         # Mock second LLM call
@@ -1228,22 +1241,99 @@ class TestProcessToolCall:
                 "id": "call_123",
                 "function": {
                     "name": "leer_ficha_tecnica",
-                    "arguments": '{"ruta_s3": "raw/paneles/jinko.pdf", "categoria": "paneles", "fabricante": "Jinko", "modelo": "Tiger"}',
+                    "arguments": '{"categoria": "category-secret", "fabricante": "maker-secret", "modelo": "model-secret"}',
                 },
             }
 
             result, source_docs = await _process_leer_ficha_tecnica(
                 tool_call=tool_call,
-                user_message="Specs del panel",
-                session_id="test-session",
+                user_message="message-secret",
+                session_id="session-secret",
                 llm_client=llm_client,
                 s3_client=mock_s3,
                 file_inputs_client=mock_file_inputs,
             )
 
         assert "460W" in result.text
-        assert source_docs == ["raw/paneles/jinko.pdf"]
-        mock_file_inputs.delete_file.assert_called_once_with("file-xyz789")
+        assert source_docs == ["raw/paneles/route-secret-a.pdf"]
+        mock_file_inputs.delete_file.assert_called_once_with("file-secret-xyz789")
+        assert "matches=2 selection=first" in caplog.text
+        for secret in (
+            "route-secret",
+            "product-secret",
+            "category-secret",
+            "maker-secret",
+            "model-secret",
+            "message-secret",
+            "session-secret",
+            "file-secret-xyz789",
+            "exception-secret",
+        ):
+            assert secret not in caplog.text
+        caplog.clear()
+        mock_get_catalog.side_effect = CatalogError("exception-secret")
+        tool_call["function"]["arguments"] = (
+            '{"ruta_s3":"raw/paneles/route-secret.pdf"}'
+        )
+
+        with pytest.raises(ValueError, match="validar la ficha"):
+            await _process_leer_ficha_tecnica(
+                tool_call=tool_call,
+                user_message="message-secret",
+                session_id="session-secret",
+                llm_client=llm_client,
+                s3_client=mock_s3,
+                file_inputs_client=mock_file_inputs,
+            )
+
+        assert "reason=catalog_unavailable" in caplog.text
+        assert "error_type=CatalogError" in caplog.text
+        assert "route-secret" not in caplog.text
+        assert "exception-secret" not in caplog.text
+
+    @pytest.mark.asyncio
+    @patch("backend.main.get_catalog")
+    async def test_process_tool_call_rejects_budget_before_upload(
+        self,
+        mock_get_catalog: MagicMock,
+    ) -> None:
+        """A rejected File Input budget prevents upload and provider execution."""
+        from backend.app.file_input_budget import ContextBudgetError
+        from backend.main import _process_leer_ficha_tecnica
+
+        mock_catalog = MagicMock()
+        mock_catalog.contains_ruta_s3.return_value = True
+        mock_get_catalog.return_value = mock_catalog
+        mock_s3 = MagicMock()
+        mock_s3.download_pdf.return_value = b"%PDF-1.4 oversized"
+        mock_file_inputs = MagicMock()
+        mock_llm_client = MagicMock(model="gpt-5.4-nano")
+        tool_call = {
+            "id": "call_budget",
+            "function": {
+                "name": "leer_ficha_tecnica",
+                "arguments": '{"ruta_s3": "raw/paneles/test.pdf"}',
+            },
+        }
+
+        with patch(
+            "backend.main.validate_file_input_size",
+            side_effect=ContextBudgetError("file_size_exceeds_limit"),
+        ) as mock_validate:
+            with pytest.raises(ContextBudgetError, match="file_size_exceeds_limit"):
+                await _process_leer_ficha_tecnica(
+                    tool_call=tool_call,
+                    user_message="Specs",
+                    session_id="test-session",
+                    llm_client=mock_llm_client,
+                    s3_client=mock_s3,
+                    file_inputs_client=mock_file_inputs,
+                )
+
+        assert mock_validate.call_args.kwargs["file_size_bytes"] == len(
+            b"%PDF-1.4 oversized"
+        )
+        mock_file_inputs.upload_pdf.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("backend.main.s3_client")

--- a/backend/tests/test_file_input_budget.py
+++ b/backend/tests/test_file_input_budget.py
@@ -1,0 +1,31 @@
+"""Focused tests for the pre-upload File Input byte guard."""
+
+import logging
+
+import pytest
+
+from backend.app.file_input_budget import ContextBudgetError, validate_file_input_size
+
+
+def test_byte_guard_accepts_exact_boundary(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="backend.app.file_input_budget")
+
+    validate_file_input_size(file_size_bytes=1_000, max_file_size_bytes=1_000)
+
+    assert "file_size_bytes=1000" in caplog.text
+    assert "is_accepted=True" in caplog.text
+    assert "reason=accepted" in caplog.text
+
+
+def test_byte_guard_rejects_before_upload_without_logging_content(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    secret = "cliente@example.com"
+    caplog.set_level(logging.INFO, logger="backend.app.file_input_budget")
+
+    with pytest.raises(ContextBudgetError, match="file_size_exceeds_limit"):
+        validate_file_input_size(file_size_bytes=1_001, max_file_size_bytes=1_000)
+
+    assert "is_accepted=False" in caplog.text
+    assert "reason=file_size_exceeds_limit" in caplog.text
+    assert secret not in caplog.text

--- a/backend/tests/test_file_inputs.py
+++ b/backend/tests/test_file_inputs.py
@@ -4,6 +4,7 @@ Unit tests for the file_inputs.py module.
 Tests the File Inputs client for OpenAI Files API integration.
 """
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -65,6 +66,44 @@ class TestFileInputsClientInitialization:
 
 class TestFileInputsClientUpload:
     """Tests for upload_pdf method."""
+
+    @patch("backend.app.file_inputs.OpenAI")
+    def test_file_lifecycle_logs_omit_names_and_provider_ids(
+        self,
+        mock_openai_class: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        caplog.set_level(logging.DEBUG, logger="backend.app.file_inputs")
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_client.files.create.return_value.id = "file-private-123"
+        client = FileInputsClient(api_key="sk-test-key")
+
+        file_id = client.upload_pdf(b"%PDF-1.4 private", "cliente@example.com.pdf")
+        client.delete_file(file_id)
+
+        assert "size_bytes=16" in caplog.text
+        assert "cliente@example.com.pdf" not in caplog.text
+        assert "file-private-123" not in caplog.text
+
+    @patch("backend.app.file_inputs.OpenAI")
+    def test_upload_failure_logs_omit_error_body(
+        self,
+        mock_openai_class: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        secret = "cliente@example.com private provider body"
+        caplog.set_level(logging.ERROR, logger="backend.app.file_inputs")
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_client.files.create.side_effect = RuntimeError(secret)
+        client = FileInputsClient(api_key="sk-test-key")
+
+        with pytest.raises(FileUploadError, match="Unexpected File Input"):
+            client.upload_pdf(b"%PDF-1.4 private", "private.pdf")
+
+        assert "error_type=RuntimeError" in caplog.text
+        assert secret not in caplog.text
 
     @patch("backend.app.file_inputs.OpenAI")
     def test_upload_pdf_success(self, mock_openai_class: MagicMock) -> None:


### PR DESCRIPTION
## ¿Qué hace este PR?

Rechaza File Inputs sobredimensionados antes del upload y endurece el logging del flujo para no exponer rutas, productos, IDs ni cuerpos de excepciones. Mantiene el guard de bytes separado del conteo exacto que llegará en el siguiente slice.

## Issues relacionados

Part of #262

## Tipo de cambio

- [x] 🆕 Nueva funcionalidad (feature)
- [ ] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [ ] 🧪 Tests
- [ ] 📄 Documentación / configuración
- [ ] 🔧 Infra / CI

## Chain context

```text
main
 ├─ ✅ #271 #281 #285 #286 #287
 └─ 📍 PR 6: File Input byte guard and safe logs
     └─ PR 7+: exact token preflight and evidence
```

## Cómo probar este PR

1. `uv run pytest backend/tests/test_file_input_budget.py backend/tests/test_file_inputs.py backend/tests/test_chat.py -q`
2. Ejecutar Ruff sobre los seis archivos modificados.

## Notas para el reviewer

El límite de bytes protege upload/costo, pero no pretende estimar tokens extraídos. Diff: 374 líneas.
