### PR TITLE
fix(context): bound file input latency

### DIFF
--- a/backend/app/llm_client.py
+++ b/backend/app/llm_client.py
@@ -23,6 +23,9 @@ from backend.app.tools import get_tool_definitions
 
 logger = logging.getLogger(__name__)
 
+FILE_INPUT_REASONING_EFFORT = "none"
+FILE_INPUT_MAX_OUTPUT_TOKENS = 512
+
 
 def expand_query_with_context(message: str, history: list) -> str:
     """Expand query with conversational context (stub for future enhancement).
@@ -236,7 +239,7 @@ class LLMClient:
                 input=user_input,
                 tools=tools,
                 max_output_tokens=settings.llm_max_output_tokens,
-                reasoning={"effort": "low"},
+                reasoning={"effort": "medium"},
                 prompt_cache_key=session_id,
             )
 
@@ -315,7 +318,7 @@ class LLMClient:
                 ],
             }
         ]
-        reasoning = {"effort": "none"}
+        reasoning = {"effort": FILE_INPUT_REASONING_EFFORT}
         self._preflight_file_input_request(
             instructions=instructions,
             input_payload=input_payload,
@@ -329,10 +332,17 @@ class LLMClient:
                 model=self.model,
                 instructions=instructions,
                 input=input_payload,
-                max_output_tokens=settings.llm_max_output_tokens,
+                max_output_tokens=FILE_INPUT_MAX_OUTPUT_TOKENS,
                 reasoning=reasoning,
                 prompt_cache_key=session_id,
             )
+            if response.status == "incomplete":
+                reason = getattr(response.incomplete_details, "reason", None)
+                reason = reason if reason == "max_output_tokens" else "unknown"
+                logger.error(
+                    "File Input incomplete: model=%s reason=%s", self.model, reason
+                )
+                raise LLMServiceError("LLM File Input response incomplete") from None
 
             # Extract token usage (response.usage can be None)
             input_tokens = response.usage.input_tokens if response.usage else 0
@@ -346,15 +356,16 @@ class LLMClient:
                 total_tokens=total_tokens,
             )
 
-        except AuthenticationError as e:
-            logger.error("OpenAI authentication error (file): %s", e)
-            raise LLMServiceError("Invalid OpenAI API key") from e
-        except APIError as e:
-            logger.error("OpenAI API error (file): %s", e)
-            raise LLMServiceError(f"OpenAI API error: {e}") from e
-        except Exception as e:
-            logger.exception("Unexpected error calling OpenAI API (file): %s", e)
-            raise LLMServiceError(f"LLM service error: {e}") from e
+        except LLMServiceError:
+            raise
+        except Exception as error:
+            logger.error(
+                "LLM create failed: model=%s operation=file "
+                "reason=create_failed error_type=%s",
+                self.model,
+                type(error).__name__,
+            )
+            raise LLMServiceError("LLM create failed") from None
 
     def _preflight_file_input_request(
         self,
@@ -396,19 +407,23 @@ class LLMClient:
                 reasoning=reasoning,
             )
             counted_input_tokens = count_response.input_tokens
-            if not isinstance(counted_input_tokens, int):
+            if type(counted_input_tokens) is not int:
                 raise TypeError("Input token count response was not an integer")
         except Exception as error:
+            reason = (
+                "input_token_counter_unavailable"
+                if isinstance(error, AttributeError)
+                else "input_token_count_failed"
+            )
             logger.warning(
-                "File Input token preflight rejected: model=%s "
-                "reason=input_token_count_failed error_type=%s",
+                "File Input token preflight rejected: model=%s reason=%s error_type=%s",
                 self.model,
+                reason,
                 type(error).__name__,
             )
             raise ContextBudgetError(
-                "File Input request rejected by context budget: "
-                "input_token_count_failed"
-            ) from error
+                f"File Input request rejected by context budget: {reason}"
+            ) from None
 
         validate_file_input_token_count(
             model=self.model,

--- a/backend/app/llm_client.py
+++ b/backend/app/llm_client.py
@@ -239,7 +239,7 @@ class LLMClient:
                 input=user_input,
                 tools=tools,
                 max_output_tokens=settings.llm_max_output_tokens,
-                reasoning={"effort": "medium"},
+                reasoning={"effort": "low"},
                 prompt_cache_key=session_id,
             )
 

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -80,7 +80,7 @@ class TestLLMClientWithTools:
     """Tests for get_llm_response_with_tools method."""
 
     @patch("backend.app.llm_client.OpenAI")
-    def test_get_llm_response_with_tools_returns_tool_calls(
+    def test_low_effort_routing_returns_tool_calls(
         self, mock_openai_class: MagicMock
     ) -> None:
         """Test get_llm_response_with_tools returns LLMResponse with tool_calls when LLM invokes tool."""
@@ -110,6 +110,9 @@ class TestLLMClientWithTools:
         assert result.text == ""
         assert len(result.tool_calls) == 1
         assert result.tool_calls[0]["function"]["name"] == "leer_ficha_tecnica"
+        assert mock_client.responses.create.call_args.kwargs["reasoning"] == {
+            "effort": "low"
+        }
 
     @patch("backend.app.llm_client.OpenAI")
     def test_get_llm_response_with_tools_no_tool_calls(
@@ -202,7 +205,7 @@ class TestLLMClientWithTools:
         call_kwargs = mock_client.responses.create.call_args.kwargs
         assert "instructions" in call_kwargs
         assert call_kwargs["instructions"] == ARTE_SYSTEM_PROMPT
-        assert call_kwargs["reasoning"] == {"effort": "medium"}
+        assert call_kwargs["reasoning"] == {"effort": "low"}
 
     @patch.dict(
         os.environ,

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -16,6 +16,7 @@ from backend.app.file_input_budget import ContextBudgetError
 from backend.app.llm_client import (
     ARTE_SYSTEM_PROMPT,
     DATASHEET_SYSTEM_PROMPT,
+    FILE_INPUT_MAX_OUTPUT_TOKENS,
     LLMClient,
     LLMServiceError,
 )
@@ -201,7 +202,7 @@ class TestLLMClientWithTools:
         call_kwargs = mock_client.responses.create.call_args.kwargs
         assert "instructions" in call_kwargs
         assert call_kwargs["instructions"] == ARTE_SYSTEM_PROMPT
-        assert call_kwargs["reasoning"] == {"effort": "low"}
+        assert call_kwargs["reasoning"] == {"effort": "medium"}
 
     @patch.dict(
         os.environ,
@@ -360,13 +361,8 @@ class TestLLMClientWithToolsReturnsLLMResponse:
 class TestLLMClientWithFile:
     """Tests for get_llm_response_with_file method."""
 
-    @patch.dict(
-        os.environ,
-        {"LLM_MAX_OUTPUT_TOKENS": "3210", "CONTEXT_OUTPUT_RESERVE_TOKENS": "3210"},
-        clear=True,
-    )
     @patch("backend.app.llm_client.OpenAI")
-    def test_get_llm_response_with_file_uses_configured_output_limit(
+    def test_get_llm_response_with_file_uses_bounded_output_limit(
         self, mock_openai_class: MagicMock
     ) -> None:
         mock_client = MagicMock()
@@ -385,7 +381,9 @@ class TestLLMClientWithFile:
             )
 
         assert (
-            mock_client.responses.create.call_args.kwargs["max_output_tokens"] == 3210
+            mock_client.responses.create.call_args.kwargs["max_output_tokens"]
+            == FILE_INPUT_MAX_OUTPUT_TOKENS
+            == 512
         )
 
     @patch("backend.app.llm_client.OpenAI")
@@ -475,11 +473,18 @@ class TestLLMClientWithFile:
         """The exact effective input limit is accepted before create."""
         mock_client = MagicMock()
         mock_openai_class.return_value = mock_client
-        _mock_official_input_count(mock_client, input_tokens=30_000)
-        mock_client.responses.create.return_value = MagicMock(
-            output_text="ok",
-            usage=None,
-        )
+        events: list[str] = []
+
+        def count_input_tokens(**_: object) -> MagicMock:
+            events.append("count")
+            return MagicMock(input_tokens=30_000)
+
+        def create_response(**_: object) -> MagicMock:
+            events.append("create")
+            return MagicMock(output_text="ok", usage=None)
+
+        mock_client.responses.input_tokens.count.side_effect = count_input_tokens
+        mock_client.responses.create.side_effect = create_response
         client = LLMClient(api_key="sk-test-key", model="gpt-5.4-nano")
 
         client.get_llm_response_with_file(
@@ -490,11 +495,64 @@ class TestLLMClientWithFile:
 
         count_kwargs = mock_client.responses.input_tokens.count.call_args.kwargs
         create_kwargs = mock_client.responses.create.call_args.kwargs
-        assert count_kwargs["model"] == create_kwargs["model"]
-        assert count_kwargs["instructions"] == create_kwargs["instructions"]
-        assert count_kwargs["input"] == create_kwargs["input"]
-        assert count_kwargs["reasoning"] == create_kwargs["reasoning"]
-        assert create_kwargs["reasoning"] == {"effort": "none"}
+        assert events == ["count", "create"]
+        assert count_kwargs == {key: create_kwargs[key] for key in count_kwargs}
+        assert count_kwargs["reasoning"] == {"effort": "none"}
+        assert "max_output_tokens" not in count_kwargs
+        assert create_kwargs["max_output_tokens"] == FILE_INPUT_MAX_OUTPUT_TOKENS
+
+    @pytest.mark.parametrize(
+        ("incomplete_reason", "logged_reason"),
+        [("max_output_tokens", "max_output_tokens"), ("private reason", "unknown")],
+    )
+    @patch("backend.app.llm_client.OpenAI")
+    def test_incomplete_file_response_fails_closed_with_safe_logs(
+        self,
+        mock_openai_class: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+        incomplete_reason: str,
+        logged_reason: str,
+    ) -> None:
+        mock_client = mock_openai_class.return_value
+        _mock_official_input_count(mock_client)
+        response = mock_client.responses.create.return_value
+        response.status = "incomplete"
+        response.incomplete_details.reason = incomplete_reason
+        response.output_text = "private partial output"
+
+        with pytest.raises(LLMServiceError, match="response incomplete") as raised:
+            LLMClient(api_key="sk-test-key").get_llm_response_with_file(
+                message="private message",
+                file_id="private-file",
+                session_id="private-session",
+            )
+
+        assert raised.value.__cause__ is None
+        assert f"reason={logged_reason}" in caplog.text
+        assert "private" not in caplog.text
+
+    @patch("backend.app.llm_client.OpenAI")
+    def test_file_create_failure_has_safe_logs_and_no_chaining(
+        self,
+        mock_openai_class: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        mock_client = mock_openai_class.return_value
+        _mock_official_input_count(mock_client)
+        mock_client.responses.create.side_effect = RuntimeError("private error")
+
+        with pytest.raises(LLMServiceError, match="LLM create failed") as raised:
+            LLMClient(api_key="sk-test-key").get_llm_response_with_file(
+                message="private message",
+                file_id="private-file",
+                session_id="private-session",
+            )
+
+        assert raised.value.__cause__ is None
+        assert "reason=create_failed" in caplog.text
+        assert "error_type=RuntimeError" in caplog.text
+        assert all(record.exc_info is None for record in caplog.records)
+        assert "private" not in caplog.text + str(raised.value)
 
     @patch("backend.app.llm_client.OpenAI")
     def test_file_request_official_count_over_budget_skips_create(
@@ -524,12 +582,12 @@ class TestLLMClientWithFile:
         caplog.set_level("WARNING", logger="backend.app.llm_client")
         mock_client = MagicMock()
         mock_openai_class.return_value = mock_client
-        mock_client.responses.input_tokens.count.side_effect = RuntimeError(
-            "counter unavailable"
-        )
+        mock_client.responses.input_tokens.count.side_effect = RuntimeError("private")
         client = LLMClient(api_key="sk-test-key", model="gpt-5.4-nano")
 
-        with pytest.raises(ContextBudgetError, match="input_token_count_failed"):
+        with pytest.raises(
+            ContextBudgetError, match="input_token_count_failed"
+        ) as raised:
             client.get_llm_response_with_file(
                 message="private content",
                 file_id="file-private",
@@ -537,9 +595,29 @@ class TestLLMClientWithFile:
             )
 
         mock_client.responses.create.assert_not_called()
+        assert raised.value.__cause__ is None
         assert "private content" not in caplog.text
         assert "file-private" not in caplog.text
         assert "session-private" not in caplog.text
+
+    @pytest.mark.parametrize("invalid_count", [True, "100"])
+    @patch("backend.app.llm_client.OpenAI")
+    def test_non_exact_integer_count_fails_closed(
+        self,
+        mock_openai_class: MagicMock,
+        invalid_count: object,
+    ) -> None:
+        mock_client = mock_openai_class.return_value
+        mock_client.responses.input_tokens.count.return_value.input_tokens = (
+            invalid_count
+        )
+
+        with pytest.raises(ContextBudgetError, match="input_token_count_failed"):
+            LLMClient(api_key="sk-test-key").get_llm_response_with_file(
+                message="Specs?", file_id="file-123", session_id="session-123"
+            )
+
+        mock_client.responses.create.assert_not_called()
 
     @patch("backend.app.llm_client.OpenAI")
     def test_file_request_missing_official_counter_skips_create(


### PR DESCRIPTION
## ¿Qué hace este PR?

Reduce el costo de generación del File Input sin eliminar el preflight exacto mergeado en #292. Mantiene el routing de herramientas, usa reasoning `none` y un máximo de 512 tokens sólo para extracción técnica, y rechaza respuestas incompletas en lugar de devolver contenido parcial.

## Issues relacionados

Part of #262

## Tipo de cambio

- [ ] 🆕 Nueva funcionalidad (feature)
- [x] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [ ] 🧪 Tests
- [ ] 📄 Documentación / configuración
- [ ] 🔧 Infra / CI

## Cómo probar este PR

1. `uv run pytest backend/tests/test_llm_client.py backend/tests/test_chat.py`
2. Ejecutar la suite determinista completa.
3. Validar Smoke Lambda PR Preview con HTTP 200 y source_documents.

## Chain Context

```text
📍 PR #299: File Input latency bound
   ↓
PR #303: canonical replay evidence
   ↓
PR #304: defaults, documentation and issue closure
```

- Start: main con #292 integrado.
- Finish: preflight exacto con menor costo de generación y rechazo de truncación.
- Follow-up: #303 y #304.
- Out of scope: aumentar timeout o eliminar el count remoto.
- Review budget: 174 changed lines.
