### PR TITLE
fix(state): [#312] recover and fence leased processing

### DIFF
--- a/backend/app/dynamodb_state_repository.py
+++ b/backend/app/dynamodb_state_repository.py
@@ -223,8 +223,10 @@ class DynamoDBStateRepository:
             },
         )
 
-    def claim_buffer_messages(self, session_id: str, token: str) -> list[BufferMessage]:
-        """Atomically rotate new messages or resume the lease-owned payload."""
+    def claim_buffer_messages(
+        self, session_id: str, token: str, resume: bool = False
+    ) -> list[BufferMessage]:
+        """Atomically rotate the current message batch out of the buffer."""
         names = {
             "#payload": "processing_payload",
             "#messages": "messages",
@@ -233,14 +235,13 @@ class DynamoDBStateRepository:
             "#lease_token": "lease_token",
         }
         values = {
-            ":empty": [],
             ":token": token,
             ":ttl": self._ttl(self._buffer_ttl_seconds),
         }
         transitions = (
             (
-                "SET #payload = #messages, #messages = :empty, "
-                "#expires_at = :ttl REMOVE #response",
+                "SET #payload = #messages, #expires_at = :ttl "
+                "REMOVE #messages, #response",
                 "#lease_token = :token AND attribute_not_exists(#payload) "
                 "AND attribute_exists(#messages)",
             ),
@@ -249,6 +250,9 @@ class DynamoDBStateRepository:
                 "#lease_token = :token AND attribute_exists(#payload)",
             ),
         )
+        if resume:
+            transitions = transitions[1:]
+            names.pop("#messages")
         for update, condition in transitions:
             try:
                 response = self._table.update_item(
@@ -262,7 +266,6 @@ class DynamoDBStateRepository:
             except ClientError as exc:
                 if self._is_conditional_failure(exc):
                     names.pop("#messages", None)
-                    values.pop(":empty", None)
                     continue
                 raise
             item = response.get("Attributes", {})
@@ -371,9 +374,11 @@ class DynamoDBStateRepository:
                     "#processing_started_at = :started, #expires_at = :ttl"
                 ),
                 ConditionExpression=(
-                    "attribute_not_exists(#lease_token) OR "
+                    "(attribute_not_exists(#lease_token) OR "
                     "attribute_not_exists(#lease_expires_at) OR "
-                    "#lease_expires_at <= :now"
+                    "#lease_expires_at <= :now) AND "
+                    "(attribute_not_exists(pending_chat_response) OR "
+                    "attribute_exists(processing_payload) OR attribute_exists(messages))"
                 ),
                 ExpressionAttributeNames={
                     "#lease_token": "lease_token",

--- a/backend/app/dynamodb_state_repository.py
+++ b/backend/app/dynamodb_state_repository.py
@@ -376,8 +376,7 @@ class DynamoDBStateRepository:
                 ConditionExpression=(
                     "((attribute_not_exists(#lease_token) OR "
                     "attribute_not_exists(#lease_expires_at)) AND "
-                    "(attribute_not_exists(pending_chat_response) OR "
-                    "attribute_exists(processing_payload) OR "
+                    "(attribute_exists(processing_payload) OR "
                     "attribute_exists(messages))) OR #lease_expires_at <= :now"
                 ),
                 ExpressionAttributeNames={

--- a/backend/app/dynamodb_state_repository.py
+++ b/backend/app/dynamodb_state_repository.py
@@ -370,6 +370,10 @@ class DynamoDBStateRepository:
                     "#processing_started_at = :started, #expires_at = :ttl"
                 ),
                 ConditionExpression=(
+                    "(attribute_not_exists(#payload) OR "
+                    "attribute_type(#payload, :list_type)) AND "
+                    "(attribute_not_exists(#messages) OR "
+                    "attribute_type(#messages, :list_type)) AND "
                     "((attribute_type(#payload, :list_type) AND "
                     "size(#payload) > :zero) OR (attribute_type(#messages, "
                     ":list_type) AND size(#messages) > :zero)) AND "

--- a/backend/app/dynamodb_state_repository.py
+++ b/backend/app/dynamodb_state_repository.py
@@ -13,6 +13,7 @@ from backend.app.state_repository import (
     BufferState,
     ChatTurn,
     OwnershipConflictError,
+    ProcessingCompletionResult,
     ProcessingLease,
     ProcessingLeaseReleaseResult,
     ProcessingLeaseResult,
@@ -222,19 +223,37 @@ class DynamoDBStateRepository:
             },
         )
 
-    def claim_buffer_messages(self, session_id: str) -> list[BufferMessage]:
-        """Atomically rotate the current message batch out of the buffer."""
-        response = self._table.update_item(
-            Key={"PK": self._session_pk(session_id), "SK": "BUFFER"},
-            UpdateExpression="SET messages = :messages, expires_at = :ttl",
-            ExpressionAttributeValues={
-                ":messages": [],
-                ":ttl": self._ttl(self._buffer_ttl_seconds),
-            },
-            ReturnValues="ALL_OLD",
-        )
+    def claim_buffer_messages(
+        self, session_id: str, token: str
+    ) -> list[BufferMessage]:
+        """Atomically rotate new messages or resume the lease-owned payload."""
+        try:
+            response = self._table.update_item(
+                Key={"PK": self._session_pk(session_id), "SK": "BUFFER"},
+                UpdateExpression=(
+                    "SET #payload = if_not_exists(#payload, #messages), "
+                    "#messages = :messages, #expires_at = :ttl"
+                ),
+                ConditionExpression="#lease_token = :token",
+                ExpressionAttributeNames={
+                    "#payload": "processing_payload",
+                    "#messages": "messages",
+                    "#expires_at": "expires_at",
+                    "#lease_token": "lease_token",
+                },
+                ExpressionAttributeValues={
+                    ":messages": [],
+                    ":token": token,
+                    ":ttl": self._ttl(self._buffer_ttl_seconds),
+                },
+                ReturnValues="ALL_NEW",
+            )
+        except ClientError as exc:
+            if self._is_conditional_failure(exc):
+                return []
+            raise
         item = response.get("Attributes", {})
-        return self._buffer_state_from_item(session_id, item).messages
+        return self._buffer_state_from_item(session_id, item).processing_payload
 
     def set_pending_result(self, session_id: str, joined_message: str) -> None:
         """Persist a joined buffer result."""
@@ -393,6 +412,48 @@ class DynamoDBStateRepository:
             raise
         return ProcessingLeaseReleaseResult(released=True)
 
+    def complete_processing(
+        self, session_id: str, token: str, response_json: Optional[str]
+    ) -> ProcessingCompletionResult:
+        """Fence response publication and lease payload cleanup by token."""
+        names = {
+            "#lease_token": "lease_token",
+            "#lease_expires_at": "lease_expires_at",
+            "#processing_started_at": "processing_started_at",
+            "#payload": "processing_payload",
+            "#pending_result": "pending_result",
+            "#expires_at": "expires_at",
+        }
+        values: dict[str, Any] = {
+            ":token": token,
+            ":ttl": self._ttl(self._buffer_ttl_seconds),
+        }
+        update = (
+            "SET #expires_at = :ttl REMOVE #lease_token, #lease_expires_at, "
+            "#processing_started_at, #payload, #pending_result"
+        )
+        if response_json is not None:
+            names["#response"] = "pending_chat_response"
+            values[":response"] = response_json
+            update = (
+                "SET #expires_at = :ttl, #response = :response REMOVE "
+                "#lease_token, #lease_expires_at, #processing_started_at, "
+                "#payload, #pending_result"
+            )
+        try:
+            self._table.update_item(
+                Key={"PK": self._session_pk(session_id), "SK": "BUFFER"},
+                UpdateExpression=update,
+                ConditionExpression="#lease_token = :token",
+                ExpressionAttributeNames=names,
+                ExpressionAttributeValues=values,
+            )
+        except ClientError as exc:
+            if self._is_conditional_failure(exc):
+                return ProcessingCompletionResult(completed=False)
+            raise
+        return ProcessingCompletionResult(completed=True)
+
     def _get_turns(self, session_id: str, max_turns: int) -> list[ChatTurn]:
         items: list[dict[str, Any]] = []
         exclusive_start_key: Optional[dict[str, Any]] = None
@@ -476,6 +537,13 @@ class DynamoDBStateRepository:
                     timestamp=datetime.fromisoformat(message["timestamp"]),
                 )
                 for message in item.get("messages", [])
+            ],
+            processing_payload=[
+                BufferMessage(
+                    message=message["message"],
+                    timestamp=datetime.fromisoformat(message["timestamp"]),
+                )
+                for message in item.get("processing_payload", [])
             ],
             pending_result=item.get("pending_result"),
             pending_chat_response=item.get("pending_chat_response"),

--- a/backend/app/dynamodb_state_repository.py
+++ b/backend/app/dynamodb_state_repository.py
@@ -239,14 +239,14 @@ class DynamoDBStateRepository:
         }
         transitions = (
             (
-                "SET #expires_at = :ttl REMOVE #response",
-                "#lease_token = :token AND attribute_exists(#payload)",
-            ),
-            (
                 "SET #payload = #messages, #messages = :empty, "
                 "#expires_at = :ttl REMOVE #response",
                 "#lease_token = :token AND attribute_not_exists(#payload) "
                 "AND attribute_exists(#messages)",
+            ),
+            (
+                "SET #expires_at = :ttl REMOVE #response",
+                "#lease_token = :token AND attribute_exists(#payload)",
             ),
         )
         for update, condition in transitions:
@@ -261,6 +261,8 @@ class DynamoDBStateRepository:
                 )
             except ClientError as exc:
                 if self._is_conditional_failure(exc):
+                    names.pop("#messages", None)
+                    values.pop(":empty", None)
                     continue
                 raise
             item = response.get("Attributes", {})

--- a/backend/app/dynamodb_state_repository.py
+++ b/backend/app/dynamodb_state_repository.py
@@ -374,11 +374,11 @@ class DynamoDBStateRepository:
                     "#processing_started_at = :started, #expires_at = :ttl"
                 ),
                 ConditionExpression=(
-                    "(attribute_not_exists(#lease_token) OR "
-                    "attribute_not_exists(#lease_expires_at) OR "
-                    "#lease_expires_at <= :now) AND "
+                    "((attribute_not_exists(#lease_token) OR "
+                    "attribute_not_exists(#lease_expires_at)) AND "
                     "(attribute_not_exists(pending_chat_response) OR "
-                    "attribute_exists(processing_payload) OR attribute_exists(messages))"
+                    "attribute_exists(processing_payload) OR "
+                    "attribute_exists(messages))) OR #lease_expires_at <= :now"
                 ),
                 ExpressionAttributeNames={
                     "#lease_token": "lease_token",

--- a/backend/app/dynamodb_state_repository.py
+++ b/backend/app/dynamodb_state_repository.py
@@ -223,37 +223,49 @@ class DynamoDBStateRepository:
             },
         )
 
-    def claim_buffer_messages(
-        self, session_id: str, token: str
-    ) -> list[BufferMessage]:
+    def claim_buffer_messages(self, session_id: str, token: str) -> list[BufferMessage]:
         """Atomically rotate new messages or resume the lease-owned payload."""
-        try:
-            response = self._table.update_item(
-                Key={"PK": self._session_pk(session_id), "SK": "BUFFER"},
-                UpdateExpression=(
-                    "SET #payload = if_not_exists(#payload, #messages), "
-                    "#messages = :messages, #expires_at = :ttl"
-                ),
-                ConditionExpression="#lease_token = :token",
-                ExpressionAttributeNames={
-                    "#payload": "processing_payload",
-                    "#messages": "messages",
-                    "#expires_at": "expires_at",
-                    "#lease_token": "lease_token",
-                },
-                ExpressionAttributeValues={
-                    ":messages": [],
-                    ":token": token,
-                    ":ttl": self._ttl(self._buffer_ttl_seconds),
-                },
-                ReturnValues="ALL_NEW",
-            )
-        except ClientError as exc:
-            if self._is_conditional_failure(exc):
-                return []
-            raise
-        item = response.get("Attributes", {})
-        return self._buffer_state_from_item(session_id, item).processing_payload
+        names = {
+            "#payload": "processing_payload",
+            "#messages": "messages",
+            "#response": "pending_chat_response",
+            "#expires_at": "expires_at",
+            "#lease_token": "lease_token",
+        }
+        values = {
+            ":empty": [],
+            ":token": token,
+            ":ttl": self._ttl(self._buffer_ttl_seconds),
+        }
+        transitions = (
+            (
+                "SET #expires_at = :ttl REMOVE #response",
+                "#lease_token = :token AND attribute_exists(#payload)",
+            ),
+            (
+                "SET #payload = #messages, #messages = :empty, "
+                "#expires_at = :ttl REMOVE #response",
+                "#lease_token = :token AND attribute_not_exists(#payload) "
+                "AND attribute_exists(#messages)",
+            ),
+        )
+        for update, condition in transitions:
+            try:
+                response = self._table.update_item(
+                    Key={"PK": self._session_pk(session_id), "SK": "BUFFER"},
+                    UpdateExpression=update,
+                    ConditionExpression=condition,
+                    ExpressionAttributeNames=names,
+                    ExpressionAttributeValues=values,
+                    ReturnValues="ALL_NEW",
+                )
+            except ClientError as exc:
+                if self._is_conditional_failure(exc):
+                    continue
+                raise
+            item = response.get("Attributes", {})
+            return self._buffer_state_from_item(session_id, item).processing_payload
+        return []
 
     def set_pending_result(self, session_id: str, joined_message: str) -> None:
         """Persist a joined buffer result."""
@@ -422,6 +434,7 @@ class DynamoDBStateRepository:
             "#processing_started_at": "processing_started_at",
             "#payload": "processing_payload",
             "#pending_result": "pending_result",
+            "#response": "pending_chat_response",
             "#expires_at": "expires_at",
         }
         values: dict[str, Any] = {
@@ -430,10 +443,9 @@ class DynamoDBStateRepository:
         }
         update = (
             "SET #expires_at = :ttl REMOVE #lease_token, #lease_expires_at, "
-            "#processing_started_at, #payload, #pending_result"
+            "#processing_started_at, #payload, #pending_result, #response"
         )
         if response_json is not None:
-            names["#response"] = "pending_chat_response"
             values[":response"] = response_json
             update = (
                 "SET #expires_at = :ttl, #response = :response REMOVE "

--- a/backend/app/dynamodb_state_repository.py
+++ b/backend/app/dynamodb_state_repository.py
@@ -229,48 +229,44 @@ class DynamoDBStateRepository:
         """Atomically rotate the current message batch out of the buffer."""
         names = {
             "#payload": "processing_payload",
-            "#messages": "messages",
             "#response": "pending_chat_response",
             "#expires_at": "expires_at",
             "#lease_token": "lease_token",
         }
-        values = {
-            ":token": token,
-            ":ttl": self._ttl(self._buffer_ttl_seconds),
-        }
-        transitions = (
-            (
-                "SET #payload = #messages, #expires_at = :ttl "
-                "REMOVE #messages, #response",
-                "#lease_token = :token AND attribute_not_exists(#payload) "
-                "AND attribute_exists(#messages)",
-            ),
-            (
-                "SET #expires_at = :ttl REMOVE #response",
-                "#lease_token = :token AND attribute_exists(#payload)",
-            ),
-        )
         if resume:
-            transitions = transitions[1:]
-            names.pop("#messages")
-        for update, condition in transitions:
-            try:
-                response = self._table.update_item(
-                    Key={"PK": self._session_pk(session_id), "SK": "BUFFER"},
-                    UpdateExpression=update,
-                    ConditionExpression=condition,
-                    ExpressionAttributeNames=names,
-                    ExpressionAttributeValues=values,
-                    ReturnValues="ALL_NEW",
-                )
-            except ClientError as exc:
-                if self._is_conditional_failure(exc):
-                    names.pop("#messages", None)
-                    continue
-                raise
-            item = response.get("Attributes", {})
-            return self._buffer_state_from_item(session_id, item).processing_payload
-        return []
+            update = "SET #expires_at = :ttl REMOVE #response"
+            condition = "#lease_token = :token AND attribute_exists(#payload)"
+        else:
+            names["#messages"] = "messages"
+            update = (
+                "SET #payload = #messages, #expires_at = :ttl "
+                "REMOVE #messages, #response"
+            )
+            condition = (
+                "#lease_token = :token AND attribute_not_exists(#payload) "
+                "AND attribute_exists(#messages)"
+            )
+        try:
+            response = self._table.update_item(
+                Key={"PK": self._session_pk(session_id), "SK": "BUFFER"},
+                UpdateExpression=update,
+                ConditionExpression=condition,
+                ExpressionAttributeNames=names,
+                ExpressionAttributeValues={
+                    ":token": token,
+                    ":ttl": self._ttl(self._buffer_ttl_seconds),
+                },
+                ReturnValues="ALL_NEW",
+            )
+        except ClientError as exc:
+            if self._is_conditional_failure(exc):
+                if resume:
+                    return []
+                return self.claim_buffer_messages(session_id, token, True)
+            raise
+        return self._buffer_state_from_item(
+            session_id, response.get("Attributes", {})
+        ).processing_payload
 
     def set_pending_result(self, session_id: str, joined_message: str) -> None:
         """Persist a joined buffer result."""
@@ -374,16 +370,20 @@ class DynamoDBStateRepository:
                     "#processing_started_at = :started, #expires_at = :ttl"
                 ),
                 ConditionExpression=(
-                    "((attribute_not_exists(#lease_token) OR "
-                    "attribute_not_exists(#lease_expires_at)) AND "
-                    "(attribute_exists(processing_payload) OR "
-                    "attribute_exists(messages))) OR #lease_expires_at <= :now"
+                    "((attribute_type(#payload, :list_type) AND "
+                    "size(#payload) > :zero) OR (attribute_type(#messages, "
+                    ":list_type) AND size(#messages) > :zero)) AND "
+                    "(attribute_not_exists(#lease_token) OR "
+                    "attribute_not_exists(#lease_expires_at) OR "
+                    "#lease_expires_at <= :now)"
                 ),
                 ExpressionAttributeNames={
                     "#lease_token": "lease_token",
                     "#lease_expires_at": "lease_expires_at",
                     "#processing_started_at": "processing_started_at",
                     "#expires_at": "expires_at",
+                    "#payload": "processing_payload",
+                    "#messages": "messages",
                 },
                 ExpressionAttributeValues={
                     ":token": lease.token,
@@ -391,6 +391,8 @@ class DynamoDBStateRepository:
                     ":started": now_utc.isoformat(),
                     ":now": self._epoch_seconds(now_utc),
                     ":ttl": self._ttl(self._buffer_ttl_seconds),
+                    ":list_type": "L",
+                    ":zero": 0,
                 },
                 ReturnValues="ALL_NEW",
             )

--- a/backend/app/message_buffer.py
+++ b/backend/app/message_buffer.py
@@ -167,27 +167,24 @@ async def _flush_owned_buffer(session_id: str, token: str) -> Optional[str]:
         joined = "\n".join(message.message for message in buffer_messages)
         return joined
 
-    with _state_lock:
+    with _state_lock, _pending_state_lock:
         current = _processing_leases.get(session_id)
         if current is None or current.token != token:
             return None
         existing_payload = _processing_payloads.get(session_id)
-        buffered_entries = _buffer.pop(session_id, [])
+        buffered_entries = [] if existing_payload else _buffer.pop(session_id, [])
         joined = existing_payload or "\n".join(msg for msg, _ in buffered_entries)
         if joined:
             _processing_payloads[session_id] = joined
+        _pending_results.pop(session_id, None)
+        _pending_chat_responses.pop(session_id, None)
+        _processing_sessions.pop(session_id, None)
     task = _buffer_tasks.pop(session_id, None)
     current_task = asyncio.current_task()
     if task and task is not current_task and not task.done():
         task.cancel()
     if not joined:
         return None
-    # Clean up stale state from previous flushes to prevent memory leaks
-    # and avoid false "not_found" responses while background processing runs.
-    with _pending_state_lock:
-        _pending_results.pop(session_id, None)
-        _pending_chat_responses.pop(session_id, None)
-        _processing_sessions.pop(session_id, None)
     return joined
 
 
@@ -217,6 +214,14 @@ def get_buffer_count(session_id: str) -> int:
     if _state_repository is not None:
         return len(_state_repository.get_buffer_state(session_id).messages)
     return len(_buffer.get(session_id, []))
+
+
+def has_processing_payload(session_id: str) -> bool:
+    """Return whether failed processing has a recoverable claimed payload."""
+    if _state_repository is not None:
+        return bool(_state_repository.get_buffer_state(session_id).processing_payload)
+    with _state_lock:
+        return session_id in _processing_payloads
 
 
 def clear_buffer(session_id: str) -> None:
@@ -422,6 +427,8 @@ def complete_processing(
                 response_json,
                 datetime.now(timezone.utc),
             )
+        else:
+            _pending_chat_responses.pop(session_id, None)
         _processing_leases.pop(session_id, None)
         _processing_payloads.pop(session_id, None)
         _processing_sessions.pop(session_id, None)

--- a/backend/app/message_buffer.py
+++ b/backend/app/message_buffer.py
@@ -130,25 +130,37 @@ async def flush_buffer(session_id: str) -> Optional[str]:
 
 async def acquire_and_flush_buffer(
     session_id: str,
+    resume: bool = False,
 ) -> Optional[OwnedBufferedMessage]:
     """Acquire processing ownership before destructively flushing a buffer."""
-    acquired = acquire_processing_lease(session_id)
+    if _state_repository is None:
+        with _state_lock:
+            if not _processing_payloads.get(session_id) and not _buffer.get(session_id):
+                return None
+            acquired = acquire_processing_lease(session_id)
+    else:
+        acquired = acquire_processing_lease(session_id)
     if not acquired.acquired or acquired.lease is None:
         return None
 
     lease = acquired.lease
     try:
-        joined = await _flush_owned_buffer(session_id, lease.token)
+        joined = await _flush_owned_buffer(session_id, lease.token, resume)
     except BaseException:
         release_processing_lease(session_id, lease.token)
         raise
     if joined is None:
-        complete_processing(session_id, lease.token, None)
+        if resume:
+            release_processing_lease(session_id, lease.token)
+        else:
+            complete_processing(session_id, lease.token, None)
         return None
     return OwnedBufferedMessage(message=joined, lease=lease)
 
 
-async def _flush_owned_buffer(session_id: str, token: str) -> Optional[str]:
+async def _flush_owned_buffer(
+    session_id: str, token: str, resume: bool = False
+) -> Optional[str]:
     """Flush a buffer after the caller has acquired processing ownership.
 
     Local mode clears stale pending delivery state before returning the joined
@@ -161,7 +173,9 @@ async def _flush_owned_buffer(session_id: str, token: str) -> Optional[str]:
         Messages joined with newline separator, or None if buffer empty.
     """
     if _state_repository is not None:
-        buffer_messages = _state_repository.claim_buffer_messages(session_id, token)
+        buffer_messages = _state_repository.claim_buffer_messages(
+            session_id, token, resume
+        )
         if not buffer_messages:
             return None
         joined = "\n".join(message.message for message in buffer_messages)
@@ -172,6 +186,8 @@ async def _flush_owned_buffer(session_id: str, token: str) -> Optional[str]:
         if current is None or current.token != token:
             return None
         existing_payload = _processing_payloads.get(session_id)
+        if resume and existing_payload is None:
+            return None
         buffered_entries = [] if existing_payload else _buffer.pop(session_id, [])
         joined = existing_payload or "\n".join(msg for msg, _ in buffered_entries)
         if joined:

--- a/backend/app/message_buffer.py
+++ b/backend/app/message_buffer.py
@@ -137,9 +137,7 @@ async def acquire_and_flush_buffer(
         with _state_lock:
             if not _processing_payloads.get(session_id) and not _buffer.get(session_id):
                 return None
-            acquired = acquire_processing_lease(session_id)
-    else:
-        acquired = acquire_processing_lease(session_id)
+    acquired = acquire_processing_lease(session_id)
     if not acquired.acquired or acquired.lease is None:
         return None
 

--- a/backend/app/message_buffer.py
+++ b/backend/app/message_buffer.py
@@ -21,6 +21,7 @@ from backend.app.config import settings
 from backend.app.state_repository import (
     ChatbotStateRepository,
     ProcessingLease,
+    ProcessingCompletionResult,
     ProcessingLeaseReleaseResult,
     ProcessingLeaseResult,
 )
@@ -50,6 +51,7 @@ _pending_state_lock = RLock()
 
 # Tokenized leases coordinate every local destructive buffer-processing path.
 _processing_leases: dict[str, ProcessingLease] = {}
+_processing_payloads: dict[str, str] = {}
 _state_lock = RLock()
 
 
@@ -123,7 +125,7 @@ async def flush_buffer(session_id: str) -> Optional[str]:
     try:
         return owned_message.message
     finally:
-        release_processing_lease(session_id, owned_message.lease.token)
+        complete_processing(session_id, owned_message.lease.token, None)
 
 
 async def acquire_and_flush_buffer(
@@ -136,17 +138,17 @@ async def acquire_and_flush_buffer(
 
     lease = acquired.lease
     try:
-        joined = await _flush_owned_buffer(session_id)
+        joined = await _flush_owned_buffer(session_id, lease.token)
     except BaseException:
         release_processing_lease(session_id, lease.token)
         raise
     if joined is None:
-        release_processing_lease(session_id, lease.token)
+        complete_processing(session_id, lease.token, None)
         return None
     return OwnedBufferedMessage(message=joined, lease=lease)
 
 
-async def _flush_owned_buffer(session_id: str) -> Optional[str]:
+async def _flush_owned_buffer(session_id: str, token: str) -> Optional[str]:
     """Flush a buffer after the caller has acquired processing ownership.
 
     Local mode clears stale pending delivery state before returning the joined
@@ -159,22 +161,27 @@ async def _flush_owned_buffer(session_id: str) -> Optional[str]:
         Messages joined with newline separator, or None if buffer empty.
     """
     if _state_repository is not None:
-        buffer_messages = _state_repository.claim_buffer_messages(session_id)
+        buffer_messages = _state_repository.claim_buffer_messages(session_id, token)
         if not buffer_messages:
             return None
         joined = "\n".join(message.message for message in buffer_messages)
-        _state_repository.set_pending_result(session_id, joined)
         return joined
 
     with _state_lock:
+        current = _processing_leases.get(session_id)
+        if current is None or current.token != token:
+            return None
+        existing_payload = _processing_payloads.get(session_id)
         buffered_entries = _buffer.pop(session_id, [])
+        joined = existing_payload or "\n".join(msg for msg, _ in buffered_entries)
+        if joined:
+            _processing_payloads[session_id] = joined
     task = _buffer_tasks.pop(session_id, None)
     current_task = asyncio.current_task()
     if task and task is not current_task and not task.done():
         task.cancel()
-    if not buffered_entries:
+    if not joined:
         return None
-    joined = "\n".join(msg for msg, _ in buffered_entries)
     # Clean up stale state from previous flushes to prevent memory leaks
     # and avoid false "not_found" responses while background processing runs.
     with _pending_state_lock:
@@ -398,6 +405,28 @@ def release_local_processing_lease(
             return ProcessingLeaseReleaseResult(released=False)
         del _processing_leases[session_id]
         return ProcessingLeaseReleaseResult(released=True)
+
+
+def complete_processing(
+    session_id: str, token: str, response_json: Optional[str]
+) -> ProcessingCompletionResult:
+    """Commit terminal output and cleanup only for the current owner."""
+    if _state_repository is not None:
+        return _state_repository.complete_processing(session_id, token, response_json)
+    with _state_lock, _pending_state_lock:
+        current = _processing_leases.get(session_id)
+        if current is None or current.token != token:
+            return ProcessingCompletionResult(completed=False)
+        if response_json is not None:
+            _pending_chat_responses[session_id] = (
+                response_json,
+                datetime.now(timezone.utc),
+            )
+        _processing_leases.pop(session_id, None)
+        _processing_payloads.pop(session_id, None)
+        _processing_sessions.pop(session_id, None)
+        _pending_results.pop(session_id, None)
+        return ProcessingCompletionResult(completed=True)
 
 
 def is_processing(session_id: str) -> bool:

--- a/backend/app/state_repository.py
+++ b/backend/app/state_repository.py
@@ -86,11 +86,18 @@ class ProcessingLeaseReleaseResult(_FrozenModel):
     released: bool
 
 
+class ProcessingCompletionResult(_FrozenModel):
+    """Outcome of a lease-fenced terminal processing transition."""
+
+    completed: bool
+
+
 class BufferState(BaseModel):
     """Durable multi-message buffer and polling state."""
 
     session_id: str
     messages: list[BufferMessage] = Field(default_factory=list)
+    processing_payload: list[BufferMessage] = Field(default_factory=list)
     pending_result: Optional[str] = None
     pending_chat_response: Optional[str] = None
     processing_started_at: Optional[datetime] = None
@@ -150,8 +157,10 @@ class ChatbotStateRepository(Protocol):
     def append_buffer_message(self, session_id: str, message: str) -> BufferState:
         """Append one message to the durable buffer."""
 
-    def claim_buffer_messages(self, session_id: str) -> list[BufferMessage]:
-        """Atomically remove and return the messages present at claim time."""
+    def claim_buffer_messages(
+        self, session_id: str, token: str
+    ) -> list[BufferMessage]:
+        """Atomically claim or resume the payload owned by ``token``."""
 
     def clear_buffer_messages(self, session_id: str) -> None:
         """Remove buffered input messages while preserving polling state."""
@@ -193,3 +202,8 @@ class ChatbotStateRepository(Protocol):
         self, session_id: str, token: str
     ) -> ProcessingLeaseReleaseResult:
         """Release processing ownership only when the token matches."""
+
+    def complete_processing(
+        self, session_id: str, token: str, response_json: Optional[str]
+    ) -> ProcessingCompletionResult:
+        """Publish optionally and clean up only for the current lease token."""

--- a/backend/app/state_repository.py
+++ b/backend/app/state_repository.py
@@ -157,9 +157,7 @@ class ChatbotStateRepository(Protocol):
     def append_buffer_message(self, session_id: str, message: str) -> BufferState:
         """Append one message to the durable buffer."""
 
-    def claim_buffer_messages(
-        self, session_id: str, token: str
-    ) -> list[BufferMessage]:
+    def claim_buffer_messages(self, session_id: str, token: str) -> list[BufferMessage]:
         """Atomically claim or resume the payload owned by ``token``."""
 
     def clear_buffer_messages(self, session_id: str) -> None:

--- a/backend/app/state_repository.py
+++ b/backend/app/state_repository.py
@@ -157,8 +157,10 @@ class ChatbotStateRepository(Protocol):
     def append_buffer_message(self, session_id: str, message: str) -> BufferState:
         """Append one message to the durable buffer."""
 
-    def claim_buffer_messages(self, session_id: str, token: str) -> list[BufferMessage]:
-        """Atomically claim or resume the payload owned by ``token``."""
+    def claim_buffer_messages(
+        self, session_id: str, token: str, resume: bool = False
+    ) -> list[BufferMessage]:
+        """Atomically remove and return the messages present at claim time."""
 
     def clear_buffer_messages(self, session_id: str) -> None:
         """Remove buffered input messages while preserving polling state."""

--- a/backend/app/tests/test_message_buffer.py
+++ b/backend/app/tests/test_message_buffer.py
@@ -557,7 +557,6 @@ class TestLocalProcessingLease:
 
         monkeypatch.setattr("backend.main.acquire_and_flush_buffer", finish)
         assert (await get_buffer_result("r", "k")).status == "ready"
-        assert get_buffer_count("r") == 0
         assert message_buffer.pop_pending_chat_response("r") is None
         assert not message_buffer.has_active_processing_lease("r")
 

--- a/backend/app/tests/test_message_buffer.py
+++ b/backend/app/tests/test_message_buffer.py
@@ -536,7 +536,6 @@ class TestLocalProcessingLease:
     ) -> None:
         from backend.app import message_buffer
         from backend.app.auth import api_key_principal
-        from backend.app.config import settings
         from backend.app.dynamodb_state_repository import DynamoDBStateRepository
         from backend.app.session import session_manager
         from backend.main import ChatResponse, get_buffer_result
@@ -546,8 +545,7 @@ class TestLocalProcessingLease:
             repository = DynamoDBStateRepository(table=FakeDynamoDBTable())
             message_buffer.set_state_repository(repository)
         session_manager.bind_session("recovery", api_key_principal("lambda-test-key"))
-        expires_at = datetime.now(timezone.utc)
-        now = expires_at - timedelta(seconds=settings.buffer_processing_lease_seconds)
+        now = datetime.now(timezone.utc) - timedelta(seconds=61)
         await add_to_buffer("recovery", "durable payload")
         assert message_buffer.acquire_processing_lease(
             "recovery", now=now, token="first"
@@ -926,7 +924,6 @@ class TestEndpointBufferIntegration:
         assert "response" in data
         assert data["session_id"] == session_id
         assert message_buffer.pop_pending_chat_response(session_id) is None
-        assert not message_buffer.has_processing_payload(session_id)
 
         # Cleanup
         message_buffer._buffer.clear()

--- a/backend/app/tests/test_message_buffer.py
+++ b/backend/app/tests/test_message_buffer.py
@@ -530,37 +530,6 @@ class TestLocalProcessingLease:
         assert not acquire_processing_lease("legacy", now=now, token="blocked").acquired
         assert release_processing_lease("legacy", "owner").released
 
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("durable", [False, True])
-    async def test_recovery_race(
-        self, durable: bool, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        from backend.app import message_buffer
-        from backend.app.auth import api_key_principal
-        from backend.app.dynamodb_state_repository import DynamoDBStateRepository
-        from backend.app.session import session_manager
-        from backend.main import get_buffer_result
-        from backend.tests.test_state_repository import FakeDynamoDBTable
-
-        if durable:
-            repository = DynamoDBStateRepository(table=FakeDynamoDBTable())
-            message_buffer.set_state_repository(repository)
-        session_manager.bind_session("r", api_key_principal("k"))
-        now = datetime.now(timezone.utc) - timedelta(seconds=61)
-        await add_to_buffer("r", "durable payload")
-        message_buffer.acquire_processing_lease("r", now=now, token="first")
-        await message_buffer._flush_owned_buffer("r", "first")
-        acquire = message_buffer.acquire_and_flush_buffer
-
-        async def finish(*args: object, **kwargs: object) -> object:
-            assert message_buffer.complete_processing("r", "first", '"ready"').completed
-            return await acquire(*args, **kwargs)
-
-        monkeypatch.setattr("backend.main.acquire_and_flush_buffer", finish)
-        assert (await get_buffer_result("r", "k")).status == "ready"
-        assert message_buffer.pop_pending_chat_response("r") is None
-        assert not message_buffer.has_active_processing_lease("r")
-
 
 # ===========================================================================
 # Task 5.5 — Overflow: max_messages triggers immediate flush

--- a/backend/app/tests/test_message_buffer.py
+++ b/backend/app/tests/test_message_buffer.py
@@ -496,8 +496,9 @@ class TestLocalProcessingLease:
 
         local_outcomes = exercise()
         message_buffer.set_state_repository(
-            DynamoDBStateRepository(table=FakeDynamoDBTable())
+            repository := DynamoDBStateRepository(table=FakeDynamoDBTable())
         )
+        repository.append_buffer_message("parity", "work")
         try:
             repository_outcomes = exercise()
         finally:

--- a/backend/app/tests/test_message_buffer.py
+++ b/backend/app/tests/test_message_buffer.py
@@ -841,13 +841,11 @@ class TestEndpointBufferIntegration:
         message_buffer._buffer.clear()
         message_buffer._buffer_tasks.clear()
 
-    @pytest.mark.parametrize("durable", [False, True])
     @patch("backend.main.llm_client.get_llm_response_with_tools")
     def test_is_final_bypasses_buffer(
         self,
         mock_llm: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
-        durable: bool,
     ) -> None:
         """When is_final=True, message is processed immediately, not buffered."""
         mock_llm.return_value = make_llm_response(
@@ -857,12 +855,6 @@ class TestEndpointBufferIntegration:
         client, app = self._make_client(monkeypatch, enabled=True)
 
         from backend.app import message_buffer
-        from backend.app.dynamodb_state_repository import DynamoDBStateRepository
-        from backend.tests.test_state_repository import FakeDynamoDBTable
-
-        if durable:
-            repository = DynamoDBStateRepository(table=FakeDynamoDBTable())
-            message_buffer.set_state_repository(repository)
 
         message_buffer._buffer.clear()
         message_buffer._buffer_tasks.clear()
@@ -874,7 +866,6 @@ class TestEndpointBufferIntegration:
         )
         assert r1.status_code == 202
         session_id = r1.json()["session_id"]
-        message_buffer.set_pending_chat_response(session_id, '"stale"')
 
         # Second message with is_final — should process
         r2 = client.post(
@@ -890,12 +881,10 @@ class TestEndpointBufferIntegration:
         # Should contain joined message (original + is_final)
         assert "response" in data
         assert data["session_id"] == session_id
-        assert message_buffer.pop_pending_chat_response(session_id) is None
 
         # Cleanup
         message_buffer._buffer.clear()
         message_buffer._buffer_tasks.clear()
-        message_buffer.set_state_repository(None)
         app.dependency_overrides.clear()
 
     @patch("backend.main.llm_client.get_llm_response_with_tools")

--- a/backend/app/tests/test_message_buffer.py
+++ b/backend/app/tests/test_message_buffer.py
@@ -531,37 +531,35 @@ class TestLocalProcessingLease:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("durable", [False, True])
-    async def test_worker_death_payload_is_resumed_and_completion_is_fenced(
+    async def test_recovery_race(
         self, durable: bool, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from backend.app import message_buffer
         from backend.app.auth import api_key_principal
         from backend.app.dynamodb_state_repository import DynamoDBStateRepository
         from backend.app.session import session_manager
-        from backend.main import ChatResponse, get_buffer_result
+        from backend.main import get_buffer_result
         from backend.tests.test_state_repository import FakeDynamoDBTable
 
         if durable:
             repository = DynamoDBStateRepository(table=FakeDynamoDBTable())
             message_buffer.set_state_repository(repository)
-        session_manager.bind_session("recovery", api_key_principal("lambda-test-key"))
+        session_manager.bind_session("r", api_key_principal("k"))
         now = datetime.now(timezone.utc) - timedelta(seconds=61)
-        await add_to_buffer("recovery", "durable payload")
-        assert message_buffer.acquire_processing_lease(
-            "recovery", now=now, token="first"
-        ).acquired
-        await message_buffer._flush_owned_buffer("recovery", "first")
-        await add_to_buffer("recovery", "next batch")
+        await add_to_buffer("r", "durable payload")
+        message_buffer.acquire_processing_lease("r", now=now, token="first")
+        await message_buffer._flush_owned_buffer("r", "first")
+        acquire = message_buffer.acquire_and_flush_buffer
 
-        async def process(**kwargs: object) -> ChatResponse:
-            assert kwargs["message"] == "durable payload"
-            return ChatResponse(response="ready", session_id="recovery")
+        async def finish(*args: object, **kwargs: object) -> object:
+            assert message_buffer.complete_processing("r", "first", '"ready"').completed
+            return await acquire(*args, **kwargs)
 
-        monkeypatch.setattr("backend.main._process_chat_message", process)
-        assert (
-            await get_buffer_result("recovery", "lambda-test-key")
-        ).status == "ready"
-        assert get_buffer_count("recovery") == 1
+        monkeypatch.setattr("backend.main.acquire_and_flush_buffer", finish)
+        assert (await get_buffer_result("r", "k")).status == "ready"
+        assert get_buffer_count("r") == 0
+        assert message_buffer.pop_pending_chat_response("r") is None
+        assert not message_buffer.has_active_processing_lease("r")
 
 
 # ===========================================================================

--- a/backend/app/tests/test_message_buffer.py
+++ b/backend/app/tests/test_message_buffer.py
@@ -57,7 +57,6 @@ def _clean_buffer_state() -> Generator[None, None, None]:
         message_buffer._pending_results.clear()
         message_buffer._pending_chat_responses.clear()
         message_buffer._processing_leases.clear()
-        message_buffer._processing_payloads.clear()
         message_buffer._processing_sessions.clear()
     except ImportError:
         pass
@@ -70,7 +69,6 @@ def _clean_buffer_state() -> Generator[None, None, None]:
         message_buffer._pending_results.clear()
         message_buffer._pending_chat_responses.clear()
         message_buffer._processing_leases.clear()
-        message_buffer._processing_payloads.clear()
         message_buffer._processing_sessions.clear()
     except ImportError:
         pass
@@ -534,38 +532,38 @@ class TestLocalProcessingLease:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("durable", [False, True])
     async def test_worker_death_payload_is_resumed_and_completion_is_fenced(
-        self, durable: bool
+        self, durable: bool, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from backend.app import message_buffer
+        from backend.app.auth import api_key_principal
+        from backend.app.config import settings
         from backend.app.dynamodb_state_repository import DynamoDBStateRepository
+        from backend.app.session import session_manager
+        from backend.main import ChatResponse, get_buffer_result
         from backend.tests.test_state_repository import FakeDynamoDBTable
 
         if durable:
-            message_buffer.set_state_repository(
-                DynamoDBStateRepository(table=FakeDynamoDBTable())
-            )
-        now = datetime(2026, 8, 17, tzinfo=timezone.utc)
+            repository = DynamoDBStateRepository(table=FakeDynamoDBTable())
+            message_buffer.set_state_repository(repository)
+        session_manager.bind_session("recovery", api_key_principal("lambda-test-key"))
+        expires_at = datetime.now(timezone.utc)
+        now = expires_at - timedelta(seconds=settings.buffer_processing_lease_seconds)
         await add_to_buffer("recovery", "durable payload")
-        first = message_buffer.acquire_processing_lease(
+        assert message_buffer.acquire_processing_lease(
             "recovery", now=now, token="first"
-        )
-        assert first.lease is not None
-        claimed = await message_buffer._flush_owned_buffer("recovery", "first")
-        successor = message_buffer.acquire_processing_lease(
-            "recovery", now=first.lease.expires_at, token="successor"
-        )
-        resumed = await message_buffer._flush_owned_buffer("recovery", "successor")
+        ).acquired
+        await message_buffer._flush_owned_buffer("recovery", "first")
+        await add_to_buffer("recovery", "next batch")
 
-        assert successor.acquired
-        assert claimed == resumed == "durable payload"
-        assert not message_buffer.complete_processing(
-            "recovery", "first", '"stale"'
-        ).completed
-        assert message_buffer.complete_processing(
-            "recovery", "successor", '"ready"'
-        ).completed
-        assert message_buffer.pop_pending_chat_response("recovery") == '"ready"'
-        message_buffer.set_state_repository(None)
+        async def process(**kwargs: object) -> ChatResponse:
+            assert kwargs["message"] == "durable payload"
+            return ChatResponse(response="ready", session_id="recovery")
+
+        monkeypatch.setattr("backend.main._process_chat_message", process)
+        assert (
+            await get_buffer_result("recovery", "lambda-test-key")
+        ).status == "ready"
+        assert get_buffer_count("recovery") == 1
 
 
 # ===========================================================================
@@ -878,11 +876,13 @@ class TestEndpointBufferIntegration:
         message_buffer._buffer.clear()
         message_buffer._buffer_tasks.clear()
 
+    @pytest.mark.parametrize("durable", [False, True])
     @patch("backend.main.llm_client.get_llm_response_with_tools")
     def test_is_final_bypasses_buffer(
         self,
         mock_llm: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
+        durable: bool,
     ) -> None:
         """When is_final=True, message is processed immediately, not buffered."""
         mock_llm.return_value = make_llm_response(
@@ -892,6 +892,12 @@ class TestEndpointBufferIntegration:
         client, app = self._make_client(monkeypatch, enabled=True)
 
         from backend.app import message_buffer
+        from backend.app.dynamodb_state_repository import DynamoDBStateRepository
+        from backend.tests.test_state_repository import FakeDynamoDBTable
+
+        if durable:
+            repository = DynamoDBStateRepository(table=FakeDynamoDBTable())
+            message_buffer.set_state_repository(repository)
 
         message_buffer._buffer.clear()
         message_buffer._buffer_tasks.clear()
@@ -903,6 +909,7 @@ class TestEndpointBufferIntegration:
         )
         assert r1.status_code == 202
         session_id = r1.json()["session_id"]
+        message_buffer.set_pending_chat_response(session_id, '"stale"')
 
         # Second message with is_final — should process
         r2 = client.post(
@@ -919,11 +926,12 @@ class TestEndpointBufferIntegration:
         assert "response" in data
         assert data["session_id"] == session_id
         assert message_buffer.pop_pending_chat_response(session_id) is None
-        assert session_id not in message_buffer._processing_payloads
+        assert not message_buffer.has_processing_payload(session_id)
 
         # Cleanup
         message_buffer._buffer.clear()
         message_buffer._buffer_tasks.clear()
+        message_buffer.set_state_repository(None)
         app.dependency_overrides.clear()
 
     @patch("backend.main.llm_client.get_llm_response_with_tools")
@@ -966,8 +974,6 @@ class TestEndpointBufferIntegration:
         assert r5.status_code == 200
         data = r5.json()
         assert "response" in data
-        assert message_buffer.pop_pending_chat_response(session_id) is None
-        assert session_id not in message_buffer._processing_payloads
 
         # Verify LLM was called with joined message
         mock_llm.assert_called_once()

--- a/backend/app/tests/test_message_buffer.py
+++ b/backend/app/tests/test_message_buffer.py
@@ -57,6 +57,7 @@ def _clean_buffer_state() -> Generator[None, None, None]:
         message_buffer._pending_results.clear()
         message_buffer._pending_chat_responses.clear()
         message_buffer._processing_leases.clear()
+        message_buffer._processing_payloads.clear()
         message_buffer._processing_sessions.clear()
     except ImportError:
         pass
@@ -69,6 +70,7 @@ def _clean_buffer_state() -> Generator[None, None, None]:
         message_buffer._pending_results.clear()
         message_buffer._pending_chat_responses.clear()
         message_buffer._processing_leases.clear()
+        message_buffer._processing_payloads.clear()
         message_buffer._processing_sessions.clear()
     except ImportError:
         pass
@@ -529,6 +531,42 @@ class TestLocalProcessingLease:
         assert not acquire_processing_lease("legacy", now=now, token="blocked").acquired
         assert release_processing_lease("legacy", "owner").released
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("durable", [False, True])
+    async def test_worker_death_payload_is_resumed_and_completion_is_fenced(
+        self, durable: bool
+    ) -> None:
+        from backend.app import message_buffer
+        from backend.app.dynamodb_state_repository import DynamoDBStateRepository
+        from backend.tests.test_state_repository import FakeDynamoDBTable
+
+        if durable:
+            message_buffer.set_state_repository(
+                DynamoDBStateRepository(table=FakeDynamoDBTable())
+            )
+        now = datetime(2026, 8, 17, tzinfo=timezone.utc)
+        await add_to_buffer("recovery", "durable payload")
+        first = message_buffer.acquire_processing_lease(
+            "recovery", now=now, token="first"
+        )
+        assert first.lease is not None
+        claimed = await message_buffer._flush_owned_buffer("recovery", "first")
+        successor = message_buffer.acquire_processing_lease(
+            "recovery", now=first.lease.expires_at, token="successor"
+        )
+        resumed = await message_buffer._flush_owned_buffer("recovery", "successor")
+
+        assert successor.acquired
+        assert claimed == resumed == "durable payload"
+        assert not message_buffer.complete_processing(
+            "recovery", "first", '"stale"'
+        ).completed
+        assert message_buffer.complete_processing(
+            "recovery", "successor", '"ready"'
+        ).completed
+        assert message_buffer.pop_pending_chat_response("recovery") == '"ready"'
+        message_buffer.set_state_repository(None)
+
 
 # ===========================================================================
 # Task 5.5 — Overflow: max_messages triggers immediate flush
@@ -880,6 +918,8 @@ class TestEndpointBufferIntegration:
         # Should contain joined message (original + is_final)
         assert "response" in data
         assert data["session_id"] == session_id
+        assert message_buffer.pop_pending_chat_response(session_id) is None
+        assert session_id not in message_buffer._processing_payloads
 
         # Cleanup
         message_buffer._buffer.clear()
@@ -926,6 +966,8 @@ class TestEndpointBufferIntegration:
         assert r5.status_code == 200
         data = r5.json()
         assert "response" in data
+        assert message_buffer.pop_pending_chat_response(session_id) is None
+        assert session_id not in message_buffer._processing_payloads
 
         # Verify LLM was called with joined message
         mock_llm.assert_called_once()

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -49,6 +49,8 @@ def _reset_runtime_state() -> None:
     message_buffer._pending_results.clear()
     message_buffer._pending_chat_responses.clear()
     message_buffer._processing_sessions.clear()
+    message_buffer._processing_leases.clear()
+    message_buffer._processing_payloads.clear()
 
     for task in list(message_buffer._buffer_tasks.values()):
         if not task.done():

--- a/backend/main.py
+++ b/backend/main.py
@@ -70,6 +70,7 @@ from backend.app.message_buffer import (
     complete_processing,
     get_buffer_count,
     has_active_processing_lease,
+    has_processing_payload,
     is_buffer_ready_to_flush,
     is_buffering,
     pop_pending_chat_response,
@@ -1928,6 +1929,21 @@ async def get_buffer_result(
             session_id=session_id,
             result=chat_response_json,
         )
+
+    if has_processing_payload(session_id):
+        owned_message = await acquire_and_flush_buffer(session_id)
+        if owned_message is not None:
+            await _on_buffer_window_expired(
+                session_id, owned_message.message, owned_message.lease
+            )
+            chat_response_json = pop_pending_chat_response(session_id)
+            if chat_response_json is not None:
+                return BufferResultResponse(
+                    status="ready",
+                    session_id=session_id,
+                    result=chat_response_json,
+                )
+        return BufferResultResponse(status="pending", session_id=session_id)
 
     if is_buffering(session_id):
         if is_buffer_ready_to_flush(

--- a/backend/main.py
+++ b/backend/main.py
@@ -1931,18 +1931,18 @@ async def get_buffer_result(
         )
 
     if has_processing_payload(session_id):
-        owned_message = await acquire_and_flush_buffer(session_id)
+        owned_message = await acquire_and_flush_buffer(session_id, resume=True)
         if owned_message is not None:
             await _on_buffer_window_expired(
                 session_id, owned_message.message, owned_message.lease
             )
-            chat_response_json = pop_pending_chat_response(session_id)
-            if chat_response_json is not None:
-                return BufferResultResponse(
-                    status="ready",
-                    session_id=session_id,
-                    result=chat_response_json,
-                )
+        chat_response_json = pop_pending_chat_response(session_id)
+        if chat_response_json is not None:
+            return BufferResultResponse(
+                status="ready",
+                session_id=session_id,
+                result=chat_response_json,
+            )
         return BufferResultResponse(status="pending", session_id=session_id)
 
     if is_buffering(session_id):

--- a/backend/main.py
+++ b/backend/main.py
@@ -67,15 +67,14 @@ from backend.app.message_buffer import (
     acquire_and_flush_buffer,
     add_to_buffer,
     clear_pending_chat_response,
+    complete_processing,
     get_buffer_count,
     has_active_processing_lease,
     is_buffer_ready_to_flush,
     is_buffering,
     pop_pending_chat_response,
-    release_processing_lease,
     schedule_flush,
     set_state_repository as set_buffer_state_repository,
-    set_pending_chat_response,
 )
 
 from backend.app.message_splitter import process_split_messages
@@ -88,7 +87,11 @@ from backend.app.security import (
     validate_session_id,
 )
 from backend.app.session import session_manager
-from backend.app.state_repository import ChatbotStateRepository, ProcessingLease
+from backend.app.state_repository import (
+    ChatbotStateRepository,
+    ProcessingCompletionResult,
+    ProcessingLease,
+)
 from backend.app.tools import get_tool_definitions, validate_s3_path
 from backend.app.user_profiler import (
     PROFILE_INSTRUCTIONS,
@@ -1739,7 +1742,7 @@ async def _process_chat_message(
 
 async def _on_buffer_window_expired(
     session_id: str, joined_message: str, lease: ProcessingLease
-) -> None:
+) -> ProcessingCompletionResult:
     """Callback when buffer window expires.
 
     Processes the joined message with the chatbot in the background
@@ -1759,7 +1762,7 @@ async def _on_buffer_window_expired(
             s3_client=s3_client,
             file_inputs_client=file_inputs_client,
         )
-        set_pending_chat_response(session_id, response.model_dump_json())
+        response_json = response.model_dump_json()
         logger.info(
             "Buffered message processed for session %s, response stored for polling",
             session_id,
@@ -1787,9 +1790,8 @@ async def _on_buffer_window_expired(
             output_tokens=0,
             total_tokens=0,
         )
-        set_pending_chat_response(session_id, error_response.model_dump_json())
-    finally:
-        release_processing_lease(session_id, lease.token)
+        response_json = error_response.model_dump_json()
+    return complete_processing(session_id, lease.token, response_json)
 
 
 @app.post("/chat", response_model=ChatResponse)
@@ -1835,7 +1837,7 @@ async def chat_endpoint(
         if owned_message is not None:
             processing_lease = owned_message.lease
             if len(owned_message.message) > settings.max_chat_message_chars:
-                release_processing_lease(session_id, processing_lease.token)
+                complete_processing(session_id, processing_lease.token, None)
                 processing_lease = None
                 raise HTTPException(
                     status_code=413, detail="Buffered message too large"
@@ -1861,7 +1863,7 @@ async def chat_endpoint(
             )
 
     try:
-        return await _process_chat_message(
+        response = await _process_chat_message(
             session_id=session_id,
             message=request.message,
             llm_client=llm_client,
@@ -1870,6 +1872,20 @@ async def chat_endpoint(
             request_id=request_id,
             deadline=deadline,
         )
+        if processing_lease is not None:
+            completion = complete_processing(
+                session_id, processing_lease.token, response_json=None
+            )
+            processing_lease = None
+            if not completion.completed:
+                return JSONResponse(
+                    status_code=202,
+                    content=BufferingResponse(
+                        session_id=session_id,
+                        poll_url=f"/buffer-result/{session_id}",
+                    ).model_dump(),
+                )
+        return response
     except LLMServiceError as e:
         logger.error(
             "LLM service error: request_id=%s, session_id=%s, error=%s",
@@ -1886,9 +1902,6 @@ async def chat_endpoint(
             e,
         )
         raise HTTPException(status_code=500, detail="Internal server error")
-    finally:
-        if processing_lease is not None:
-            release_processing_lease(session_id, processing_lease.token)
 
 
 @app.get("/buffer-result/{session_id}", response_model=BufferResultResponse)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1937,13 +1937,10 @@ async def get_buffer_result(
                 session_id, owned_message.message, owned_message.lease
             )
         chat_response_json = pop_pending_chat_response(session_id)
-        if chat_response_json is not None:
-            return BufferResultResponse(
-                status="ready",
-                session_id=session_id,
-                result=chat_response_json,
-            )
-        return BufferResultResponse(status="pending", session_id=session_id)
+        status = "ready" if chat_response_json is not None else "pending"
+        return BufferResultResponse(
+            status=status, session_id=session_id, result=chat_response_json
+        )
 
     if is_buffering(session_id):
         if is_buffer_ready_to_flush(

--- a/backend/tests/test_deadline_orchestration.py
+++ b/backend/tests/test_deadline_orchestration.py
@@ -134,11 +134,10 @@ async def test_buffered_path_stores_controlled_timeout() -> None:
     with (
         patch("backend.main._request_deadline", return_value=deadline),
         patch(LLM_CALL, side_effect=_sdk_timeout),
-        patch("backend.main.set_pending_chat_response", stored),
-        patch("backend.main.release_processing_lease"),
+        patch("backend.main.complete_processing", stored),
     ):
         await backend_main._on_buffer_window_expired("buffer-session", "paneles", lease)
-    data = json.loads(stored.call_args.args[1])
+    data = json.loads(stored.call_args.args[2])
     outcome = data["intent_type"], data["escalate"], data["input_tokens"]
     assert outcome == ("request_timeout", True, 0)
     assert data["source_documents"] == [] and data["num_sources"] == 0

--- a/backend/tests/test_lambda_runtime.py
+++ b/backend/tests/test_lambda_runtime.py
@@ -210,6 +210,7 @@ def test_chat_processes_owned_batch_from_stale_precount(
     owned = OwnedBufferedMessage(message="first\nsecond", lease=lease)
     processed: list[str] = []
     released: list[str] = []
+    completion = type("Completion", (), {"completed": True})()
 
     async def overflow(*_: Any, **__: Any) -> OwnedBufferedMessage:
         return owned
@@ -226,8 +227,8 @@ def test_chat_processes_owned_batch_from_stale_precount(
     monkeypatch.setattr("backend.main.schedule_flush", reject_schedule)
     monkeypatch.setattr("backend.main._process_chat_message", process)
     monkeypatch.setattr(
-        "backend.main.release_processing_lease",
-        lambda _session_id, token: released.append(token),
+        "backend.main.complete_processing",
+        lambda _session_id, token, response_json: released.append(token) or completion,
     )
 
     response = handler(

--- a/backend/tests/test_lambda_runtime.py
+++ b/backend/tests/test_lambda_runtime.py
@@ -391,11 +391,11 @@ async def test_two_due_buffer_pollers_run_one_processor(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("error_type", [RuntimeError, asyncio.CancelledError])
-async def test_buffer_callback_always_releases_its_lease(
+async def test_buffer_callback_commits_errors_but_preserves_cancelled_work(
     monkeypatch: pytest.MonkeyPatch,
     error_type: type[BaseException],
 ) -> None:
-    """Callback errors and cancellation cannot leak processing ownership."""
+    """Terminal errors publish, while worker death leaves recoverable ownership."""
     from backend.app import message_buffer
     from backend.main import _on_buffer_window_expired
 
@@ -413,7 +413,9 @@ async def test_buffer_callback_always_releases_its_lease(
     else:
         await _on_buffer_window_expired(session_id, "Hola", acquired.lease)
 
-    assert not message_buffer.has_active_processing_lease(session_id)
+    assert message_buffer.has_active_processing_lease(session_id) is issubclass(
+        error_type, asyncio.CancelledError
+    )
 
 
 def test_auth_override_is_not_required_for_lambda_auth() -> None:

--- a/backend/tests/test_state_repository.py
+++ b/backend/tests/test_state_repository.py
@@ -176,6 +176,19 @@ class FakeDynamoDBTable:
             if item.get(token_name) != values[":token"]:
                 FakeDynamoDBTable._conditional_failure("token mismatch")
             return
+        claim_conditions = {
+            "#lease_token = :token AND attribute_exists(#payload)": True,
+            "#lease_token = :token AND attribute_not_exists(#payload) "
+            "AND attribute_exists(#messages)": False,
+        }
+        if expression in claim_conditions:
+            has_payload = names["#payload"] in item
+            is_invalid = item.get(names["#lease_token"]) != values[":token"]
+            is_invalid |= has_payload != claim_conditions[expression]
+            is_invalid |= not has_payload and names["#messages"] not in item
+            if is_invalid:
+                FakeDynamoDBTable._conditional_failure("payload claim failed")
+            return
         else:
             raise ValueError(f"Unsupported condition expression: {expression}")
 
@@ -251,26 +264,27 @@ class FakeDynamoDBTable:
             item["expires_at"] = deepcopy(values[":ttl"])
             return
 
-        if expression == (
-            "SET #payload = if_not_exists(#payload, #messages), "
-            "#messages = :messages, #expires_at = :ttl"
+        if expression in (
+            "SET #expires_at = :ttl REMOVE #response",
+            "SET #payload = #messages, #messages = :empty, #expires_at = :ttl "
+            "REMOVE #response",
         ):
-            payload_name = names["#payload"]
-            if payload_name not in item:
-                item[payload_name] = deepcopy(item.get(names["#messages"], []))
-            item[names["#messages"]] = deepcopy(values[":messages"])
+            if expression.startswith("SET #payload"):
+                item[names["#payload"]] = deepcopy(item[names["#messages"]])
+                item[names["#messages"]] = deepcopy(values[":empty"])
             item[names["#expires_at"]] = deepcopy(values[":ttl"])
+            item.pop(names["#response"], None)
             return
 
         if expression in (
             "SET #expires_at = :ttl REMOVE #lease_token, #lease_expires_at, "
-            "#processing_started_at, #payload, #pending_result",
+            "#processing_started_at, #payload, #pending_result, #response",
             "SET #expires_at = :ttl, #response = :response REMOVE "
             "#lease_token, #lease_expires_at, #processing_started_at, "
             "#payload, #pending_result",
         ):
             item[names["#expires_at"]] = deepcopy(values[":ttl"])
-            if "#response" in names:
+            if ":response" in values:
                 item[names["#response"]] = deepcopy(values[":response"])
             for alias in (
                 "#lease_token",
@@ -280,6 +294,8 @@ class FakeDynamoDBTable:
                 "#pending_result",
             ):
                 item.pop(names[alias], None)
+            if ":response" not in values:
+                item.pop(names["#response"], None)
             return
 
         if expression == (
@@ -424,7 +440,7 @@ class ClaimInterleavingTable(FakeDynamoDBTable):
     ) -> dict[str, Any]:
         is_claim = (
             current_thread().name == "buffer-claim"
-            and UpdateExpression.startswith("SET #payload = if_not_exists")
+            and UpdateExpression.startswith("SET #payload = #messages")
             and ReturnValues == "ALL_NEW"
         )
         if is_claim and self.pause == "before":
@@ -971,9 +987,7 @@ def test_atomic_buffer_claim_partitions_deterministic_interleaving(
     repository.append_buffer_message("s1", "first")
     now = datetime(2026, 8, 17, tzinfo=timezone.utc)
     lease = ProcessingLease(token="owner", expires_at=now + timedelta(minutes=1))
-    assert repository.try_acquire_processing_lease(
-        "s1", now=now, lease=lease
-    ).acquired
+    assert repository.try_acquire_processing_lease("s1", now=now, lease=lease).acquired
     result: list[BufferMessage] = []
 
     thread = Thread(
@@ -1032,7 +1046,6 @@ def test_processing_lease_has_one_winner_and_exact_expiry_takeover(
 
 
 def test_takeover_resumes_payload_and_stale_completion_is_fenced() -> None:
-    """Worker death preserves its batch until the exact-expiry successor commits."""
     repository = DynamoDBStateRepository(table=FakeDynamoDBTable())
     now = datetime(2026, 8, 17, tzinfo=timezone.utc)
     first = ProcessingLease(token="first", expires_at=now + timedelta(seconds=30))
@@ -1040,12 +1053,11 @@ def test_takeover_resumes_payload_and_stale_completion_is_fenced() -> None:
         token="successor", expires_at=now + timedelta(seconds=60)
     )
     repository.append_buffer_message("s1", "Hola")
-    assert repository.try_acquire_processing_lease(
-        "s1", now=now, lease=first
-    ).acquired
-    claimed = repository.claim_buffer_messages("s1", first.token)
+    assert repository.try_acquire_processing_lease("s1", now=now, lease=first).acquired
+    repository.claim_buffer_messages("s1", first.token)
+    repository.append_buffer_message("s1", "next")
+    repository.set_pending_chat_response("s1", '"stale"')
 
-    assert [message.message for message in claimed] == ["Hola"]
     assert repository.try_acquire_processing_lease(
         "s1", now=first.expires_at, lease=successor
     ).acquired
@@ -1054,12 +1066,13 @@ def test_takeover_resumes_payload_and_stale_completion_is_fenced() -> None:
     completed = repository.complete_processing("s1", successor.token, '"ready"')
 
     assert [message.message for message in resumed] == ["Hola"]
-    assert stale.completed is False
-    assert completed.completed is True
-    state = repository.get_buffer_state("s1")
-    assert state.processing_payload == []
-    assert state.processing_lease is None
-    assert state.pending_chat_response == '"ready"'
+    assert [
+        message.message for message in repository.get_buffer_state("s1").messages
+    ] == ["next"]
+    assert (stale.completed, completed.completed) == (False, True)
+    empty = ProcessingLease(token="empty", expires_at=successor.expires_at)
+    assert repository.try_acquire_processing_lease("e", now=now, lease=empty).acquired
+    assert repository.claim_buffer_messages("e", empty.token) == []
 
 
 def test_processing_lease_dtos_reject_incoherent_or_mutable_state() -> None:

--- a/backend/tests/test_state_repository.py
+++ b/backend/tests/test_state_repository.py
@@ -158,11 +158,9 @@ class FakeDynamoDBTable:
             return
         if expression.startswith("((attribute_not_exists(#lease_token)"):
             has_work = "processing_payload" in item or "messages" in item
-            token, expiry = names["#lease_token"], names["#lease_expires_at"]
-            has_lease = token in item and expiry in item
-            is_expired = has_lease and item[expiry] <= values[":now"]
-            is_blocked = has_lease or ("pending_chat_response" in item and not has_work)
-            if not is_expired and is_blocked:
+            has_lease = "lease_token" in item and "lease_expires_at" in item
+            is_expired = has_lease and item["lease_expires_at"] <= values[":now"]
+            if not is_expired and (has_lease or not has_work):
                 FakeDynamoDBTable._conditional_failure("lease unavailable")
             return
         if expression == (
@@ -190,14 +188,10 @@ class FakeDynamoDBTable:
             return
         if expression.startswith("#lease_token = :token AND attribute_"):
             is_resume = expression.endswith("attribute_exists(#payload)")
-            has_payload = names["#payload"] in item
-            if any(
-                (
-                    item.get(names["#lease_token"]) != values[":token"],
-                    has_payload != is_resume,
-                    not is_resume and names["#messages"] not in item,
-                )
-            ):
+            is_invalid = item.get(names["#lease_token"]) != values[":token"]
+            is_invalid |= (names["#payload"] in item) != is_resume
+            is_invalid |= not is_resume and names["#messages"] not in item
+            if is_invalid:
                 FakeDynamoDBTable._conditional_failure("payload claim failed")
             return
         else:
@@ -291,16 +285,15 @@ class FakeDynamoDBTable:
             and "#lease_token" in expression
         ):
             item[names["#expires_at"]] = deepcopy(values[":ttl"])
-            for alias in (
-                "#lease_token",
-                "#lease_expires_at",
-                "#processing_started_at",
-                "#payload",
-                "#pending_result",
-                "#response",
+            for attribute in (
+                "lease_token",
+                "lease_expires_at",
+                "processing_started_at",
+                "processing_payload",
+                "pending_result",
+                "pending_chat_response",
             ):
-                if alias in names:
-                    item.pop(names[alias], None)
+                item.pop(attribute, None)
             if ":response" in values:
                 item[names["#response"]] = deepcopy(values[":response"])
             return
@@ -1019,6 +1012,10 @@ def test_processing_lease_has_one_winner_and_exact_expiry_takeover(
     repository: DynamoDBStateRepository,
 ) -> None:
     now = datetime(2026, 7, 29, microsecond=123456, tzinfo=timezone.utc)
+    empty = ProcessingLease(token="empty", expires_at=now + timedelta(seconds=60))
+    assert not repository.try_acquire_processing_lease(
+        "s1", now=now, lease=empty
+    ).acquired
     repository.append_buffer_message("s1", "work")
     start = Barrier(2)
 
@@ -1081,6 +1078,7 @@ def test_processing_lease_recovers_malformed_legacy_state(missing: str) -> None:
     item.pop(missing)
     table.put_item(Item=item)
     repository = DynamoDBStateRepository(table=table)
+    repository.append_buffer_message("s1", "work")
     now = datetime(2026, 7, 29, tzinfo=timezone.utc)
     lease = ProcessingLease(token="new", expires_at=now + timedelta(seconds=60))
 

--- a/backend/tests/test_state_repository.py
+++ b/backend/tests/test_state_repository.py
@@ -156,6 +156,11 @@ class FakeDynamoDBTable:
             if item.get(owner_name) not in (None, values[":owner"]):
                 FakeDynamoDBTable._conditional_failure("owner mismatch")
             return
+        if expression.startswith("(attribute_not_exists(#lease_token)"):
+            has_work = "processing_payload" in item or "messages" in item
+            if "pending_chat_response" in item and not has_work:
+                FakeDynamoDBTable._conditional_failure("no recoverable work")
+            expression = expression[1 : expression.index(") AND")]
         if expression == (
             "attribute_not_exists(#lease_token) OR "
             "attribute_not_exists(#lease_expires_at) OR "
@@ -179,18 +184,16 @@ class FakeDynamoDBTable:
             if item.get(token_name) != values[":token"]:
                 FakeDynamoDBTable._conditional_failure("token mismatch")
             return
-        claim_conditions = {
-            "#lease_token = :token AND attribute_exists(#payload)": True,
-            "#lease_token = :token AND attribute_not_exists(#payload) "
-            "AND attribute_exists(#messages)": False,
-        }
-        if expression in claim_conditions:
+        if expression.startswith("#lease_token = :token AND attribute_"):
+            is_resume = expression.endswith("attribute_exists(#payload)")
             has_payload = names["#payload"] in item
-            is_invalid = item.get(names["#lease_token"]) != values[":token"]
-            is_invalid |= has_payload != claim_conditions[expression]
-            if not claim_conditions[expression]:
-                is_invalid |= names["#messages"] not in item
-            if is_invalid:
+            if any(
+                (
+                    item.get(names["#lease_token"]) != values[":token"],
+                    has_payload != is_resume,
+                    not is_resume and names["#messages"] not in item,
+                )
+            ):
                 FakeDynamoDBTable._conditional_failure("payload claim failed")
             return
         else:
@@ -270,36 +273,32 @@ class FakeDynamoDBTable:
 
         if expression in (
             "SET #expires_at = :ttl REMOVE #response",
-            "SET #payload = #messages, #messages = :empty, #expires_at = :ttl "
-            "REMOVE #response",
+            "SET #payload = #messages, #expires_at = :ttl REMOVE #messages, #response",
         ):
             if expression.startswith("SET #payload"):
                 item[names["#payload"]] = deepcopy(item[names["#messages"]])
-                item[names["#messages"]] = deepcopy(values[":empty"])
+                item.pop(names["#messages"])
             item[names["#expires_at"]] = deepcopy(values[":ttl"])
             item.pop(names["#response"], None)
             return
 
-        if expression in (
-            "SET #expires_at = :ttl REMOVE #lease_token, #lease_expires_at, "
-            "#processing_started_at, #payload, #pending_result, #response",
-            "SET #expires_at = :ttl, #response = :response REMOVE "
-            "#lease_token, #lease_expires_at, #processing_started_at, "
-            "#payload, #pending_result",
+        if (
+            expression.startswith("SET #expires_at = :ttl")
+            and "#lease_token" in expression
         ):
             item[names["#expires_at"]] = deepcopy(values[":ttl"])
-            if ":response" in values:
-                item[names["#response"]] = deepcopy(values[":response"])
             for alias in (
                 "#lease_token",
                 "#lease_expires_at",
                 "#processing_started_at",
                 "#payload",
                 "#pending_result",
+                "#response",
             ):
-                item.pop(names[alias], None)
-            if ":response" not in values:
-                item.pop(names["#response"], None)
+                if alias in names:
+                    item.pop(names[alias], None)
+            if ":response" in values:
+                item[names["#response"]] = deepcopy(values[":response"])
             return
 
         if expression == (
@@ -1010,6 +1009,11 @@ def test_atomic_buffer_claim_partitions_deterministic_interleaving(
     assert [message.message for message in result] == claimed
     state = repository.get_buffer_state("s1")
     assert [message.message for message in state.messages] == remaining
+    successor = ProcessingLease(token="next", expires_at=lease.expires_at)
+    assert repository.try_acquire_processing_lease(
+        "s1", now=lease.expires_at, lease=successor
+    ).acquired
+    assert repository.claim_buffer_messages("s1", successor.token) == result
 
 
 def test_processing_lease_has_one_winner_and_exact_expiry_takeover(
@@ -1043,39 +1047,10 @@ def test_processing_lease_has_one_winner_and_exact_expiry_takeover(
         "s1", now=winner.expires_at, lease=replacement
     )
     assert takeover.acquired and takeover.lease == replacement
-    assert repository.release_processing_lease("s1", winner.token).released is False
+    assert not repository.complete_processing("s1", winner.token, '"stale"').completed
     assert repository.get_buffer_state("s1").processing_lease == replacement
     assert repository.release_processing_lease("s1", replacement.token).released is True
     assert not repository.release_processing_lease("s1", replacement.token).released
-
-
-def test_takeover_resumes_payload_and_stale_completion_is_fenced() -> None:
-    repository = DynamoDBStateRepository(table=FakeDynamoDBTable())
-    now = datetime(2026, 8, 17, tzinfo=timezone.utc)
-    first = ProcessingLease(token="first", expires_at=now + timedelta(seconds=30))
-    successor = ProcessingLease(
-        token="successor", expires_at=now + timedelta(seconds=60)
-    )
-    repository.append_buffer_message("s1", "Hola")
-    assert repository.try_acquire_processing_lease("s1", now=now, lease=first).acquired
-    repository.claim_buffer_messages("s1", first.token)
-    repository.append_buffer_message("s1", "next")
-    repository.set_pending_chat_response("s1", '"stale"')
-
-    assert repository.try_acquire_processing_lease(
-        "s1", now=first.expires_at, lease=successor
-    ).acquired
-    repository.claim_buffer_messages("s1", successor.token)
-    stale = repository.complete_processing("s1", first.token, '"stale"')
-    completed = repository.complete_processing("s1", successor.token, '"ready"')
-
-    assert [
-        message.message for message in repository.get_buffer_state("s1").messages
-    ] == ["next"]
-    assert (stale.completed, completed.completed) == (False, True)
-    empty = ProcessingLease(token="empty", expires_at=successor.expires_at)
-    assert repository.try_acquire_processing_lease("e", now=now, lease=empty).acquired
-    assert repository.claim_buffer_messages("e", empty.token) == []
 
 
 def test_processing_lease_dtos_reject_incoherent_or_mutable_state() -> None:

--- a/backend/tests/test_state_repository.py
+++ b/backend/tests/test_state_repository.py
@@ -156,11 +156,15 @@ class FakeDynamoDBTable:
             if item.get(owner_name) not in (None, values[":owner"]):
                 FakeDynamoDBTable._conditional_failure("owner mismatch")
             return
-        if expression.startswith("(attribute_not_exists(#lease_token)"):
+        if expression.startswith("((attribute_not_exists(#lease_token)"):
             has_work = "processing_payload" in item or "messages" in item
-            if "pending_chat_response" in item and not has_work:
-                FakeDynamoDBTable._conditional_failure("no recoverable work")
-            expression = expression[1 : expression.index(") AND")]
+            token, expiry = names["#lease_token"], names["#lease_expires_at"]
+            has_lease = token in item and expiry in item
+            is_expired = has_lease and item[expiry] <= values[":now"]
+            is_blocked = has_lease or ("pending_chat_response" in item and not has_work)
+            if not is_expired and is_blocked:
+                FakeDynamoDBTable._conditional_failure("lease unavailable")
+            return
         if expression == (
             "attribute_not_exists(#lease_token) OR "
             "attribute_not_exists(#lease_expires_at) OR "
@@ -1009,17 +1013,13 @@ def test_atomic_buffer_claim_partitions_deterministic_interleaving(
     assert [message.message for message in result] == claimed
     state = repository.get_buffer_state("s1")
     assert [message.message for message in state.messages] == remaining
-    successor = ProcessingLease(token="next", expires_at=lease.expires_at)
-    assert repository.try_acquire_processing_lease(
-        "s1", now=lease.expires_at, lease=successor
-    ).acquired
-    assert repository.claim_buffer_messages("s1", successor.token) == result
 
 
 def test_processing_lease_has_one_winner_and_exact_expiry_takeover(
     repository: DynamoDBStateRepository,
 ) -> None:
     now = datetime(2026, 7, 29, microsecond=123456, tzinfo=timezone.utc)
+    repository.append_buffer_message("s1", "work")
     start = Barrier(2)
 
     def acquire(token: str):
@@ -1036,6 +1036,7 @@ def test_processing_lease_has_one_winner_and_exact_expiry_takeover(
     winner = next(result.lease for result in results if result.acquired)
     assert winner is not None
     assert winner.expires_at == now + timedelta(seconds=60)
+    assert repository.claim_buffer_messages("s1", winner.token)
 
     replacement = ProcessingLease(
         token="replacement", expires_at=now + timedelta(seconds=120)
@@ -1047,6 +1048,7 @@ def test_processing_lease_has_one_winner_and_exact_expiry_takeover(
         "s1", now=winner.expires_at, lease=replacement
     )
     assert takeover.acquired and takeover.lease == replacement
+    assert repository.claim_buffer_messages("s1", replacement.token)
     assert not repository.complete_processing("s1", winner.token, '"stale"').completed
     assert repository.get_buffer_state("s1").processing_lease == replacement
     assert repository.release_processing_lease("s1", replacement.token).released is True
@@ -1116,8 +1118,6 @@ def test_processing_lease_translates_only_conditional_errors() -> None:
         repository.try_acquire_processing_lease("s1", now=now, lease=lease)
     with pytest.raises(ClientError):
         repository.release_processing_lease("s1", "token")
-    with pytest.raises(ClientError):
-        repository.complete_processing("s1", "token", '"ready"')
 
 
 def test_rate_limit_uses_shared_counter(repository: DynamoDBStateRepository) -> None:

--- a/backend/tests/test_state_repository.py
+++ b/backend/tests/test_state_repository.py
@@ -161,6 +161,9 @@ class FakeDynamoDBTable:
                 FakeDynamoDBTable._conditional_failure("owner mismatch")
             return
         if expression == (
+            "(attribute_not_exists(#payload) OR attribute_type(#payload, "
+            ":list_type)) AND (attribute_not_exists(#messages) OR "
+            "attribute_type(#messages, :list_type)) AND "
             "((attribute_type(#payload, :list_type) AND size(#payload) > :zero) OR "
             "(attribute_type(#messages, :list_type) AND size(#messages) > :zero)) "
             "AND (attribute_not_exists(#lease_token) OR "
@@ -171,14 +174,13 @@ class FakeDynamoDBTable:
                 raise ValueError("Unsupported work attribute mapping")
             if (values[":list_type"], values[":zero"]) != ("L", 0):
                 raise ValueError("Unsupported work predicate values")
-            has_work = any(
-                isinstance(item.get(field), list) and bool(item[field])
-                for field in work_fields
-            )
+            work = [item.get(field, []) for field in work_fields]
+            has_work = any(isinstance(value, list) and value for value in work)
+            has_valid_types = all(isinstance(value, list) for value in work)
             has_lease = "lease_token" in item and "lease_expires_at" in item
             expiry = item.get("lease_expires_at")
             is_expired = isinstance(expiry, Number) and expiry <= values[":now"]
-            if not has_work or (has_lease and not is_expired):
+            if not has_valid_types or not has_work or (has_lease and not is_expired):
                 FakeDynamoDBTable._conditional_failure("lease unavailable or no work")
             return
         if expression == (
@@ -1069,7 +1071,13 @@ def test_processing_lease_has_one_winner_and_exact_expiry_takeover(
 def test_processing_lease_requires_recoverable_work() -> None:
     now = datetime(2026, 8, 18, tzinfo=timezone.utc)
     lease = ProcessingLease(token="owner", expires_at=now + timedelta(minutes=1))
-    rows = ({}, {"messages": "invalid"}, {"processing_payload": {}}, {"messages": []})
+    valid = [{"message": "work", "timestamp": now.isoformat()}]
+    rows = ({}, {"messages": "invalid"}, {"processing_payload": {}})
+    rows += (
+        {"messages": valid, "processing_payload": {}},
+        {"processing_payload": valid, "messages": "invalid"},
+        {"messages": []},
+    )
     for work in rows:
         table = FakeDynamoDBTable()
         table.put_item(Item={"PK": "SESSION#s1", "SK": "BUFFER", **work})

--- a/backend/tests/test_state_repository.py
+++ b/backend/tests/test_state_repository.py
@@ -3,6 +3,8 @@
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
+from numbers import Number
+import re
 from threading import Barrier, Event, RLock, Thread, current_thread
 from typing import Any, Callable
 
@@ -115,7 +117,9 @@ class FakeDynamoDBTable:
         names = ExpressionAttributeNames or {}
         expression = " ".join(UpdateExpression.split())
         used = f"{UpdateExpression} {ConditionExpression or ''}"
-        if any(alias not in used for alias in (*names, *ExpressionAttributeValues)):
+        used_names = set(re.findall(r"#[A-Za-z0-9_]+", used))
+        used_values = set(re.findall(r":[A-Za-z0-9_]+", used))
+        if used_names != set(names) or used_values != set(ExpressionAttributeValues):
             raise ValueError("Unused expression attribute")
 
         with self._lock:
@@ -156,12 +160,26 @@ class FakeDynamoDBTable:
             if item.get(owner_name) not in (None, values[":owner"]):
                 FakeDynamoDBTable._conditional_failure("owner mismatch")
             return
-        if expression.startswith("((attribute_not_exists(#lease_token)"):
-            has_work = "processing_payload" in item or "messages" in item
+        if expression == (
+            "((attribute_type(#payload, :list_type) AND size(#payload) > :zero) OR "
+            "(attribute_type(#messages, :list_type) AND size(#messages) > :zero)) "
+            "AND (attribute_not_exists(#lease_token) OR "
+            "attribute_not_exists(#lease_expires_at) OR #lease_expires_at <= :now)"
+        ):
+            work_fields = names["#payload"], names["#messages"]
+            if work_fields != ("processing_payload", "messages"):
+                raise ValueError("Unsupported work attribute mapping")
+            if (values[":list_type"], values[":zero"]) != ("L", 0):
+                raise ValueError("Unsupported work predicate values")
+            has_work = any(
+                isinstance(item.get(field), list) and bool(item[field])
+                for field in work_fields
+            )
             has_lease = "lease_token" in item and "lease_expires_at" in item
-            is_expired = has_lease and item["lease_expires_at"] <= values[":now"]
-            if not is_expired and (has_lease or not has_work):
-                FakeDynamoDBTable._conditional_failure("lease unavailable")
+            expiry = item.get("lease_expires_at")
+            is_expired = isinstance(expiry, Number) and expiry <= values[":now"]
+            if not has_work or (has_lease and not is_expired):
+                FakeDynamoDBTable._conditional_failure("lease unavailable or no work")
             return
         if expression == (
             "attribute_not_exists(#lease_token) OR "
@@ -1012,10 +1030,6 @@ def test_processing_lease_has_one_winner_and_exact_expiry_takeover(
     repository: DynamoDBStateRepository,
 ) -> None:
     now = datetime(2026, 7, 29, microsecond=123456, tzinfo=timezone.utc)
-    empty = ProcessingLease(token="empty", expires_at=now + timedelta(seconds=60))
-    assert not repository.try_acquire_processing_lease(
-        "s1", now=now, lease=empty
-    ).acquired
     repository.append_buffer_message("s1", "work")
     start = Barrier(2)
 
@@ -1050,6 +1064,21 @@ def test_processing_lease_has_one_winner_and_exact_expiry_takeover(
     assert repository.get_buffer_state("s1").processing_lease == replacement
     assert repository.release_processing_lease("s1", replacement.token).released is True
     assert not repository.release_processing_lease("s1", replacement.token).released
+
+
+def test_processing_lease_requires_recoverable_work() -> None:
+    now = datetime(2026, 8, 18, tzinfo=timezone.utc)
+    lease = ProcessingLease(token="owner", expires_at=now + timedelta(minutes=1))
+    rows = ({}, {"messages": "invalid"}, {"processing_payload": {}}, {"messages": []})
+    for work in rows:
+        table = FakeDynamoDBTable()
+        table.put_item(Item={"PK": "SESSION#s1", "SK": "BUFFER", **work})
+        repository = DynamoDBStateRepository(table=table)
+        assert not repository.try_acquire_processing_lease(
+            "s1", now=now, lease=lease
+        ).acquired
+    repository.append_buffer_message("s1", "later")
+    assert repository.get_buffer_state("s1").messages[0].message == "later"
 
 
 def test_processing_lease_dtos_reject_incoherent_or_mutable_state() -> None:

--- a/backend/tests/test_state_repository.py
+++ b/backend/tests/test_state_repository.py
@@ -252,6 +252,37 @@ class FakeDynamoDBTable:
             return
 
         if expression == (
+            "SET #payload = if_not_exists(#payload, #messages), "
+            "#messages = :messages, #expires_at = :ttl"
+        ):
+            payload_name = names["#payload"]
+            if payload_name not in item:
+                item[payload_name] = deepcopy(item.get(names["#messages"], []))
+            item[names["#messages"]] = deepcopy(values[":messages"])
+            item[names["#expires_at"]] = deepcopy(values[":ttl"])
+            return
+
+        if expression in (
+            "SET #expires_at = :ttl REMOVE #lease_token, #lease_expires_at, "
+            "#processing_started_at, #payload, #pending_result",
+            "SET #expires_at = :ttl, #response = :response REMOVE "
+            "#lease_token, #lease_expires_at, #processing_started_at, "
+            "#payload, #pending_result",
+        ):
+            item[names["#expires_at"]] = deepcopy(values[":ttl"])
+            if "#response" in names:
+                item[names["#response"]] = deepcopy(values[":response"])
+            for alias in (
+                "#lease_token",
+                "#lease_expires_at",
+                "#processing_started_at",
+                "#payload",
+                "#pending_result",
+            ):
+                item.pop(names[alias], None)
+            return
+
+        if expression == (
             "SET #lease_token = :token, #lease_expires_at = :lease_expires, "
             "#processing_started_at = :started, #expires_at = :ttl"
         ):
@@ -393,8 +424,8 @@ class ClaimInterleavingTable(FakeDynamoDBTable):
     ) -> dict[str, Any]:
         is_claim = (
             current_thread().name == "buffer-claim"
-            and UpdateExpression == "SET messages = :messages, expires_at = :ttl"
-            and ReturnValues == "ALL_OLD"
+            and UpdateExpression.startswith("SET #payload = if_not_exists")
+            and ReturnValues == "ALL_NEW"
         )
         if is_claim and self.pause == "before":
             self.claim_reached.set()
@@ -938,10 +969,17 @@ def test_atomic_buffer_claim_partitions_deterministic_interleaving(
     table = ClaimInterleavingTable(pause)
     repository = DynamoDBStateRepository(table=table)
     repository.append_buffer_message("s1", "first")
+    now = datetime(2026, 8, 17, tzinfo=timezone.utc)
+    lease = ProcessingLease(token="owner", expires_at=now + timedelta(minutes=1))
+    assert repository.try_acquire_processing_lease(
+        "s1", now=now, lease=lease
+    ).acquired
     result: list[BufferMessage] = []
 
     thread = Thread(
-        target=lambda: result.extend(repository.claim_buffer_messages("s1")),
+        target=lambda: result.extend(
+            repository.claim_buffer_messages("s1", lease.token)
+        ),
         name="buffer-claim",
     )
     thread.start()
@@ -991,6 +1029,37 @@ def test_processing_lease_has_one_winner_and_exact_expiry_takeover(
     assert repository.get_buffer_state("s1").processing_lease == replacement
     assert repository.release_processing_lease("s1", replacement.token).released is True
     assert not repository.release_processing_lease("s1", replacement.token).released
+
+
+def test_takeover_resumes_payload_and_stale_completion_is_fenced() -> None:
+    """Worker death preserves its batch until the exact-expiry successor commits."""
+    repository = DynamoDBStateRepository(table=FakeDynamoDBTable())
+    now = datetime(2026, 8, 17, tzinfo=timezone.utc)
+    first = ProcessingLease(token="first", expires_at=now + timedelta(seconds=30))
+    successor = ProcessingLease(
+        token="successor", expires_at=now + timedelta(seconds=60)
+    )
+    repository.append_buffer_message("s1", "Hola")
+    assert repository.try_acquire_processing_lease(
+        "s1", now=now, lease=first
+    ).acquired
+    claimed = repository.claim_buffer_messages("s1", first.token)
+
+    assert [message.message for message in claimed] == ["Hola"]
+    assert repository.try_acquire_processing_lease(
+        "s1", now=first.expires_at, lease=successor
+    ).acquired
+    resumed = repository.claim_buffer_messages("s1", successor.token)
+    stale = repository.complete_processing("s1", first.token, '"stale"')
+    completed = repository.complete_processing("s1", successor.token, '"ready"')
+
+    assert [message.message for message in resumed] == ["Hola"]
+    assert stale.completed is False
+    assert completed.completed is True
+    state = repository.get_buffer_state("s1")
+    assert state.processing_payload == []
+    assert state.processing_lease is None
+    assert state.pending_chat_response == '"ready"'
 
 
 def test_processing_lease_dtos_reject_incoherent_or_mutable_state() -> None:
@@ -1049,12 +1118,15 @@ def test_processing_lease_translates_only_conditional_errors() -> None:
         "s1", now=now, lease=lease
     ).acquired
     assert not repository.release_processing_lease("s1", "token").released
+    assert not repository.complete_processing("s1", "token", '"ready"').completed
 
     table.code = "ProvisionedThroughputExceededException"
     with pytest.raises(ClientError):
         repository.try_acquire_processing_lease("s1", now=now, lease=lease)
     with pytest.raises(ClientError):
         repository.release_processing_lease("s1", "token")
+    with pytest.raises(ClientError):
+        repository.complete_processing("s1", "token", '"ready"')
 
 
 def test_rate_limit_uses_shared_counter(repository: DynamoDBStateRepository) -> None:

--- a/backend/tests/test_state_repository.py
+++ b/backend/tests/test_state_repository.py
@@ -114,6 +114,9 @@ class FakeDynamoDBTable:
         key = (Key["PK"], Key["SK"])
         names = ExpressionAttributeNames or {}
         expression = " ".join(UpdateExpression.split())
+        used = f"{UpdateExpression} {ConditionExpression or ''}"
+        if any(alias not in used for alias in (*names, *ExpressionAttributeValues)):
+            raise ValueError("Unused expression attribute")
 
         with self._lock:
             item = deepcopy(self.items.get(key, {"PK": Key["PK"], "SK": Key["SK"]}))
@@ -185,7 +188,8 @@ class FakeDynamoDBTable:
             has_payload = names["#payload"] in item
             is_invalid = item.get(names["#lease_token"]) != values[":token"]
             is_invalid |= has_payload != claim_conditions[expression]
-            is_invalid |= not has_payload and names["#messages"] not in item
+            if not claim_conditions[expression]:
+                is_invalid |= names["#messages"] not in item
             if is_invalid:
                 FakeDynamoDBTable._conditional_failure("payload claim failed")
             return
@@ -1061,11 +1065,10 @@ def test_takeover_resumes_payload_and_stale_completion_is_fenced() -> None:
     assert repository.try_acquire_processing_lease(
         "s1", now=first.expires_at, lease=successor
     ).acquired
-    resumed = repository.claim_buffer_messages("s1", successor.token)
+    repository.claim_buffer_messages("s1", successor.token)
     stale = repository.complete_processing("s1", first.token, '"stale"')
     completed = repository.complete_processing("s1", successor.token, '"ready"')
 
-    assert [message.message for message in resumed] == ["Hola"]
     assert [
         message.message for message in repository.get_buffer_state("s1").messages
     ] == ["next"]


### PR DESCRIPTION
## ¿Qué hace este PR?

Hace durable el payload reclamado, permite retomarlo al expirar el lease y condiciona la publicación/limpieza terminal al token propietario. También preserva appends posteriores para el siguiente lote y normaliza conflictos condicionales como resultados de dominio.

## Issues relacionados

Closes #312
Part of #232

## Tipo de cambio

- [ ] 🆕 Nueva funcionalidad (feature)
- [x] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [ ] 🧪 Tests
- [ ] 📄 Documentación / configuración
- [ ] 🔧 Infra / CI

## Checklist antes de pedir review

- [x] El código corre localmente sin errores (`uvicorn` levanta, tests pasan)
- [x] Los criterios de aceptación del issue relacionado están cumplidos
- [x] No hay credenciales, API keys ni rutas absolutas hardcodeadas
- [x] Si agregué dependencias nuevas, actualicé `requirements.txt` / `pyproject.toml`
- [x] Si modifiqué el schema del endpoint, verifiqué que `/docs` refleja los cambios
- [x] Si modifiqué el harness o el dataset, corrí `python evaluation/harness.py` y el output es el esperado

## Cómo probar este PR

1. Ejecutar `uv run pytest -p no:cacheprovider backend/tests/test_state_repository.py backend/app/tests/test_message_buffer.py backend/tests/test_lambda_runtime.py`.
2. Verificar worker death, takeover en expiración exacta, stale completion y appends posteriores al claim.
3. Ejecutar `uv run pytest -p no:cacheprovider backend`.

## Notas para el reviewer

### Cadena de entrega

```text
main → #317/#311 atomic claim → 📍 #312 recovery/fencing → #313 polling ownership → #315 side-effect idempotency
```

Depende de PR #317. Presupuesto de revisión: 399 líneas cambiadas contra `fix/atomic-buffer-claim`. Rollback: revertir este work unit retira recuperación y fencing sin quitar el claim atómico.