### PR TITLE
fix(llm): [FIX-R0-05B] bound file input preflight

### DIFF
--- a/backend/app/llm_client.py
+++ b/backend/app/llm_client.py
@@ -6,6 +6,7 @@ for generating chatbot responses with tool calling support.
 
 import logging
 import os
+from time import monotonic as _monotonic
 from typing import Optional
 
 from openai import APIError, AuthenticationError, OpenAI
@@ -327,7 +328,17 @@ class LLMClient:
             }
         ]
         reasoning = {"effort": FILE_INPUT_REASONING_EFFORT}
+        request_client = self.openai_client
+        request_deadline: Optional[float] = None
+        if timeout_seconds is not None:
+            allocation = min(timeout_seconds, settings.openai_timeout_seconds)
+            request_deadline = _monotonic() + allocation
+            request_client = request_client.with_options(
+                timeout=allocation,
+                max_retries=0,
+            )
         self._preflight_file_input_request(
+            request_client=request_client,
             instructions=instructions,
             input_payload=input_payload,
             reasoning=reasoning,
@@ -336,10 +347,12 @@ class LLMClient:
         logger.debug("LLM File Input request preflight accepted: model=%s", self.model)
 
         try:
-            request_client = self.openai_client
-            if timeout_seconds is not None:
-                request_client = request_client.with_options(
-                    timeout=min(timeout_seconds, settings.openai_timeout_seconds),
+            if request_deadline is not None:
+                remaining_seconds = request_deadline - _monotonic()
+                if remaining_seconds <= 0:
+                    raise LLMServiceError("LLM create failed")
+                request_client = self.openai_client.with_options(
+                    timeout=remaining_seconds,
                     max_retries=0,
                 )
             response = request_client.responses.create(
@@ -384,6 +397,7 @@ class LLMClient:
     def _preflight_file_input_request(
         self,
         *,
+        request_client: OpenAI,
         instructions: str,
         input_payload: list[dict[str, object]],
         reasoning: dict[str, str],
@@ -397,7 +411,7 @@ class LLMClient:
             )
 
         input_tokens_resource = getattr(
-            self.openai_client.responses,
+            request_client.responses,
             "input_tokens",
             None,
         )

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -6,7 +6,7 @@ Tests the LLM client for OpenAI Responses API integration with tool calling supp
 
 from collections.abc import Iterator
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -473,22 +473,85 @@ class TestLLMClientWithFile:
         assert "ficha técnica" in call_kwargs["instructions"].lower()
 
     @patch("backend.app.llm_client.OpenAI")
-    def test_file_call_uses_bounded_zero_retry_client(
+    def test_file_count_and_create_use_bounded_zero_retry_clients(
         self, mock_openai_class: MagicMock
     ) -> None:
         base_client = mock_openai_class.return_value
-        bounded_client = base_client.with_options.return_value
-        bounded_client.responses.create.return_value = MagicMock(
+        count_client = MagicMock()
+        create_client = MagicMock()
+        base_client.with_options.side_effect = [count_client, create_client]
+        _mock_official_input_count(count_client)
+        create_client.responses.create.return_value = MagicMock(
             output_text="bounded", usage=None
         )
-        _mock_official_input_count(base_client)
 
-        LLMClient(api_key="sk-test-key").get_llm_response_with_file(
-            "Test", "file-1", "session", timeout_seconds=3.0
-        )
+        with patch.object(llm_client_module, "_monotonic", side_effect=[10.0, 11.25]):
+            LLMClient(api_key="sk-test-key").get_llm_response_with_file(
+                "Test", "file-1", "session", timeout_seconds=3.0
+            )
+
+        assert base_client.with_options.call_args_list == [
+            call(timeout=3.0, max_retries=0),
+            call(timeout=1.75, max_retries=0),
+        ]
+        count_client.responses.input_tokens.count.assert_called_once()
+        create_client.responses.create.assert_called_once()
+
+    @patch("backend.app.llm_client.OpenAI")
+    def test_file_count_exhausts_timeout_skips_create(
+        self, mock_openai_class: MagicMock
+    ) -> None:
+        base_client = mock_openai_class.return_value
+        count_client = base_client.with_options.return_value
+        _mock_official_input_count(count_client)
+
+        with (
+            patch.object(llm_client_module, "_monotonic", side_effect=[10.0, 13.0]),
+            pytest.raises(LLMServiceError, match="LLM create failed"),
+        ):
+            LLMClient(api_key="sk-test-key").get_llm_response_with_file(
+                "Test", "file-1", "session", timeout_seconds=3.0
+            )
 
         base_client.with_options.assert_called_once_with(timeout=3.0, max_retries=0)
-        bounded_client.responses.create.assert_called_once()
+        count_client.responses.input_tokens.count.assert_called_once()
+        base_client.responses.create.assert_not_called()
+        count_client.responses.create.assert_not_called()
+
+    @patch("backend.app.llm_client.OpenAI")
+    def test_file_call_without_timeout_uses_base_client(
+        self, mock_openai_class: MagicMock
+    ) -> None:
+        base_client = mock_openai_class.return_value
+        _mock_official_input_count(base_client)
+        base_client.responses.create.return_value = MagicMock(
+            output_text="base", usage=None
+        )
+
+        LLMClient(api_key="sk-test-key").get_llm_response_with_file(
+            "Test", "file-1", "session"
+        )
+
+        base_client.with_options.assert_not_called()
+        base_client.responses.input_tokens.count.assert_called_once()
+        base_client.responses.create.assert_called_once()
+
+    @patch("backend.app.llm_client.OpenAI")
+    def test_bounded_file_count_failure_skips_create(
+        self, mock_openai_class: MagicMock
+    ) -> None:
+        base_client = mock_openai_class.return_value
+        count_client = base_client.with_options.return_value
+        count_client.responses.input_tokens.count.side_effect = RuntimeError("private")
+
+        with pytest.raises(ContextBudgetError, match="input_token_count_failed"):
+            LLMClient(api_key="sk-test-key").get_llm_response_with_file(
+                "Test", "file-1", "session", timeout_seconds=3.0
+            )
+
+        base_client.with_options.assert_called_once_with(timeout=3.0, max_retries=0)
+        count_client.responses.create.assert_not_called()
+        base_client.responses.create.assert_not_called()
 
     def test_get_llm_response_with_file_raises_without_api_key(self) -> None:
         """Test get_llm_response_with_file raises error without API key."""


### PR DESCRIPTION
Closes #305
Part of #234

## Summary

- Bound the official File Input token-count preflight to the caller allocation with retries disabled.
- Pass only the monotonic post-count remainder to `responses.create`.
- Preserve exact payloads, fail-closed behavior, timeout-free compatibility, and public types.

## Type

- [x] Bug fix

## Changes

| File | Change |
|------|--------|
| `backend/app/llm_client.py` | Use bounded zero-retry clients for count and create, sharing one monotonic deadline. |
| `backend/tests/test_llm_client.py` | Cover bounded clients, post-count remainder, exhausted allocation, base-client compatibility, and fail-closed count errors. |

## Tests

- [x] Exact exhausted-timeout node: 1 passed
- [x] `uv run pytest backend/tests/test_llm_client.py`: 43 passed
- [x] `uv run pytest backend/tests backend/app/tests rag/tests -m "not live"`: 604 passed, 4 deselected
- [x] Ruff check and format check
- [x] `git diff --check`

## Chain Context

- Strategy: stacked-to-main
- Starts from: `origin/main@b868b7f`
- Ends with: bounded official File Input preflight and retained regression coverage
- Prior dependencies: none beyond merged PR #294
- Follow-up: request-wide orchestration, controlled deadline degradation, cleanup telemetry, and runtime wiring under parent #234
- Out of scope: orchestration, deployment settings, OpenSpec artifacts, and closing #234
- Review budget: 99 changed lines (88 additions, 11 deletions), under the 400-line limit

```text
#234 Lambda-aware request deadline
├── 📍 Slice 1 — bounded official File Input preflight (this PR)
└── Slice 2+ — orchestration, degradation, cleanup, and runtime wiring
```

## Contributor Checklist

- [x] Linked approved issue #305
- [x] Added exactly one `type:*` label: `type:bug`
- [x] No shell scripts changed; shellcheck not applicable
- [x] Deterministic focused and repository test suites pass
- [x] Documentation not required for this internal bug fix
- [x] Conventional commit used
- [x] No `Co-Authored-By` or AI trailers
