### PR TITLE
feat(context): enforce exact file input token preflight

### DIFF
--- a/backend/app/file_input_budget.py
+++ b/backend/app/file_input_budget.py
@@ -1,12 +1,28 @@
-"""Conservative byte guard for File Input requests."""
+"""Conservative guards for File Input requests."""
 
 import logging
+import math
+from dataclasses import dataclass
+
+from backend.app.context_budget_config import ContextBudgetConfig
+from backend.app.model_capabilities import get_model_capabilities
 
 logger = logging.getLogger(__name__)
 
 
 class ContextBudgetError(ValueError):
     """Raised before a File Input request that cannot fit its budget."""
+
+
+@dataclass(frozen=True)
+class FileInputBudgetDecision:
+    model: str
+    input_limit_tokens: int
+    counted_input_tokens: int
+    output_reserve_tokens: int
+    is_accepted: bool
+    reason: str
+    registry_version: str | None
 
 
 def validate_file_input_size(
@@ -29,3 +45,63 @@ def validate_file_input_size(
         raise ContextBudgetError(
             "File Input request rejected by context budget: file_size_exceeds_limit"
         )
+
+
+def validate_file_input_token_count(
+    *, model: str, config: ContextBudgetConfig, counted_input_tokens: int
+) -> FileInputBudgetDecision:
+    capabilities = get_model_capabilities(model)
+    if capabilities is None:
+        return _reject(model, "unknown_model")
+
+    gross_limit = min(
+        config.hard_cap_tokens,
+        math.floor(capabilities.context_window_tokens * config.ratio),
+    )
+    input_limit = max(0, gross_limit - config.output_reserve_tokens)
+    reason = "accepted"
+    if config.output_reserve_tokens > capabilities.max_output_tokens:
+        reason = "output_reserve_exceeds_model"
+    elif counted_input_tokens < 0:
+        reason = "invalid_input_token_count"
+    elif counted_input_tokens > input_limit:
+        reason = "input_tokens_exceed_limit"
+
+    decision = FileInputBudgetDecision(
+        model,
+        input_limit,
+        counted_input_tokens,
+        config.output_reserve_tokens,
+        reason == "accepted",
+        reason,
+        capabilities.registry_version,
+    )
+    _log_decision(decision)
+    if not decision.is_accepted:
+        raise ContextBudgetError(
+            f"File Input request rejected by context budget: {decision.reason}"
+        )
+    return decision
+
+
+def _reject(model: str, reason: str) -> FileInputBudgetDecision:
+    decision = FileInputBudgetDecision(model, 0, 0, 0, False, reason, None)
+    _log_decision(decision)
+    raise ContextBudgetError(
+        f"File Input request rejected by context budget: {decision.reason}"
+    )
+
+
+def _log_decision(decision: FileInputBudgetDecision) -> None:
+    logger.info(
+        "File Input budget decision: model=%s registry_version=%s "
+        "input_limit_tokens=%d counted_input_tokens=%d output_reserve_tokens=%d "
+        "is_accepted=%s reason=%s",
+        decision.model,
+        decision.registry_version,
+        decision.input_limit_tokens,
+        decision.counted_input_tokens,
+        decision.output_reserve_tokens,
+        decision.is_accepted,
+        decision.reason,
+    )

--- a/backend/app/llm_client.py
+++ b/backend/app/llm_client.py
@@ -12,6 +12,11 @@ from openai import APIError, AuthenticationError, OpenAI
 
 from backend.app.config import settings
 from backend.app.conversation_logger import redact_text
+from backend.app.file_input_budget import (
+    ContextBudgetError,
+    validate_file_input_token_count,
+)
+from backend.app.model_capabilities import get_model_capabilities
 from backend.app.schemas import LLMResponse
 from backend.app.secret_resolver import configured_secret_value
 from backend.app.tools import get_tool_definitions
@@ -301,31 +306,31 @@ class LLMClient:
             raise LLMServiceError("Missing OpenAI API key.")
 
         instructions = system_prompt or DATASHEET_SYSTEM_PROMPT
-
-        logger.debug(
-            "LLM call with file: model=%s, session_id=%s, file_id=%s, "
-            "message_preview=%s",
-            self.model,
-            session_id,
-            file_id,
-            redact_text(message)[:100],
+        input_payload: list[dict[str, object]] = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_file", "file_id": file_id},
+                    {"type": "input_text", "text": message},
+                ],
+            }
+        ]
+        reasoning = {"effort": "medium"}
+        self._preflight_file_input_request(
+            instructions=instructions,
+            input_payload=input_payload,
+            reasoning=reasoning,
         )
+
+        logger.debug("LLM File Input request preflight accepted: model=%s", self.model)
 
         try:
             response = self.openai_client.responses.create(
                 model=self.model,
                 instructions=instructions,
-                input=[
-                    {
-                        "role": "user",
-                        "content": [
-                            {"type": "input_file", "file_id": file_id},
-                            {"type": "input_text", "text": message},
-                        ],
-                    }
-                ],
+                input=input_payload,
                 max_output_tokens=settings.llm_max_output_tokens,
-                reasoning={"effort": "medium"},
+                reasoning=reasoning,
                 prompt_cache_key=session_id,
             )
 
@@ -350,3 +355,63 @@ class LLMClient:
         except Exception as e:
             logger.exception("Unexpected error calling OpenAI API (file): %s", e)
             raise LLMServiceError(f"LLM service error: {e}") from e
+
+    def _preflight_file_input_request(
+        self,
+        *,
+        instructions: str,
+        input_payload: list[dict[str, object]],
+        reasoning: dict[str, str],
+    ) -> None:
+        """Count the exact File Input payload remotely and fail closed."""
+        if get_model_capabilities(self.model) is None:
+            validate_file_input_token_count(
+                model=self.model,
+                config=settings.context_budget_config(),
+                counted_input_tokens=0,
+            )
+
+        input_tokens_resource = getattr(
+            self.openai_client.responses,
+            "input_tokens",
+            None,
+        )
+        count_method = getattr(input_tokens_resource, "count", None)
+        if not callable(count_method):
+            logger.warning(
+                "File Input token preflight rejected: model=%s "
+                "reason=input_token_counter_unavailable",
+                self.model,
+            )
+            raise ContextBudgetError(
+                "File Input request rejected by context budget: "
+                "input_token_counter_unavailable"
+            )
+
+        try:
+            count_response = count_method(
+                model=self.model,
+                instructions=instructions,
+                input=input_payload,
+                reasoning=reasoning,
+            )
+            counted_input_tokens = count_response.input_tokens
+            if not isinstance(counted_input_tokens, int):
+                raise TypeError("Input token count response was not an integer")
+        except Exception as error:
+            logger.warning(
+                "File Input token preflight rejected: model=%s "
+                "reason=input_token_count_failed error_type=%s",
+                self.model,
+                type(error).__name__,
+            )
+            raise ContextBudgetError(
+                "File Input request rejected by context budget: "
+                "input_token_count_failed"
+            ) from error
+
+        validate_file_input_token_count(
+            model=self.model,
+            config=settings.context_budget_config(),
+            counted_input_tokens=counted_input_tokens,
+        )

--- a/backend/app/llm_client.py
+++ b/backend/app/llm_client.py
@@ -236,7 +236,7 @@ class LLMClient:
                 input=user_input,
                 tools=tools,
                 max_output_tokens=settings.llm_max_output_tokens,
-                reasoning={"effort": "none"},
+                reasoning={"effort": "low"},
                 prompt_cache_key=session_id,
             )
 

--- a/backend/app/llm_client.py
+++ b/backend/app/llm_client.py
@@ -236,7 +236,7 @@ class LLMClient:
                 input=user_input,
                 tools=tools,
                 max_output_tokens=settings.llm_max_output_tokens,
-                reasoning={"effort": "medium"},
+                reasoning={"effort": "low"},
                 prompt_cache_key=session_id,
             )
 

--- a/backend/app/llm_client.py
+++ b/backend/app/llm_client.py
@@ -236,7 +236,7 @@ class LLMClient:
                 input=user_input,
                 tools=tools,
                 max_output_tokens=settings.llm_max_output_tokens,
-                reasoning={"effort": "low"},
+                reasoning={"effort": "none"},
                 prompt_cache_key=session_id,
             )
 
@@ -315,7 +315,7 @@ class LLMClient:
                 ],
             }
         ]
-        reasoning = {"effort": "low"}
+        reasoning = {"effort": "none"}
         self._preflight_file_input_request(
             instructions=instructions,
             input_payload=input_payload,

--- a/backend/app/llm_client.py
+++ b/backend/app/llm_client.py
@@ -315,7 +315,7 @@ class LLMClient:
                 ],
             }
         ]
-        reasoning = {"effort": "medium"}
+        reasoning = {"effort": "low"}
         self._preflight_file_input_request(
             instructions=instructions,
             input_payload=input_payload,

--- a/backend/tests/test_file_input_budget.py
+++ b/backend/tests/test_file_input_budget.py
@@ -4,7 +4,21 @@ import logging
 
 import pytest
 
-from backend.app.file_input_budget import ContextBudgetError, validate_file_input_size
+from backend.app.context_budget_config import ContextBudgetConfig
+from backend.app.file_input_budget import (
+    ContextBudgetError,
+    validate_file_input_size,
+    validate_file_input_token_count,
+)
+
+
+TOKEN_CONFIG = ContextBudgetConfig(
+    ratio=1.0,
+    hard_cap_tokens=32_000,
+    output_reserve_tokens=2_000,
+    non_history_reserve_tokens=0,
+    max_turns=1,
+)
 
 
 def test_byte_guard_accepts_exact_boundary(caplog: pytest.LogCaptureFixture) -> None:
@@ -29,3 +43,32 @@ def test_byte_guard_rejects_before_upload_without_logging_content(
     assert "is_accepted=False" in caplog.text
     assert "reason=file_size_exceeds_limit" in caplog.text
     assert secret not in caplog.text
+
+
+def test_token_guard_accepts_exact_effective_boundary() -> None:
+    decision = validate_file_input_token_count(
+        model="gpt-5.4-nano",
+        config=TOKEN_CONFIG,
+        counted_input_tokens=30_000,
+    )
+
+    assert decision.input_limit_tokens == 30_000
+    assert decision.output_reserve_tokens == 2_000
+    assert decision.is_accepted is True
+
+
+def test_token_guard_rejects_one_token_over_effective_limit(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.INFO, logger="backend.app.file_input_budget")
+
+    with pytest.raises(ContextBudgetError, match="input_tokens_exceed_limit"):
+        validate_file_input_token_count(
+            model="gpt-5.4-nano",
+            config=TOKEN_CONFIG,
+            counted_input_tokens=30_001,
+        )
+
+    assert "counted_input_tokens=30001" in caplog.text
+    assert "is_accepted=False" in caplog.text
+    assert "reason=input_tokens_exceed_limit" in caplog.text

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -201,6 +201,7 @@ class TestLLMClientWithTools:
         call_kwargs = mock_client.responses.create.call_args.kwargs
         assert "instructions" in call_kwargs
         assert call_kwargs["instructions"] == ARTE_SYSTEM_PROMPT
+        assert call_kwargs["reasoning"] == {"effort": "low"}
 
     @patch.dict(
         os.environ,

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -493,6 +493,7 @@ class TestLLMClientWithFile:
         assert count_kwargs["instructions"] == create_kwargs["instructions"]
         assert count_kwargs["input"] == create_kwargs["input"]
         assert count_kwargs["reasoning"] == create_kwargs["reasoning"]
+        assert create_kwargs["reasoning"] == {"effort": "low"}
 
     @patch("backend.app.llm_client.OpenAI")
     def test_file_request_official_count_over_budget_skips_create(

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -201,7 +201,7 @@ class TestLLMClientWithTools:
         call_kwargs = mock_client.responses.create.call_args.kwargs
         assert "instructions" in call_kwargs
         assert call_kwargs["instructions"] == ARTE_SYSTEM_PROMPT
-        assert call_kwargs["reasoning"] == {"effort": "none"}
+        assert call_kwargs["reasoning"] == {"effort": "low"}
 
     @patch.dict(
         os.environ,

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -201,7 +201,7 @@ class TestLLMClientWithTools:
         call_kwargs = mock_client.responses.create.call_args.kwargs
         assert "instructions" in call_kwargs
         assert call_kwargs["instructions"] == ARTE_SYSTEM_PROMPT
-        assert call_kwargs["reasoning"] == {"effort": "low"}
+        assert call_kwargs["reasoning"] == {"effort": "none"}
 
     @patch.dict(
         os.environ,
@@ -494,7 +494,7 @@ class TestLLMClientWithFile:
         assert count_kwargs["instructions"] == create_kwargs["instructions"]
         assert count_kwargs["input"] == create_kwargs["input"]
         assert count_kwargs["reasoning"] == create_kwargs["reasoning"]
-        assert create_kwargs["reasoning"] == {"effort": "low"}
+        assert create_kwargs["reasoning"] == {"effort": "none"}
 
     @patch("backend.app.llm_client.OpenAI")
     def test_file_request_official_count_over_budget_skips_create(

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -12,6 +12,7 @@ import pytest
 
 from backend.app import llm_client as llm_client_module
 from backend.app.config import settings
+from backend.app.file_input_budget import ContextBudgetError
 from backend.app.llm_client import (
     ARTE_SYSTEM_PROMPT,
     DATASHEET_SYSTEM_PROMPT,
@@ -20,6 +21,16 @@ from backend.app.llm_client import (
 )
 from backend.app.schemas import LLMResponse
 from backend.app.secret_resolver import clear_runtime_secret_cache
+
+
+def _mock_official_input_count(
+    mock_client: MagicMock,
+    input_tokens: int = 100,
+) -> None:
+    """Configure the SDK input-token counter without a network call."""
+    response = MagicMock()
+    response.input_tokens = input_tokens
+    mock_client.responses.input_tokens.count.return_value = response
 
 
 @pytest.fixture(autouse=True)
@@ -365,11 +376,12 @@ class TestLLMClientWithFile:
         )
         client = LLMClient(api_key="sk-test-key")
 
-        client.get_llm_response_with_file(
-            message="Test",
-            file_id="file-123",
-            session_id="test-session",
-        )
+        with patch.object(client, "_preflight_file_input_request"):
+            client.get_llm_response_with_file(
+                message="Test",
+                file_id="file-123",
+                session_id="test-session",
+            )
 
         assert (
             mock_client.responses.create.call_args.kwargs["max_output_tokens"] == 3210
@@ -388,6 +400,7 @@ class TestLLMClientWithFile:
         mock_response = MagicMock()
         mock_response.output_text = "El panel tiene una potencia de 460W..."
         mock_client.responses.create.return_value = mock_response
+        _mock_official_input_count(mock_client)
 
         client = LLMClient(api_key="sk-test-key")
         result = client.get_llm_response_with_file(
@@ -426,6 +439,7 @@ class TestLLMClientWithFile:
         mock_response = MagicMock()
         mock_response.output_text = "Test"
         mock_client.responses.create.return_value = mock_response
+        _mock_official_input_count(mock_client)
 
         client = LLMClient(api_key="sk-test-key")
         client.get_llm_response_with_file(
@@ -452,6 +466,120 @@ class TestLLMClientWithFile:
 
         assert "Missing OpenAI API key" in str(exc_info.value)
 
+    @patch("backend.app.llm_client.OpenAI")
+    def test_file_request_official_count_exact_boundary(
+        self,
+        mock_openai_class: MagicMock,
+    ) -> None:
+        """The exact effective input limit is accepted before create."""
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        _mock_official_input_count(mock_client, input_tokens=30_000)
+        mock_client.responses.create.return_value = MagicMock(
+            output_text="ok",
+            usage=None,
+        )
+        client = LLMClient(api_key="sk-test-key", model="gpt-5.4-nano")
+
+        client.get_llm_response_with_file(
+            message="Specs?",
+            file_id="file-123",
+            session_id="test-session",
+        )
+
+        count_kwargs = mock_client.responses.input_tokens.count.call_args.kwargs
+        create_kwargs = mock_client.responses.create.call_args.kwargs
+        assert count_kwargs["model"] == create_kwargs["model"]
+        assert count_kwargs["instructions"] == create_kwargs["instructions"]
+        assert count_kwargs["input"] == create_kwargs["input"]
+        assert count_kwargs["reasoning"] == create_kwargs["reasoning"]
+
+    @patch("backend.app.llm_client.OpenAI")
+    def test_file_request_official_count_over_budget_skips_create(
+        self,
+        mock_openai_class: MagicMock,
+    ) -> None:
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        _mock_official_input_count(mock_client, input_tokens=30_001)
+        client = LLMClient(api_key="sk-test-key", model="gpt-5.4-nano")
+
+        with pytest.raises(ContextBudgetError, match="input_tokens_exceed_limit"):
+            client.get_llm_response_with_file(
+                message="Specs?",
+                file_id="file-123",
+                session_id="test-session",
+            )
+
+        mock_client.responses.create.assert_not_called()
+
+    @patch("backend.app.llm_client.OpenAI")
+    def test_file_request_official_count_failure_skips_create(
+        self,
+        mock_openai_class: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        caplog.set_level("WARNING", logger="backend.app.llm_client")
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_client.responses.input_tokens.count.side_effect = RuntimeError(
+            "counter unavailable"
+        )
+        client = LLMClient(api_key="sk-test-key", model="gpt-5.4-nano")
+
+        with pytest.raises(ContextBudgetError, match="input_token_count_failed"):
+            client.get_llm_response_with_file(
+                message="private content",
+                file_id="file-private",
+                session_id="session-private",
+            )
+
+        mock_client.responses.create.assert_not_called()
+        assert "private content" not in caplog.text
+        assert "file-private" not in caplog.text
+        assert "session-private" not in caplog.text
+
+    @patch("backend.app.llm_client.OpenAI")
+    def test_file_request_missing_official_counter_skips_create(
+        self,
+        mock_openai_class: MagicMock,
+    ) -> None:
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_client.responses.input_tokens = None
+        client = LLMClient(api_key="sk-test-key", model="gpt-5.4-nano")
+
+        with pytest.raises(
+            ContextBudgetError,
+            match="input_token_counter_unavailable",
+        ):
+            client.get_llm_response_with_file(
+                message="Specs?",
+                file_id="file-123",
+                session_id="test-session",
+            )
+
+        mock_client.responses.create.assert_not_called()
+
+    @patch("backend.app.llm_client.OpenAI")
+    def test_file_request_unknown_model_skips_count_and_create(
+        self,
+        mock_openai_class: MagicMock,
+    ) -> None:
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        client = LLMClient(api_key="sk-test-key", model="unknown-model")
+
+        with pytest.raises(ContextBudgetError, match="unknown_model"):
+            client.get_llm_response_with_file(
+                message="Specs?",
+                file_id="file-123",
+                session_id="test-session",
+            )
+
+        mock_client.responses.input_tokens.count.assert_not_called()
+        mock_client.responses.create.assert_not_called()
+
 
 class TestLLMClientWithFileReturnsLLMResponse:
     """Tests that get_llm_response_with_file returns LLMResponse with token extraction."""
@@ -470,10 +598,13 @@ class TestLLMClientWithFileReturnsLLMResponse:
         mock_response.usage.output_tokens = 100
         mock_response.usage.total_tokens = 300
         mock_client.responses.create.return_value = mock_response
+        _mock_official_input_count(mock_client)
 
         client = LLMClient(api_key="sk-test-key")
         result = client.get_llm_response_with_file(
-            message="Specs?", file_id="file-123", session_id="test-session"
+            message="Specs?",
+            file_id="file-123",
+            session_id="test-session",
         )
 
         assert isinstance(result, LLMResponse)
@@ -493,10 +624,13 @@ class TestLLMClientWithFileReturnsLLMResponse:
         mock_response.output_text = "Response text"
         mock_response.usage = None
         mock_client.responses.create.return_value = mock_response
+        _mock_official_input_count(mock_client)
 
         client = LLMClient(api_key="sk-test-key")
         result = client.get_llm_response_with_file(
-            message="Test", file_id="file-123", session_id="test-session"
+            message="Test",
+            file_id="file-123",
+            session_id="test-session",
         )
 
         assert isinstance(result, LLMResponse)

--- a/infra/terraform/envs/pr-preview/variables.tf
+++ b/infra/terraform/envs/pr-preview/variables.tf
@@ -94,7 +94,7 @@ variable "lambda_memory_size" {
 variable "lambda_timeout_seconds" {
   description = "Preview Lambda timeout in seconds."
   type        = number
-  default     = 25
+  default     = 29
 }
 
 variable "lambda_session_ttl_seconds" {

--- a/infra/terraform/envs/pr-preview/variables.tf
+++ b/infra/terraform/envs/pr-preview/variables.tf
@@ -94,7 +94,7 @@ variable "lambda_memory_size" {
 variable "lambda_timeout_seconds" {
   description = "Preview Lambda timeout in seconds."
   type        = number
-  default     = 29
+  default     = 25
 }
 
 variable "lambda_session_ttl_seconds" {


### PR DESCRIPTION
## ¿Qué hace este PR?

Cuenta los tokens del payload real de File Input con `responses.input_tokens.count` antes de crear la respuesta. Rechaza en forma cerrada modelos desconocidos, contador ausente/fallido y requests fuera del límite efectivo.

## Issues relacionados

Part of #262

## Tipo de cambio

- [x] 🆕 Nueva funcionalidad (feature)
- [ ] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [ ] 🧪 Tests
- [ ] 📄 Documentación / configuración
- [ ] 🔧 Infra / CI

## Chain context

```text
main
 ├─ ✅ #271 #281 #285 #286 #287 #288
 └─ 📍 PR 7: exact File Input token preflight
     └─ PR 8+: simulation and final evidence
```

## Cómo probar este PR

1. `uv run pytest backend/tests/test_file_input_budget.py backend/tests/test_llm_client.py -q`
2. Ejecutar Ruff format/check y mypy focalizado.

Resultado: 37 tests.

## Notas para el reviewer

`count` y `create` comparten los campos tokenizables; la reserva de output se aplica una sola vez. Diff: 372 líneas.
