### PR TITLE
fix(runtime): restore request deadline orchestration

### DIFF
--- a/backend/app/llm_client.py
+++ b/backend/app/llm_client.py
@@ -392,7 +392,7 @@ class LLMClient:
                 self.model,
                 type(error).__name__,
             )
-            raise LLMServiceError("LLM create failed") from None
+            raise LLMServiceError("LLM create failed") from (error if type(error).__name__ == "APITimeoutError" else None)  # fmt: skip
 
     def _preflight_file_input_request(
         self,
@@ -451,7 +451,7 @@ class LLMClient:
             )
             raise ContextBudgetError(
                 f"File Input request rejected by context budget: {reason}"
-            ) from None
+            ) from (error if type(error).__name__ == "APITimeoutError" else None)
 
         validate_file_input_token_count(
             model=self.model,

--- a/backend/app/request_deadline.py
+++ b/backend/app/request_deadline.py
@@ -29,6 +29,7 @@ class RequestDeadline:
     hard_at: float
     work_at: float
     minimum_operation_margin_seconds: float
+    started_at: float = 0.0
     clock: Callable[[], float] = field(
         default=time.monotonic, repr=False, compare=False
     )
@@ -46,7 +47,7 @@ class RequestDeadline:
         """Build cutoffs, falling back when Lambda remaining time is invalid."""
         effective_total = configured_total_seconds
         try:
-            lambda_seconds = float(lambda_remaining_ms) / 1000.0
+            lambda_seconds = float(lambda_remaining_ms) / 1000.0  # type: ignore[arg-type]
         except (TypeError, ValueError):
             lambda_seconds = 0.0
         if math.isfinite(lambda_seconds) and lambda_seconds > 0:
@@ -57,6 +58,7 @@ class RequestDeadline:
         return cls(
             hard_at=hard_at,
             work_at=hard_at - cleanup_reserve_seconds,
+            started_at=started_at,
             minimum_operation_margin_seconds=minimum_operation_margin_seconds,
             clock=clock,
         )
@@ -67,7 +69,11 @@ class RequestDeadline:
 
     def remaining_cleanup_seconds(self) -> float:
         """Return non-negative time remaining before the hard cutoff."""
-        return max(0.0, self.hard_at - self.clock())
+        return max(0.0, min(self.hard_at - self.clock(), self.hard_at - self.work_at))
+
+    def elapsed_seconds(self) -> float:
+        """Return elapsed monotonic time for sanitized telemetry."""
+        return max(0.0, self.clock() - self.started_at)
 
     def require_work(self, operation: str, iteration: Optional[int] = None) -> float:
         """Return the available allocation or reject work below its margin."""

--- a/backend/app/s3_client.py
+++ b/backend/app/s3_client.py
@@ -9,6 +9,7 @@ import os
 from typing import Any, Optional
 
 import boto3
+from botocore.client import BaseClient  # type: ignore[import-untyped]
 from botocore.config import Config
 from botocore.exceptions import ClientError, NoCredentialsError
 
@@ -112,7 +113,7 @@ class S3Client:
             )
         return self._client
 
-    def _client_for_timeout(self, timeout_seconds: Optional[float]):
+    def _client_for_timeout(self, timeout_seconds: Optional[float]) -> BaseClient:
         """Return the shared client or a one-attempt request-scoped client."""
         if timeout_seconds is None:
             return self.client

--- a/backend/main.py
+++ b/backend/main.py
@@ -36,10 +36,11 @@ from backend.app.logging_config import setup_logging
 # Configure logging before anything else (reads LOG_LEVEL from centralized settings)
 setup_logging()
 
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from mangum import Mangum
+from openai import APITimeoutError
 from pydantic import BaseModel, Field
 
 from backend.app.auth import api_key_principal, verify_api_key
@@ -78,6 +79,7 @@ from backend.app.message_buffer import (
 )
 
 from backend.app.message_splitter import process_split_messages
+from backend.app.request_deadline import RequestDeadline, RequestDeadlineExceeded
 from backend.app.s3_client import S3Client, S3DownloadError
 from backend.app.schemas import LLMResponse, SourceDocument
 from backend.app.security import (
@@ -294,6 +296,84 @@ def get_catalog_search() -> Any:
 
 
 MAX_AGENTIC_ITERATIONS = int(os.getenv("MAX_AGENTIC_ITERATIONS", "5"))
+
+
+def _request_deadline(scope: Optional[Any] = None) -> RequestDeadline:
+    context = (scope or {}).get("aws.context")
+    get_remaining = getattr(context, "get_remaining_time_in_millis", None)
+    try:
+        lambda_remaining_ms = get_remaining() if callable(get_remaining) else None
+    except Exception:
+        lambda_remaining_ms = None
+    return RequestDeadline.from_budget(
+        configured_total_seconds=settings.lambda_timeout_seconds,
+        response_safety_seconds=settings.request_response_safety_seconds,
+        cleanup_reserve_seconds=settings.request_cleanup_reserve_seconds,
+        minimum_operation_margin_seconds=settings.request_min_operation_margin_seconds,
+        lambda_remaining_ms=lambda_remaining_ms,
+    )
+
+
+def _is_timeout_error(error: BaseException) -> bool:
+    while error:
+        if isinstance(error, (TimeoutError, APITimeoutError)):
+            return True
+        error = error.__cause__  # type: ignore[assignment]
+    return False
+
+
+async def _bounded(
+    deadline: RequestDeadline,
+    operation: str,
+    function: Any,
+    *args: Any,
+    iteration: Optional[int] = None,
+    pass_timeout: bool = False,
+    **kwargs: Any,
+) -> Any:
+    allocation = deadline.require_work(operation, iteration)
+    if pass_timeout:
+        kwargs["timeout_seconds"] = allocation
+    try:
+        async with asyncio.timeout(allocation):
+            return await asyncio.to_thread(function, *args, **kwargs)
+    except Exception as error:
+        if not _is_timeout_error(error):
+            raise
+        raise RequestDeadlineExceeded(
+            operation, "operation_timeout", iteration
+        ) from None
+
+
+async def _download_pdf(deadline: RequestDeadline, client: S3Client, key: str) -> bytes:
+    return await _bounded(deadline, "s3_download", client.download_pdf, key, pass_timeout=True)  # fmt: skip
+
+
+async def _cleanup_file(
+    client: FileInputsClient,
+    file_id: str,
+    deadline: RequestDeadline,
+    request_id: str,
+) -> None:
+    timeout = deadline.remaining_cleanup_seconds()
+    outcome = "timeout"
+    try:
+        if timeout <= 0:
+            raise TimeoutError
+        async with asyncio.timeout(timeout):
+            await asyncio.to_thread(
+                client.delete_file, file_id, timeout_seconds=timeout
+            )
+        outcome = "success"
+    except TimeoutError:
+        pass
+    except Exception:
+        outcome = "failure"
+    logger.info(
+        "Request cleanup: request_id=%s operation=file_delete outcome=%s",
+        request_id,
+        outcome,
+    )
 
 
 def _fire_conversation_log(
@@ -560,6 +640,7 @@ def _handle_buscar_producto_tool(
 def _process_buscar_producto(
     arguments: dict[str, Any],
     session_id: str,
+    timeout_seconds: Optional[float] = None,
 ) -> str:
     """Process a buscar_producto tool call.
 
@@ -593,7 +674,7 @@ def _process_buscar_producto(
         return "Error: Se requiere especificar una categoría (paneles, inversores, controladores, baterias)."
 
     try:
-        catalog = get_catalog()
+        catalog = get_catalog(timeout_seconds=timeout_seconds)
         results = catalog.search(
             categoria=categoria,
             fabricante=fabricante,
@@ -651,6 +732,8 @@ async def _process_leer_ficha_tecnica(
     s3_client: S3Client,
     file_inputs_client: FileInputsClient,
     system_prompt: Optional[str] = None,
+    deadline: Optional[RequestDeadline] = None,
+    request_id: Optional[str] = None,
 ) -> tuple[LLMResponse, list[str]]:
     """Process a tool call for reading a technical datasheet.
 
@@ -673,6 +756,9 @@ async def _process_leer_ficha_tecnica(
     if function_name != "leer_ficha_tecnica":
         raise ValueError(f"Unknown tool: {function_name}")
 
+    deadline = deadline or _request_deadline()
+    request_id = request_id or str(uuid.uuid4())
+
     # Parse tool arguments
     arguments = _parse_tool_arguments(tool_call)
     ruta_s3 = arguments.get("ruta_s3")
@@ -684,7 +770,9 @@ async def _process_leer_ficha_tecnica(
     if ruta_s3:
         validate_s3_path(ruta_s3)
         try:
-            catalog = get_catalog()
+            catalog = await _bounded(
+                deadline, "catalog", get_catalog, pass_timeout=True
+            )
         except CatalogError as e:
             logger.error(
                 "File Input catalog validation failed: "
@@ -722,10 +810,15 @@ async def _process_leer_ficha_tecnica(
             )
 
         try:
-            catalog = get_catalog()
+            catalog = await _bounded(
+                deadline, "catalog", get_catalog, pass_timeout=True
+            )
             # Search by categoria and optionally fabricante/modelo
             modelo_contiene = modelo if modelo else None
-            results = catalog.search(
+            results = await _bounded(
+                deadline,
+                "catalog",
+                catalog.search,
                 categoria=categoria,
                 fabricante=fabricante,
                 modelo_contiene=modelo_contiene,
@@ -762,7 +855,7 @@ async def _process_leer_ficha_tecnica(
 
     # Download PDF from S3
     try:
-        pdf_bytes = await asyncio.to_thread(s3_client.download_pdf, ruta_s3)
+        pdf_bytes = await _download_pdf(deadline, s3_client, ruta_s3)
     except S3DownloadError:
         # Fallback: if direct download fails, search catalog using other parameters
         logger.info(
@@ -774,9 +867,14 @@ async def _process_leer_ficha_tecnica(
         )
 
         if categoria:
-            catalog = get_catalog()
+            catalog = await _bounded(
+                deadline, "catalog", get_catalog, pass_timeout=True
+            )
             modelo_contiene = modelo if modelo else None
-            results = catalog.search(
+            results = await _bounded(
+                deadline,
+                "catalog",
+                catalog.search,
                 categoria=categoria,
                 fabricante=fabricante,
                 modelo_contiene=modelo_contiene,
@@ -789,7 +887,7 @@ async def _process_leer_ficha_tecnica(
                 logger.info(
                     "File Input download fallback resolved: matches=1 selection=single"
                 )
-                pdf_bytes = await asyncio.to_thread(s3_client.download_pdf, ruta_s3)
+                pdf_bytes = await _download_pdf(deadline, s3_client, ruta_s3)
             elif len(results) > 1:
                 # Multiple products found - pick first one as fallback (deterministic)
                 ruta_s3 = results[0].ruta_s3
@@ -798,7 +896,7 @@ async def _process_leer_ficha_tecnica(
                     "File Input download fallback resolved: matches=%d selection=first",
                     len(results),
                 )
-                pdf_bytes = await asyncio.to_thread(s3_client.download_pdf, ruta_s3)
+                pdf_bytes = await _download_pdf(deadline, s3_client, ruta_s3)
             else:
                 # No results found in catalog fallback
                 raise ValueError(
@@ -818,29 +916,30 @@ async def _process_leer_ficha_tecnica(
     )
 
     # Upload PDF to OpenAI
-    file_id = await asyncio.to_thread(
-        file_inputs_client.upload_pdf, pdf_bytes, filename
+    file_id = await _bounded(
+        deadline,
+        "file_upload",
+        file_inputs_client.upload_pdf,
+        pdf_bytes,
+        filename,
+        pass_timeout=True,
     )
 
     # Second LLM call with file
     try:
-        llm_response = await asyncio.to_thread(
+        llm_response = await _bounded(
+            deadline,
+            "file_llm",
             llm_client.get_llm_response_with_file,
             message=user_message,
             file_id=file_id,
             session_id=session_id,
             system_prompt=system_prompt,
+            pass_timeout=True,
         )
         return llm_response, [ruta_s3]
     finally:
-        # Clean up: delete the uploaded file
-        try:
-            await asyncio.to_thread(file_inputs_client.delete_file, file_id)
-        except Exception as e:
-            logger.warning(
-                "Failed to delete uploaded File Input: error_type=%s",
-                type(e).__name__,
-            )
+        await _cleanup_file(file_inputs_client, file_id, deadline, request_id)
 
 
 # Alias for backward compatibility with tests
@@ -854,9 +953,11 @@ async def _process_chat_message(
     s3_client: S3Client,
     file_inputs_client: FileInputsClient,
     request_id: Optional[str] = None,
+    deadline: Optional[RequestDeadline] = None,
 ) -> ChatResponse:
     """Core chat processing logic shared between endpoint and buffer callback."""
     request_id = request_id or str(uuid.uuid4())
+    deadline = deadline or _request_deadline()
     request_start = time.time()
 
     logger.debug(
@@ -1023,12 +1124,16 @@ async def _process_chat_message(
                 llm_client.model,
                 iteration,
             )
-            llm_response = await asyncio.to_thread(
+            llm_response = await _bounded(
+                deadline,
+                "llm",
                 llm_client.get_llm_response_with_tools,
                 message=user_input,
                 session_id=session_id,
                 system_prompt=system_prompt_with_profile,
                 context=request_context,
+                iteration=iteration,
+                pass_timeout=True,
             )
 
             last_output_text = llm_response.text
@@ -1216,9 +1321,14 @@ async def _process_chat_message(
 
                 try:
                     if function_name == "buscar_producto":
-                        result_content = _process_buscar_producto(
+                        result_content = await _bounded(
+                            deadline,
+                            "catalog",
+                            _process_buscar_producto,
                             arguments=arguments,
                             session_id=session_id,
+                            iteration=iteration,
+                            pass_timeout=True,
                         )
                         tool_results.append(
                             {
@@ -1241,6 +1351,8 @@ async def _process_chat_message(
                             s3_client=s3_client,
                             file_inputs_client=file_inputs_client,
                             system_prompt=datasheet_system_prompt,
+                            deadline=deadline,
+                            request_id=request_id,
                         )
                         acc_input_tokens += ficha_response.input_tokens
                         acc_output_tokens += ficha_response.output_tokens
@@ -1275,6 +1387,8 @@ async def _process_chat_message(
                                 "success": False,
                             }
                         )
+                except RequestDeadlineExceeded:
+                    raise
                 except S3DownloadError as e:
                     logger.error(
                         "Tool call failed: function=%s reason=s3_download_error "
@@ -1574,6 +1688,37 @@ async def _process_chat_message(
             total_tokens=acc_total_tokens,
         )
 
+    except RequestDeadlineExceeded as error:
+        response_text = (
+            "No pude completar la consulta dentro del tiempo disponible. "
+            "Por favor, intentá nuevamente o contactá a un agente."
+        )
+        logger.warning(
+            "Request deadline: request_id=%s operation=%s timeout_class=%s "
+            "iteration=%s elapsed_ms=%d",
+            request_id,
+            error.operation,
+            error.timeout_class,
+            error.iteration,
+            int(deadline.elapsed_seconds() * 1000),
+        )
+        session_manager.add_turn(session_id, message, response_text, [])
+        session_manager.add_token_usage(
+            session_id, acc_input_tokens, acc_output_tokens, acc_total_tokens
+        )
+        return ChatResponse(
+            response=response_text,
+            escalate=True,
+            intent_type="request_timeout",
+            reason="request_timeout",
+            session_id=session_id,
+            source_documents=[],
+            num_sources=0,
+            input_tokens=acc_input_tokens,
+            output_tokens=acc_output_tokens,
+            total_tokens=acc_total_tokens,
+        )
+
     except LLMServiceError as e:
         logger.error(
             "LLM service error: request_id=%s, session_id=%s, error=%s",
@@ -1650,6 +1795,7 @@ async def _on_buffer_window_expired(
 @app.post("/chat", response_model=ChatResponse)
 async def chat_endpoint(
     request: ChatRequest,
+    http_request: Request,
     api_key: Annotated[str, Depends(verify_api_key)],
     llm_client: Annotated[LLMClient, Depends(get_llm_client)],
     s3_client: Annotated[S3Client, Depends(get_s3_client)],
@@ -1671,6 +1817,7 @@ async def chat_endpoint(
     session_id = request.session_id or str(uuid.uuid4())
     validate_session_id(session_id)
     bind_or_validate_session(session_id, principal, is_new=is_new_session)
+    deadline = _request_deadline(http_request.scope)
     request_id = str(uuid.uuid4())
     processing_lease: Optional[ProcessingLease] = None
 
@@ -1729,6 +1876,7 @@ async def chat_endpoint(
             s3_client=s3_client,
             file_inputs_client=file_inputs_client,
             request_id=request_id,
+            deadline=deadline,
         )
     except LLMServiceError as e:
         logger.error(

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -685,7 +685,9 @@ class TestChatEndpointWithToolCall:
             )
 
         # Verify delete was called after the second LLM call
-        mock_file_inputs.delete_file.assert_called_once_with("file-abc123")
+        mock_file_inputs.delete_file.assert_called_once_with(
+            "file-abc123", timeout_seconds=3.0
+        )
 
     @patch("backend.main.llm_client.get_llm_response_with_tools")
     def test_chat_endpoint_returns_normal_response_when_no_tool_call(
@@ -1256,7 +1258,9 @@ class TestProcessToolCall:
 
         assert "460W" in result.text
         assert source_docs == ["raw/paneles/route-secret-a.pdf"]
-        mock_file_inputs.delete_file.assert_called_once_with("file-secret-xyz789")
+        mock_file_inputs.delete_file.assert_called_once_with(
+            "file-secret-xyz789", timeout_seconds=3.0
+        )
         assert "matches=2 selection=first" in caplog.text
         for secret in (
             "route-secret",

--- a/backend/tests/test_deadline_orchestration.py
+++ b/backend/tests/test_deadline_orchestration.py
@@ -1,0 +1,160 @@
+import json
+import time
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from openai import APITimeoutError
+
+from backend.app.auth import verify_api_key
+from backend.app.llm_client import LLMServiceError
+from backend.app.request_deadline import RequestDeadline, RequestDeadlineExceeded
+from backend.app.state_repository import ProcessingLease
+import backend.main as backend_main
+from backend.tests.conftest import make_llm_response
+
+app = backend_main.app
+client = TestClient(app)
+LLM_CALL = "backend.main.llm_client.get_llm_response_with_tools"
+
+
+def _deadline(*, clock=time.monotonic, total=0.08, cleanup=0.03) -> RequestDeadline:
+    return RequestDeadline.from_budget(total, 0.01, cleanup, 0.001, clock=clock)
+
+
+def _tool_call() -> dict[str, object]:
+    function = {
+        "name": "buscar_producto",
+        "arguments": json.dumps({"categoria": "paneles"}),
+    }
+    return {"id": "1", "function": function}
+
+
+def _sdk_timeout(**_: object) -> None:
+    time.sleep(0.005)
+    raise LLMServiceError("SDK timeout") from APITimeoutError(MagicMock())
+
+
+def _post(deadline: RequestDeadline, llm: object) -> tuple[object, MagicMock]:
+    with (
+        patch("backend.main._request_deadline", return_value=deadline),
+        patch(LLM_CALL, side_effect=llm) as call,
+    ):
+        return client.post("/chat", json={"message": "paneles"}), call
+
+
+@pytest.fixture(autouse=True)
+def _authenticated() -> None:
+    previous = app.dependency_overrides.copy()
+    app.dependency_overrides[verify_api_key] = lambda: "deadline-key"
+    yield
+    app.dependency_overrides = previous
+
+
+def test_slow_first_call_returns_controlled_response_before_hard_at() -> None:
+    deadline = _deadline(total=0.5, cleanup=0.2)
+    response, _ = _post(deadline, _sdk_timeout)
+    assert time.monotonic() < deadline.hard_at
+    assert response.json()["intent_type"] == "request_timeout"
+    assert response.json()["source_documents"] == []
+
+
+def test_completed_iteration_refuses_the_next() -> None:
+    now = [0.0]
+
+    def complete_tool(**_: object) -> str:
+        now[0] = 0.05
+        return "done"
+
+    with patch(
+        "backend.main._process_buscar_producto", side_effect=complete_tool
+    ) as tool:
+        response, llm = _post(
+            _deadline(clock=lambda: now[0]),
+            lambda **_: make_llm_response(
+                text="", tool_calls=[_tool_call()], input_tokens=7
+            ),
+        )
+    data = response.json()
+    assert (data["intent_type"], data["input_tokens"]) == ("request_timeout", 7)
+    assert llm.call_count == tool.call_count == 1 and data["source_documents"] == []
+
+
+def test_slow_product_tool_propagates_allocation_and_degrades() -> None:
+    seen: list[float] = []
+
+    def slow_catalog(*, timeout_seconds: float) -> None:
+        seen.append(timeout_seconds)
+        time.sleep(timeout_seconds + 0.001)
+
+    with patch("backend.main.get_catalog", side_effect=slow_catalog):
+        response, _ = _post(
+            _deadline(total=0.5, cleanup=0.2),
+            lambda **_: make_llm_response(text="", tool_calls=[_tool_call()]),
+        )
+    assert response.json()["intent_type"] == "request_timeout"
+    assert 0 < seen[0] <= 0.3
+
+
+@pytest.mark.parametrize("operation", ["s3_download", "file_upload", "file_llm"])
+@pytest.mark.asyncio
+async def test_slow_datasheet_paths_are_wall_clock_bounded(operation: str) -> None:
+    with pytest.raises(RequestDeadlineExceeded) as raised:
+        await backend_main._bounded(_deadline(), operation, lambda: time.sleep(0.041))
+    assert raised.value.operation == operation
+
+
+@pytest.mark.parametrize(
+    "effect,outcome",
+    [(None, "success"), (RuntimeError("private"), "failure"), ("slow", "timeout")],
+)
+@pytest.mark.asyncio
+async def test_cleanup_outcomes_are_bounded_and_observable(
+    effect: object, outcome: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    side_effect = (
+        (lambda *args, **kwargs: time.sleep(0.04)) if effect == "slow" else effect
+    )
+    delete = MagicMock(side_effect=side_effect)
+    started = time.monotonic()
+    await backend_main._cleanup_file(
+        MagicMock(delete_file=delete), "secret-file", _deadline(), "request-1"
+    )
+    assert 0 < delete.call_args.kwargs["timeout_seconds"] == pytest.approx(0.03)
+    assert time.monotonic() - started < 0.04 and f"outcome={outcome}" in caplog.text
+    assert "secret-file" not in caplog.text and "private" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_buffered_path_stores_controlled_timeout() -> None:
+    lease = ProcessingLease(token="lease", expires_at=datetime.now(timezone.utc) + timedelta(seconds=1))  # fmt: skip
+    stored = MagicMock()
+    deadline = _deadline(total=0.5, cleanup=0.2)
+    with (
+        patch("backend.main._request_deadline", return_value=deadline),
+        patch(LLM_CALL, side_effect=_sdk_timeout),
+        patch("backend.main.set_pending_chat_response", stored),
+        patch("backend.main.release_processing_lease"),
+    ):
+        await backend_main._on_buffer_window_expired("buffer-session", "paneles", lease)
+    data = json.loads(stored.call_args.args[1])
+    outcome = data["intent_type"], data["escalate"], data["input_tokens"]
+    assert outcome == ("request_timeout", True, 0)
+    assert data["source_documents"] == [] and data["num_sources"] == 0
+
+
+def test_lambda_cap_local_fallback_and_auth_short_circuit() -> None:
+    context = MagicMock()
+    context.get_remaining_time_in_millis.return_value = 8_000
+    lambda_deadline, local_deadline = (
+        backend_main._request_deadline({"aws.context": context}),
+        backend_main._request_deadline(),
+    )
+    assert lambda_deadline.hard_at - lambda_deadline.started_at == pytest.approx(6.0)
+    assert local_deadline.hard_at - local_deadline.started_at == pytest.approx(23.0)
+    app.dependency_overrides.pop(verify_api_key)
+    with patch("backend.main._request_deadline") as builder:
+        response = client.post("/chat", json={"message": "paneles"})
+    assert response.status_code in {401, 403}
+    builder.assert_not_called()

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -8,6 +8,7 @@ from collections.abc import Iterator
 import os
 from unittest.mock import MagicMock, call, patch
 
+from openai import APITimeoutError
 import pytest
 
 from backend.app import llm_client as llm_client_module
@@ -552,6 +553,25 @@ class TestLLMClientWithFile:
         base_client.with_options.assert_called_once_with(timeout=3.0, max_retries=0)
         count_client.responses.create.assert_not_called()
         base_client.responses.create.assert_not_called()
+
+    @pytest.mark.parametrize("operation", ["count", "create"])
+    @patch("backend.app.llm_client.OpenAI")
+    def test_file_timeout_keeps_cause(self, sdk: MagicMock, operation: str) -> None:
+        base_client = sdk.return_value
+        count_client, create_client = MagicMock(), MagicMock()
+        base_client.with_options.side_effect = [count_client, create_client]
+        _mock_official_input_count(count_client)
+        timeout = APITimeoutError(MagicMock())
+        target = count_client.responses.input_tokens.count
+        if operation == "create":
+            target = create_client.responses.create
+        target.side_effect = timeout
+        expected = {"count": ContextBudgetError, "create": LLMServiceError}[operation]
+        with pytest.raises(expected) as raised:
+            LLMClient(api_key="sk-test-key").get_llm_response_with_file(
+                "Test", "file-1", "session", timeout_seconds=3.0
+            )
+        assert raised.value.__cause__ is timeout
 
     def test_get_llm_response_with_file_raises_without_api_key(self) -> None:
         """Test get_llm_response_with_file raises error without API key."""


### PR DESCRIPTION
## ¿Qué hace este PR?

Restaura selectivamente el work unit de request-deadline orchestration que se perdió durante la secuencia de merge/revert, sin degradar el File Input preflight canónico de PR #306. El patch vuelve a acotar el trabajo LLM, catálogo, S3, upload y cleanup por deadline, y conserva la causa tipada de `APITimeoutError` para degradación controlada.

### Incidente y recuperación

- PR #307 fue mergeada antes de PR #306.
- PR #308 revirtió PR #307.
- PR #306 mergeó después y quedó como implementación canónica de File Input preflight.
- Esta PR **NO revierte PR #308 mecánicamente**: restaura selectivamente WU2 desde PR #307 y preserva íntegramente las semánticas superiores de PR #306 (bounded count, remainder create client, zero retries y monotonic deadline).

## Issues relacionados

Closes #234

## Tipo de cambio

- [ ] 🆕 Nueva funcionalidad (feature)
- [x] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [ ] 🧪 Tests
- [ ] 📄 Documentación / configuración
- [ ] 🔧 Infra / CI

## Checklist antes de pedir review

- [x] El código corre localmente sin errores (`uvicorn` levanta, tests pasan)
- [x] Los criterios de aceptación del issue relacionado están cumplidos
- [x] No hay credenciales, API keys ni rutas absolutas hardcodeadas
- [x] No se agregaron dependencias nuevas
- [x] El contrato del endpoint conserva compatibilidad y está cubierto por tests
- [x] No se modificó el harness ni el dataset

## Cómo probar este PR

1. Probe real de timeout en count/create a través del wrapper productivo:
   `uv run pytest backend/tests/test_llm_client.py::TestLLMClientWithFile::test_file_timeout_keeps_cause -q`
   Resultado auditado: **2 passed**.
2. Suites enfocadas:
   `uv run pytest backend/tests/test_deadline_orchestration.py backend/tests/test_chat.py backend/tests/test_llm_client.py backend/tests/test_s3_client.py -m "not live"`
   Resultado auditado: **141 passed, 4 deselected**.
3. Suite CI determinística exacta:
   `uv run pytest backend/tests backend/app/tests rag/tests -m "not live"`
   Resultado auditado: **617 passed, 4 deselected**.
4. Suite completa:
   `uv run pytest`
   Resultado auditado: **769 passed, 3 skipped**.
5. Calidad: `uv run ruff check backend/ rag/` y `uv run ruff format --check backend/ rag/` — ambos pasan.

## Notas para el reviewer

### Chain context

**Estrategia:** work unit focalizado, single PR contra `main`, dentro del límite de revisión.

```text
Historial del incidente:
#307 merged before #306
        │
        ▼
#308 reverted #307
        │
        ▼
#306 merged — canonical File Input preflight
        │
        ▼
📍 this PR — selective WU2 recovery, preserving #306
```

- **Start:** `main@823f8ec` (merge de PR #306).
- **End:** deadline orchestration restaurada sobre el preflight canónico.
- **Prior dependency:** PR #306 ya está incluida en `main`; no hay dependencia abierta.
- **Review budget:** 7 archivos, **+369/-30 = 399 changed lines**.
- **Rollback boundary:** revertir únicamente el commit de esta PR elimina WU2 y devuelve exactamente el comportamiento de `main@823f8ec`, manteniendo PR #306.

### Fuera de alcance

- Revertir mecánicamente PR #308 o reintroducir todos los hunks de PR #307.
- Reaplicar shared-client/remainder inferior de PR #307.
- Modificar los cuatro tests canónicos o la semántica de preflight de PR #306.
- Cambiar dependencias, configuración, documentación, infraestructura o lockfiles.
- Mergear esta PR como parte de esta publicación.