### PR TITLE
test(evaluation): [#235] add quality policy engine

### DIFF
--- a/evaluation/harness/quality.py
+++ b/evaluation/harness/quality.py
@@ -1,0 +1,270 @@
+"""Pure quality-policy evaluation for harness result rows."""
+
+import json
+import operator
+import re
+from pathlib import Path
+from typing import Any, Callable
+
+QUALITY_PASS = 0
+QUALITY_FAILURE = 1
+INFRASTRUCTURE_FAILURE = 2
+
+HALLUCINATION_DETECTOR = "unsupported_technical_numeric_claims_v1"
+_TECHNICAL_VALUE_PATTERN = re.compile(
+    r"\b\d+(?:[.,]\d+)?\s*(?:kwh|kw|w|v|a|ah|%|°c)(?=\s|[.,;:!?)]|$)",
+    re.IGNORECASE,
+)
+_OPERATORS: dict[str, Callable[[float, float], bool]] = {
+    "<=": operator.le,
+    ">=": operator.ge,
+    "<": operator.lt,
+    ">": operator.gt,
+    "==": operator.eq,
+}
+_METRICS = (
+    "failed_query_rate_percent",
+    "escalation_accuracy_percent",
+    "hallucination_rate_percent",
+    "p95_latency_ms",
+)
+
+
+class QualityConfigurationError(ValueError):
+    pass
+
+
+def load_policy(path: Path) -> dict[str, Any]:
+    """Load and validate a committed quality policy."""
+    try:
+        with path.open(encoding="utf-8") as policy_file:
+            policy = json.load(policy_file)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise QualityConfigurationError(
+            f"Cannot load quality policy {path}: {exc}"
+        ) from exc
+
+    validate_policy(policy)
+    return policy
+
+
+def validate_policy(policy: Any) -> None:
+    """Validate required policy metadata and check definitions."""
+    if not isinstance(policy, dict):
+        raise QualityConfigurationError("Quality policy must be a JSON object")
+    if policy.get("schema_version") != 1:
+        raise QualityConfigurationError("Policy schema_version must be 1")
+    for field in ("version", "status"):
+        if not isinstance(policy.get(field), str) or not policy[field]:
+            raise QualityConfigurationError(
+                f"Policy {field} must be a non-empty string"
+            )
+
+    detector = policy.get("hallucination_detector", {})
+    if not isinstance(detector, dict):
+        raise QualityConfigurationError("Hallucination detector must be an object")
+    if detector.get("name") != HALLUCINATION_DETECTOR:
+        raise QualityConfigurationError(
+            f"Unsupported hallucination detector: {detector.get('name')!r}"
+        )
+
+    checks = policy.get("checks")
+    if not isinstance(checks, list) or not checks:
+        raise QualityConfigurationError("Policy checks must be a non-empty list")
+
+    seen: set[str] = set()
+    for check in checks:
+        if not isinstance(check, dict):
+            raise QualityConfigurationError("Each policy check must be an object")
+        metric = check.get("metric")
+        if not isinstance(metric, str) or metric not in _METRICS:
+            raise QualityConfigurationError(f"Unsupported policy metric: {metric!r}")
+        if metric in seen:
+            raise QualityConfigurationError(f"Duplicate policy metric: {metric}")
+        seen.add(metric)
+        if check.get("operator") not in _OPERATORS:
+            raise QualityConfigurationError(
+                f"Unsupported operator for {metric}: {check.get('operator')!r}"
+            )
+        threshold = check.get("threshold")
+        if isinstance(threshold, bool) or not isinstance(threshold, (int, float)):
+            raise QualityConfigurationError(f"Threshold for {metric} must be numeric")
+        if not isinstance(check.get("required"), bool):
+            raise QualityConfigurationError(
+                f"Required flag for {metric} must be boolean"
+            )
+
+    if missing := set(_METRICS) - seen:
+        raise QualityConfigurationError(
+            f"Policy is missing checks: {', '.join(sorted(missing))}"
+        )
+
+
+def normalize_source_documents(source_documents: Any) -> str:
+    """Serialize heterogeneous source metadata deterministically for reports."""
+    if source_documents in (None, ""):
+        return ""
+    if isinstance(source_documents, str):
+        return source_documents
+    return json.dumps(source_documents, ensure_ascii=False, sort_keys=True)
+
+
+def _source_support(source_documents: Any, num_sources: int) -> tuple[bool, str]:
+    """Return whether source references exist and any inspectable source text."""
+    if not source_documents:
+        return num_sources > 0, ""
+
+    if isinstance(source_documents, dict):
+        source_documents = [source_documents]
+
+    keys = ("content", "contenido", "contenido_relevante", "text")
+    parts = [
+        value
+        for source in source_documents
+        if isinstance(source, dict)
+        for key in keys
+        if isinstance((value := source.get(key)), str) and value.strip()
+    ]
+    return True, " ".join(parts)
+
+
+def _technical_values(text: str) -> set[str]:
+    return {
+        claim.lower().replace(",", ".")
+        for claim in _TECHNICAL_VALUE_PATTERN.findall(text)
+    }
+
+
+def has_unsupported_technical_numeric_claim(result: dict[str, Any]) -> bool:
+    """Detect unsupported technical numeric claims without flagging normal prose."""
+    claims = _technical_values(str(result.get("response", "")))
+    if not claims:
+        return False
+
+    raw_num_sources = result.get("num_sources", 0)
+    try:
+        num_sources = int(raw_num_sources)
+    except (TypeError, ValueError):
+        num_sources = 0
+
+    has_sources, source_text = _source_support(
+        result.get("source_documents", []), num_sources
+    )
+    if not has_sources:
+        return True
+    if not source_text:
+        return False
+
+    return not claims.issubset(_technical_values(source_text))
+
+
+def _p95(values: list[float]) -> float | None:
+    if not values:
+        return None
+    return sorted(values)[max(0, (95 * len(values) + 99) // 100 - 1)]
+
+
+def _percent(numerator: int, denominator: int) -> float | None:
+    return round(numerator / denominator * 100, 2) if denominator else None
+
+
+def calculate_metrics(results: list[dict[str, Any]]) -> dict[str, float | None]:
+    """Calculate gate metrics exclusively from raw result rows."""
+    if not results:
+        return dict.fromkeys(_METRICS)
+
+    successful = [result for result in results if not result.get("error")]
+    correct = sum(
+        result.get("should_escalate", False) == result.get("escalated", False)
+        for result in successful
+    )
+    hallucinations = sum(map(has_unsupported_technical_numeric_claim, successful))
+    latencies = [
+        float(value)
+        for result in successful
+        if isinstance((value := result.get("latency_ms")), (int, float))
+        and not isinstance(value, bool)
+        and value >= 0
+    ]
+
+    return {
+        "failed_query_rate_percent": _percent(
+            len(results) - len(successful), len(results)
+        ),
+        "escalation_accuracy_percent": _percent(correct, len(successful)),
+        "hallucination_rate_percent": _percent(hallucinations, len(successful)),
+        "p95_latency_ms": round(p95, 2)
+        if (p95 := _p95(latencies)) is not None
+        else None,
+    }
+
+
+def evaluate_quality(
+    metrics: dict[str, float | None], policy: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Evaluate calculated metrics against explicit policy operators."""
+    checks: list[dict[str, Any]] = []
+    for definition in policy["checks"]:
+        metric = definition["metric"]
+        observed = metrics.get(metric)
+        passed = observed is not None and _OPERATORS[definition["operator"]](
+            observed, float(definition["threshold"])
+        )
+        checks.append(
+            {
+                "metric": metric,
+                "observed": observed,
+                "operator": definition["operator"],
+                "threshold": definition["threshold"],
+                "required": definition["required"],
+                "status": "pass"
+                if passed
+                else "fail"
+                if observed is not None
+                else "unavailable",
+            }
+        )
+    return checks
+
+
+def build_quality_gate(
+    results: list[dict[str, Any]], policy: dict[str, Any]
+) -> tuple[dict[str, float | None], dict[str, Any]]:
+    """Build metrics and a structured quality gate from raw results."""
+    metrics = calculate_metrics(results)
+    checks = evaluate_quality(metrics, policy)
+    infrastructure_errors = [
+        {
+            "query_id": result.get("query_id", "unknown"),
+            "error": str(result["error"]),
+        }
+        for result in results
+        if result.get("error")
+    ]
+    infrastructure_errors.extend(
+        {
+            "metric": check["metric"],
+            "error": "Required metric is unavailable from raw results",
+        }
+        for check in checks
+        if check["required"] and check["status"] == "unavailable"
+    )
+    return metrics, {
+        "policy_version": policy["version"],
+        "policy_status": policy["status"],
+        "hallucination_detector": policy["hallucination_detector"]["name"],
+        "checks": checks,
+        "quality_failures": [
+            check for check in checks if check["required"] and check["status"] == "fail"
+        ],
+        "infrastructure_errors": infrastructure_errors,
+    }
+
+
+def quality_exit_code(quality_gate: dict[str, Any]) -> int:
+    """Map gate outcomes to stable process exit codes."""
+    if quality_gate["infrastructure_errors"]:
+        return INFRASTRUCTURE_FAILURE
+    if quality_gate["quality_failures"]:
+        return QUALITY_FAILURE
+    return QUALITY_PASS

--- a/evaluation/harness/tests/test_quality.py
+++ b/evaluation/harness/tests/test_quality.py
@@ -1,0 +1,129 @@
+from copy import deepcopy
+
+import pytest
+
+from evaluation.harness.quality import (
+    HALLUCINATION_DETECTOR,
+    INFRASTRUCTURE_FAILURE,
+    QUALITY_FAILURE,
+    QUALITY_PASS,
+    build_quality_gate,
+    calculate_metrics,
+    evaluate_quality,
+    quality_exit_code,
+)
+
+POLICY = {
+    "version": "test",
+    "status": "test",
+    "hallucination_detector": {"name": HALLUCINATION_DETECTOR},
+    "checks": [
+        {"metric": metric, "operator": operator, "threshold": limit, "required": True}
+        for metric, operator, limit in (
+            ("failed_query_rate_percent", "<=", 5),
+            ("escalation_accuracy_percent", ">=", 90),
+            ("hallucination_rate_percent", "<=", 20),
+            ("p95_latency_ms", "<=", 5000),
+        )
+    ],
+}
+
+
+def _metrics(**overrides: float) -> dict[str, float | None]:
+    metrics: dict[str, float | None] = {
+        "failed_query_rate_percent": 0.0,
+        "escalation_accuracy_percent": 100.0,
+        "hallucination_rate_percent": 0.0,
+        "p95_latency_ms": 100.0,
+    }
+    metrics.update(overrides)
+    return metrics
+
+
+def _result(**overrides: object) -> dict[str, object]:
+    result = dict(
+        response="Hola",
+        source_documents=[],
+        num_sources=0,
+        latency_ms=100.0,
+        should_escalate=False,
+        escalated=False,
+        error="",
+    )
+    result.update(overrides)
+    return result
+
+
+@pytest.mark.parametrize(
+    ("metrics", "expected"),
+    [
+        (_metrics(), QUALITY_PASS),
+        (
+            _metrics(
+                failed_query_rate_percent=5,
+                escalation_accuracy_percent=90,
+                hallucination_rate_percent=20,
+                p95_latency_ms=5000,
+            ),
+            QUALITY_PASS,
+        ),
+        (_metrics(escalation_accuracy_percent=89.99), QUALITY_FAILURE),
+    ],
+    ids=("safe", "inclusive-boundary", "required-failure"),
+)
+def test_required_quality_checks(
+    metrics: dict[str, float | None], expected: int
+) -> None:
+    checks = evaluate_quality(metrics, POLICY)
+    gate = {
+        "infrastructure_errors": [],
+        "quality_failures": [check for check in checks if check["status"] == "fail"],
+    }
+    assert quality_exit_code(gate) == expected
+
+
+def test_metrics_recomputed_from_raw_rows() -> None:
+    results = [
+        _result(
+            response=response,
+            latency_ms=latency,
+            should_escalate=escalated,
+            escalated=escalated,
+        )
+        for response, latency, escalated in (
+            ("El panel entrega 500 W.", 100.0, False),
+            ("Hola, podemos ayudarte.", 200.0, True),
+        )
+    ]
+
+    metrics = calculate_metrics(results)
+
+    assert metrics == {
+        "failed_query_rate_percent": 0.0,
+        "escalation_accuracy_percent": 100.0,
+        "hallucination_rate_percent": 50.0,
+        "p95_latency_ms": 200.0,
+    }
+
+
+def test_advisory_failure_does_not_fail_gate() -> None:
+    policy = deepcopy(POLICY)
+    policy["checks"][1]["required"] = False
+    _, gate = build_quality_gate([_result(query_id="q1", should_escalate=True)], policy)
+
+    assert gate["checks"][1]["status"] == "fail"
+    assert quality_exit_code(gate) == QUALITY_PASS
+
+
+def test_infrastructure_errors_are_distinct_and_take_precedence() -> None:
+    _, gate = build_quality_gate(
+        [{"query_id": "q1", "error": "Connection error", "latency_ms": 0}],
+        POLICY,
+    )
+
+    assert gate["quality_failures"][0]["metric"] == "failed_query_rate_percent"
+    assert gate["infrastructure_errors"][0] == {
+        "query_id": "q1",
+        "error": "Connection error",
+    }
+    assert quality_exit_code(gate) == INFRASTRUCTURE_FAILURE


### PR DESCRIPTION
Closes #235

## PR Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Adds a pure, dependency-free evaluation quality policy engine.
- Calculates failed-query, escalation, hallucination, and p95 latency metrics from raw rows.
- Distinguishes required quality failures from infrastructure failures with stable exit codes.

## Changes

| File | Change |
|------|--------|
| `evaluation/harness/quality.py` | Implements metric calculation, threshold evaluation, detector semantics, and exit-code mapping. |
| `evaluation/harness/tests/test_quality.py` | Covers passing, equality-boundary, quality-failure, advisory, hallucination, and infrastructure cases. |

## Test Plan

- [x] `uv run pytest evaluation/harness/tests/test_quality.py -q` — 6 passed
- [x] Ruff and formatting checks passed before branch preparation
- [x] `git diff --check` passed
- [x] Shellcheck: N/A — no shell scripts changed

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Shellcheck completed or not applicable
- [x] Skills exercised in the target agent
- [x] Documentation is included in the follow-up integration slice
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers

## Chain Context

| Field | Value |
|-------|-------|
| Chain | Evaluation quality gates |
| Tracker PR | Not needed |
| Position | 1 of 2 |
| Base | `main` |
| Depends on | None |
| Follow-up | Harness and CI integration slice after this PR merges |
| Review budget | 399 / 400 |
| Starts at | Existing report-only evaluation harness |
| Ends with | Tested pure quality policy engine available for integration |

### Chain Overview

```text
main
 └── 📍 PR 1: quality policy engine
      └── PR 2: harness and CI integration
```

### Scope

- Includes: pure metrics, threshold evaluation, hallucination detector, exit mapping, and unit tests.
- Excludes: harness CLI wiring, versioned policy file, CI fixture, and documentation; those remain in PR 2.

### Autonomy

- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests cover this unit
