### PR TITLE
fix(state): [#311] claim buffered messages atomically

### DIFF
--- a/backend/app/dynamodb_state_repository.py
+++ b/backend/app/dynamodb_state_repository.py
@@ -222,6 +222,20 @@ class DynamoDBStateRepository:
             },
         )
 
+    def claim_buffer_messages(self, session_id: str) -> list[BufferMessage]:
+        """Atomically rotate the current message batch out of the buffer."""
+        response = self._table.update_item(
+            Key={"PK": self._session_pk(session_id), "SK": "BUFFER"},
+            UpdateExpression="SET messages = :messages, expires_at = :ttl",
+            ExpressionAttributeValues={
+                ":messages": [],
+                ":ttl": self._ttl(self._buffer_ttl_seconds),
+            },
+            ReturnValues="ALL_OLD",
+        )
+        item = response.get("Attributes", {})
+        return self._buffer_state_from_item(session_id, item).messages
+
     def set_pending_result(self, session_id: str, joined_message: str) -> None:
         """Persist a joined buffer result."""
         self._table.update_item(

--- a/backend/app/message_buffer.py
+++ b/backend/app/message_buffer.py
@@ -158,16 +158,15 @@ async def _flush_owned_buffer(session_id: str) -> Optional[str]:
         Messages joined with newline separator, or None if buffer empty.
     """
     if _state_repository is not None:
-        state = _state_repository.get_buffer_state(session_id)
-        buffer_messages = state.messages
+        buffer_messages = _state_repository.claim_buffer_messages(session_id)
         if not buffer_messages:
             return None
         joined = "\n".join(message.message for message in buffer_messages)
-        _state_repository.clear_buffer_messages(session_id)
         _state_repository.set_pending_result(session_id, joined)
         return joined
 
-    buffered_entries = _buffer.pop(session_id, [])
+    with _state_lock:
+        buffered_entries = _buffer.pop(session_id, [])
     task = _buffer_tasks.pop(session_id, None)
     current_task = asyncio.current_task()
     if task and task is not current_task and not task.done():

--- a/backend/app/message_buffer.py
+++ b/backend/app/message_buffer.py
@@ -98,13 +98,14 @@ async def add_to_buffer(
         if session_id not in _buffer:
             _buffer[session_id] = []
         _buffer[session_id].append((message, datetime.now(timezone.utc)))
+        message_count = len(_buffer[session_id])
 
-    if len(_buffer[session_id]) >= max_messages:
+    if message_count >= max_messages:
         # Overflow: flush immediately
         logger.info(
             "Buffer overflow for session %s: %d messages, flushing",
             session_id,
-            len(_buffer[session_id]),
+            message_count,
         )
         return await acquire_and_flush_buffer(session_id)
     return None

--- a/backend/app/state_repository.py
+++ b/backend/app/state_repository.py
@@ -150,6 +150,9 @@ class ChatbotStateRepository(Protocol):
     def append_buffer_message(self, session_id: str, message: str) -> BufferState:
         """Append one message to the durable buffer."""
 
+    def claim_buffer_messages(self, session_id: str) -> list[BufferMessage]:
+        """Atomically remove and return the messages present at claim time."""
+
     def clear_buffer_messages(self, session_id: str) -> None:
         """Remove buffered input messages while preserving polling state."""
 

--- a/backend/app/tests/test_message_buffer.py
+++ b/backend/app/tests/test_message_buffer.py
@@ -9,7 +9,7 @@ Strict TDD: tests written BEFORE implementation.
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
-from threading import Barrier
+from threading import Barrier, Event, RLock, Thread
 from typing import Generator
 from unittest.mock import MagicMock, patch
 
@@ -537,6 +537,46 @@ class TestLocalProcessingLease:
 
 class TestOverflow:
     """Test buffer overflow behavior."""
+
+    @pytest.mark.asyncio
+    async def test_append_decides_overflow_before_concurrent_claim(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A claim after append unlock cannot invalidate its overflow read."""
+        from backend.app import message_buffer
+
+        claim_started = Event()
+        claim_finished = Event()
+        claimed: list[str | None] = []
+
+        class ClaimOnReleaseLock:
+            def __init__(self) -> None:
+                self.lock = RLock()
+                self.is_armed = True
+
+            def __enter__(self) -> None:
+                self.lock.acquire()
+
+            def __exit__(self, *args: object) -> None:
+                self.lock.release()
+                if self.is_armed:
+                    self.is_armed = False
+                    claim_started.set()
+                    assert claim_finished.wait(timeout=2)
+
+        def claim() -> None:
+            assert claim_started.wait(timeout=2)
+            claimed.append(asyncio.run(message_buffer._flush_owned_buffer("race")))
+            claim_finished.set()
+
+        monkeypatch.setattr(message_buffer, "_state_lock", ClaimOnReleaseLock())
+        thread = Thread(target=claim)
+        thread.start()
+        result = await add_to_buffer("race", "first", max_messages=1)
+        thread.join(timeout=2)
+
+        assert result is None
+        assert claimed == ["first"] and not thread.is_alive()
 
     @pytest.mark.asyncio
     async def test_overflow_at_max_messages(self) -> None:

--- a/backend/app/tests/test_message_buffer.py
+++ b/backend/app/tests/test_message_buffer.py
@@ -566,7 +566,7 @@ class TestOverflow:
 
         def claim() -> None:
             assert claim_started.wait(timeout=2)
-            claimed.append(asyncio.run(message_buffer._flush_owned_buffer("race")))
+            claimed.append(asyncio.run(message_buffer.flush_buffer("race")))
             claim_finished.set()
 
         monkeypatch.setattr(message_buffer, "_state_lock", ClaimOnReleaseLock())

--- a/backend/main.py
+++ b/backend/main.py
@@ -1824,21 +1824,15 @@ async def chat_endpoint(
     # P4: Multi-message buffer — intercept before normal processing
     if settings.multi_message_buffer_enabled:
         current_count = get_buffer_count(session_id)
-
-        if request.is_final or current_count >= 4:
-            owned_message = await add_to_buffer(
-                session_id,
-                request.message,
-                max_messages=1 if request.is_final else 5,
-            )
-            if owned_message is None:
-                return JSONResponse(
-                    status_code=202,
-                    content=BufferingResponse(
-                        session_id=session_id,
-                        poll_url=f"/buffer-result/{session_id}",
-                    ).model_dump(),
-                )
+        should_flush = request.is_final or current_count >= 4
+        if not should_flush:
+            clear_pending_chat_response(session_id)
+        owned_message = await add_to_buffer(
+            session_id,
+            request.message,
+            max_messages=1 if request.is_final else 5,
+        )
+        if owned_message is not None:
             processing_lease = owned_message.lease
             if len(owned_message.message) > settings.max_chat_message_chars:
                 release_processing_lease(session_id, processing_lease.token)
@@ -1852,14 +1846,12 @@ async def chat_endpoint(
                 is_final=request.is_final,
             )
         else:
-            # Clear any stale pending response from a previous buffer window
-            clear_pending_chat_response(session_id)
-            await add_to_buffer(session_id, request.message)
-            schedule_flush(
-                session_id,
-                settings.buffer_window_seconds,
-                _on_buffer_window_expired,
-            )
+            if not should_flush:
+                schedule_flush(
+                    session_id,
+                    settings.buffer_window_seconds,
+                    _on_buffer_window_expired,
+                )
             return JSONResponse(
                 status_code=202,
                 content=BufferingResponse(

--- a/backend/tests/test_lambda_runtime.py
+++ b/backend/tests/test_lambda_runtime.py
@@ -193,6 +193,58 @@ def test_mangum_chat_http_api_event() -> None:
     assert body["session_id"]
 
 
+def test_chat_processes_owned_batch_from_stale_precount(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A concurrent overflow result is processed even after a zero pre-count."""
+    from backend.app.message_buffer import OwnedBufferedMessage
+    from backend.app.state_repository import ProcessingLease
+    from backend.main import ChatResponse, handler
+
+    monkeypatch.setenv("MULTI_MESSAGE_BUFFER_ENABLED", "true")
+    settings.reset()
+    lease = ProcessingLease(
+        token="concurrent-overflow",
+        expires_at=datetime.now(timezone.utc) + timedelta(seconds=60),
+    )
+    owned = OwnedBufferedMessage(message="first\nsecond", lease=lease)
+    processed: list[str] = []
+    released: list[str] = []
+
+    async def overflow(*_: Any, **__: Any) -> OwnedBufferedMessage:
+        return owned
+
+    async def process(**kwargs: Any) -> ChatResponse:
+        processed.append(kwargs["message"])
+        return ChatResponse(response="processed", session_id=kwargs["session_id"])
+
+    def reject_schedule(*_: Any, **__: Any) -> None:
+        pytest.fail("owned batches must not schedule a second flush")
+
+    monkeypatch.setattr("backend.main.get_buffer_count", lambda _: 0)
+    monkeypatch.setattr("backend.main.add_to_buffer", overflow)
+    monkeypatch.setattr("backend.main.schedule_flush", reject_schedule)
+    monkeypatch.setattr("backend.main._process_chat_message", process)
+    monkeypatch.setattr(
+        "backend.main.release_processing_lease",
+        lambda _session_id, token: released.append(token),
+    )
+
+    response = handler(
+        _http_api_v2_event(
+            "POST",
+            "/chat",
+            body={"message": "second"},
+            headers={"x-api-key": "lambda-test-key"},
+        ),
+        LambdaContext(),
+    )
+
+    assert response["statusCode"] == 200
+    assert processed == ["first\nsecond"]
+    assert released == [lease.token]
+
+
 def test_mangum_buffer_result_http_api_event() -> None:
     """Buffered polling responses are returned through Mangum."""
     from backend.app.message_buffer import set_pending_chat_response

--- a/backend/tests/test_state_repository.py
+++ b/backend/tests/test_state_repository.py
@@ -12,6 +12,7 @@ from pydantic import ValidationError
 
 from backend.app.dynamodb_state_repository import DynamoDBStateRepository
 from backend.app.state_repository import (
+    BufferMessage,
     ChatTurn,
     OwnershipConflictError,
     ProcessingLease,
@@ -370,6 +371,46 @@ class MessageInterleavingTable(ProcessingInterleavingTable):
             ConditionExpression,
             ReturnValues,
         )
+
+
+class ClaimInterleavingTable(FakeDynamoDBTable):
+    """Pause a claim immediately before or after its atomic rotation."""
+
+    def __init__(self, pause: str) -> None:
+        super().__init__()
+        self.pause = pause
+        self.claim_reached = Event()
+        self.allow_claim = Event()
+
+    def update_item(
+        self,
+        Key: dict[str, str],
+        UpdateExpression: str,
+        ExpressionAttributeValues: dict[str, Any],
+        ExpressionAttributeNames: dict[str, str] | None = None,
+        ConditionExpression: str | None = None,
+        ReturnValues: str | None = None,
+    ) -> dict[str, Any]:
+        is_claim = (
+            current_thread().name == "buffer-claim"
+            and UpdateExpression == "SET messages = :messages, expires_at = :ttl"
+            and ReturnValues == "ALL_OLD"
+        )
+        if is_claim and self.pause == "before":
+            self.claim_reached.set()
+            assert self.allow_claim.wait(timeout=2)
+        response = super().update_item(
+            Key,
+            UpdateExpression,
+            ExpressionAttributeValues,
+            ExpressionAttributeNames,
+            ConditionExpression,
+            ReturnValues,
+        )
+        if is_claim and self.pause == "after":
+            self.claim_reached.set()
+            assert self.allow_claim.wait(timeout=2)
+        return response
 
 
 def run_paused_buffer_mutation(
@@ -881,6 +922,38 @@ def test_concurrent_buffer_appends_retain_each_message_exactly_once() -> None:
     assert sorted(messages) == ["Hola", "mundo"]
     assert messages.count("Hola") == 1
     assert messages.count("mundo") == 1
+
+
+@pytest.mark.parametrize(
+    ("pause", "claimed", "remaining"),
+    [
+        ("before", ["first", "interleaved"], []),
+        ("after", ["first"], ["interleaved"]),
+    ],
+)
+def test_atomic_buffer_claim_partitions_deterministic_interleaving(
+    pause: str, claimed: list[str], remaining: list[str]
+) -> None:
+    """Appends on either side of the claim belong to exactly one batch."""
+    table = ClaimInterleavingTable(pause)
+    repository = DynamoDBStateRepository(table=table)
+    repository.append_buffer_message("s1", "first")
+    result: list[BufferMessage] = []
+
+    thread = Thread(
+        target=lambda: result.extend(repository.claim_buffer_messages("s1")),
+        name="buffer-claim",
+    )
+    thread.start()
+    assert table.claim_reached.wait(timeout=2)
+    repository.append_buffer_message("s1", "interleaved")
+    table.allow_claim.set()
+    thread.join(timeout=2)
+
+    assert not thread.is_alive()
+    assert [message.message for message in result] == claimed
+    state = repository.get_buffer_state("s1")
+    assert [message.message for message in state.messages] == remaining
 
 
 def test_processing_lease_has_one_winner_and_exact_expiry_takeover(


### PR DESCRIPTION
## ¿Qué hace este PR?

Convierte el claim del buffer en una transición atómica frente a appends concurrentes. Mantiene la misma frontera de sincronización en memoria y garantiza que todo mensaje aceptado quede exactamente en el lote reclamado o en el siguiente buffer.

## Issues relacionados

Closes #311
Part of #232

## Tipo de cambio

- [ ] 🆕 Nueva funcionalidad (feature)
- [x] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [ ] 🧪 Tests
- [ ] 📄 Documentación / configuración
- [ ] 🔧 Infra / CI

## Checklist antes de pedir review

- [x] El código corre localmente sin errores (`uvicorn` levanta, tests pasan)
- [x] Los criterios de aceptación del issue relacionado están cumplidos
- [x] No hay credenciales, API keys ni rutas absolutas hardcodeadas
- [x] Si agregué dependencias nuevas, actualicé `requirements.txt` / `pyproject.toml`
- [x] Si modifiqué el schema del endpoint, verifiqué que `/docs` refleja los cambios
- [x] Si modifiqué el harness o el dataset, corrí `python evaluation/harness.py` y el output es el esperado

## Cómo probar este PR

1. Ejecutar `uv run pytest -p no:cacheprovider backend/tests/test_state_repository.py backend/app/tests/test_message_buffer.py`.
2. Confirmar los casos determinísticos append-before-claim y append-after-claim.
3. Ejecutar `uv run pytest -p no:cacheprovider backend`.

## Notas para el reviewer

### Cadena de entrega

```text
main → 📍 #311 atomic claim → #312 recovery/fencing → #313 polling ownership → #315 side-effect idempotency
```

Este PR es el primer work unit. Los siguientes PRs usan la rama inmediata anterior como base. Presupuesto de revisión: 234 líneas cambiadas. Rollback: revertir esta rama elimina exclusivamente el protocolo de claim atómico y sus regresiones.