### PR TITLE
fix(catalog): [#231] apply capacity and product-type filters

### DIFF
--- a/backend/app/catalog.py
+++ b/backend/app/catalog.py
@@ -3,8 +3,9 @@ Catalog module for product indexing and search functionality.
 Loads catalog index from S3 and provides search capabilities.
 """
 
-import logging
 import json
+import logging
+import math
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
@@ -16,6 +17,33 @@ s3_client = S3Client()
 logger = logging.getLogger(__name__)
 
 CATALOG_INDEX_PATH = "index/catalog_index.json"
+
+CAPACITY_FIELD_BY_CATEGORY = {
+    "paneles": "potencia_w",
+    "inversores": "capacidad",
+    "controladores": "capacidad_a",
+    "baterias": "capacidad",
+}
+
+TYPE_FIELD_BY_CATEGORY = {
+    "paneles": "tipo_celda",
+    "inversores": "tipo",
+    "controladores": "tipo",
+    "baterias": "tipo",
+}
+
+
+def _normalize_numeric(value: Any) -> Optional[float]:
+    """Return a finite float for a supported catalog numeric value."""
+    if value is None or isinstance(value, bool):
+        return None
+
+    try:
+        normalized = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    return normalized if math.isfinite(normalized) else None
 
 
 class CatalogError(Exception):
@@ -92,13 +120,31 @@ class Catalog:
         if fabricante:
             results = [p for p in results if fabricante.lower() in p.fabricante.lower()]
 
-        if modelo_contiene:
+        if (
+            modelo_contiene
+            or capacidad_min is not None
+            or capacidad_max is not None
+            or tipo
+        ):
             filtered = []
             for product in results:
+                category = product.categoria.lower()
+                capacity_field = CAPACITY_FIELD_BY_CATEGORY.get(category)
+                type_field = TYPE_FIELD_BY_CATEGORY.get(category)
                 matching_variants = [
                     v
                     for v in product.variantes
-                    if modelo_contiene.lower() in v.modelo.lower()
+                    if (
+                        not modelo_contiene
+                        or modelo_contiene.lower() in v.modelo.lower()
+                    )
+                    and self._matches_capacity(
+                        v,
+                        capacity_field,
+                        capacidad_min,
+                        capacidad_max,
+                    )
+                    and self._matches_type(product, v, type_field, tipo)
                 ]
                 if matching_variants:
                     filtered.append(product)
@@ -112,6 +158,49 @@ class Catalog:
         )
 
         return results
+
+    @staticmethod
+    def _matches_capacity(
+        variant: ProductVariant,
+        capacity_field: Optional[str],
+        capacidad_min: Optional[float],
+        capacidad_max: Optional[float],
+    ) -> bool:
+        """Return whether a variant satisfies inclusive capacity bounds."""
+        if capacidad_min is None and capacidad_max is None:
+            return True
+        if capacity_field is None:
+            return False
+
+        capacity = _normalize_numeric(variant.parametros_clave.get(capacity_field))
+        if capacity is None:
+            return False
+        if capacidad_min is not None and capacity < capacidad_min:
+            return False
+        if capacidad_max is not None and capacity > capacidad_max:
+            return False
+        return True
+
+    @staticmethod
+    def _matches_type(
+        product: CatalogProduct,
+        variant: ProductVariant,
+        type_field: Optional[str],
+        tipo: Optional[str],
+    ) -> bool:
+        """Return whether a variant matches its category's documented type field."""
+        if not tipo:
+            return True
+        if type_field is None:
+            return False
+
+        product_type = variant.parametros_clave.get(
+            type_field,
+            product.parametros_comunes.get(type_field),
+        )
+        return isinstance(product_type, str) and (
+            product_type.casefold() == tipo.casefold()
+        )
 
     def contains_ruta_s3(self, ruta_s3: str) -> bool:
         """Return whether the S3 key is declared by the catalog."""

--- a/backend/tests/test_catalog.py
+++ b/backend/tests/test_catalog.py
@@ -1,0 +1,197 @@
+"""Unit tests for structured catalog filtering."""
+
+from typing import Any, Dict
+
+import pytest
+
+from backend.app.catalog import Catalog
+
+
+@pytest.fixture
+def catalog_data() -> Dict[str, Any]:
+    """Return catalog data with valid, absent, and malformed optional values."""
+    return {
+        "productos": [
+            {
+                "nombre_comercial": "Jinko Tiger Pro",
+                "fabricante": "Jinko Solar",
+                "categoria": "paneles",
+                "descripcion": "Panel with no type clues in its name",
+                "ruta_s3": "raw/paneles/jinko.pdf",
+                "parametros_comunes": {"tipo_celda": "monocristalino"},
+                "variantes": [
+                    {
+                        "modelo": "JKM-400",
+                        "parametros_clave": {"potencia_w": 400},
+                    },
+                    {
+                        "modelo": "JKM-500",
+                        "parametros_clave": {"potencia_w": "500"},
+                    },
+                ],
+            },
+            {
+                "nombre_comercial": "Growatt Mixed",
+                "fabricante": "Growatt",
+                "categoria": "inversores",
+                "ruta_s3": "raw/inversores/growatt.pdf",
+                "parametros_comunes": {"tipo": "multifuncional"},
+                "variantes": [
+                    {
+                        "modelo": "MIN-3000",
+                        "parametros_clave": {"capacidad": 3000},
+                    },
+                    {
+                        "modelo": "GRID-5000",
+                        "parametros_clave": {
+                            "capacidad": 5000,
+                            "tipo": "conexion_a_red",
+                        },
+                    },
+                ],
+            },
+            {
+                "nombre_comercial": "Malformed Capacity",
+                "fabricante": "Growatt",
+                "categoria": "inversores",
+                "ruta_s3": "raw/inversores/malformed.pdf",
+                "parametros_comunes": {"tipo": "multifuncional"},
+                "variantes": [
+                    {
+                        "modelo": "BAD-TEXT",
+                        "parametros_clave": {"capacidad": "unknown"},
+                    },
+                    {
+                        "modelo": "BAD-BOOL",
+                        "parametros_clave": {"capacidad": True},
+                    },
+                    {
+                        "modelo": "BAD-NAN",
+                        "parametros_clave": {"capacidad": float("nan")},
+                    },
+                    {"modelo": "MISSING", "parametros_clave": {}},
+                ],
+            },
+            {
+                "nombre_comercial": "Type Only In Name MPPT",
+                "fabricante": "Victron",
+                "categoria": "controladores",
+                "descripcion": "An MPPT controller",
+                "ruta_s3": "raw/controladores/missing-type.pdf",
+                "parametros_comunes": {},
+                "variantes": [
+                    {
+                        "modelo": "MPPT-100",
+                        "parametros_clave": {"capacidad_a": 100},
+                    }
+                ],
+            },
+            {
+                "nombre_comercial": "Malformed Type",
+                "fabricante": "Victron",
+                "categoria": "controladores",
+                "ruta_s3": "raw/controladores/malformed-type.pdf",
+                "parametros_comunes": {"tipo": 123},
+                "variantes": [
+                    {
+                        "modelo": "CTRL-100",
+                        "parametros_clave": {"capacidad_a": 100},
+                    }
+                ],
+            },
+        ]
+    }
+
+
+@pytest.fixture
+def catalog(catalog_data: Dict[str, Any]) -> Catalog:
+    """Build a catalog from the test data."""
+    return Catalog(catalog_data)
+
+
+def test_search_without_optional_filters_preserves_all_products(
+    catalog: Catalog,
+) -> None:
+    """Absent optional filters must not reject incomplete catalog entries."""
+    assert len(catalog.search()) == 5
+
+
+@pytest.mark.parametrize(
+    ("minimum", "maximum", "expected_names"),
+    [
+        (400, 400, ["Jinko Tiger Pro"]),
+        (500, 500, ["Jinko Tiger Pro"]),
+        (401, 499, []),
+        (None, 400, ["Jinko Tiger Pro"]),
+        (500, None, ["Jinko Tiger Pro"]),
+    ],
+)
+def test_search_applies_inclusive_normalized_capacity_boundaries(
+    catalog: Catalog,
+    minimum: float | None,
+    maximum: float | None,
+    expected_names: list[str],
+) -> None:
+    """Capacity bounds are inclusive and normalize numeric strings."""
+    results = catalog.search(
+        categoria="paneles",
+        capacidad_min=minimum,
+        capacidad_max=maximum,
+    )
+
+    assert [product.nombre_comercial for product in results] == expected_names
+
+
+def test_search_excludes_missing_and_malformed_capacity_values(
+    catalog: Catalog,
+) -> None:
+    """Malformed capacities do not match an active numeric filter."""
+    assert catalog.search(
+        categoria="inversores",
+        fabricante="Growatt",
+        capacidad_min=0,
+    ) == [catalog.products[1]]
+
+
+@pytest.mark.parametrize(
+    ("category", "product_type", "expected_names"),
+    [
+        ("paneles", "MONOCRISTALINO", ["Jinko Tiger Pro"]),
+        ("inversores", "multifuncional", ["Growatt Mixed", "Malformed Capacity"]),
+        ("inversores", "conexion_a_red", ["Growatt Mixed"]),
+        ("controladores", "mppt", []),
+        ("controladores", "123", []),
+    ],
+)
+def test_search_uses_documented_type_fields_only(
+    catalog: Catalog,
+    category: str,
+    product_type: str,
+    expected_names: list[str],
+) -> None:
+    """Type matching uses common fields and variant overrides, never free text."""
+    results = catalog.search(categoria=category, tipo=product_type)
+
+    assert [product.nombre_comercial for product in results] == expected_names
+
+
+def test_search_combines_filters_on_the_same_variant(catalog: Catalog) -> None:
+    """All variant-level filters must match one technically compatible variant."""
+    matching = catalog.search(
+        categoria="INVERSORES",
+        fabricante="grow",
+        capacidad_min=5000,
+        capacidad_max=5000,
+        tipo="conexion_a_red",
+        modelo_contiene="grid",
+    )
+    incompatible_model = catalog.search(
+        categoria="inversores",
+        fabricante="Growatt",
+        capacidad_min=5000,
+        tipo="conexion_a_red",
+        modelo_contiene="MIN",
+    )
+
+    assert matching == [catalog.products[1]]
+    assert incompatible_model == []


### PR DESCRIPTION
## Summary
- apply inclusive minimum and maximum capacity filters using normalized finite numeric values
- match product types through documented category fields with variant overrides
- require combined model, capacity, and type filters to match the same variant
- preserve existing behavior when optional filters are absent

## Verification
- `uv run pytest backend/tests/test_catalog.py -q` — 13 passed
- `uv run pytest backend/tests -q` — 436 passed, 3 skipped
- `uv run --group lint ruff check backend/app/catalog.py backend/tests/test_catalog.py` — passed
- `uv run --group lint ruff format --check backend/app/catalog.py backend/tests/test_catalog.py` — passed

Closes #231