### PR TITLE
fix(buffer): [#313] preserve polling ownership

### DIFF
--- a/backend/app/dynamodb_state_repository.py
+++ b/backend/app/dynamodb_state_repository.py
@@ -302,9 +302,7 @@ class DynamoDBStateRepository:
             additional_remove="processing_started_at",
         )
 
-    def pop_pending_chat_response_if_unowned(
-        self, session_id: str, now: datetime
-    ) -> Optional[str]:
+    def pop_pending_chat_response_if_unowned(self, session_id: str) -> Optional[str]:
         """Atomically consume a response only outside active ownership."""
         try:
             response = self._table.update_item(
@@ -312,20 +310,14 @@ class DynamoDBStateRepository:
                 UpdateExpression=("REMOVE #response, #processing_started_at"),
                 ConditionExpression=(
                     "attribute_type(#response, :string_type) AND "
-                    "(attribute_not_exists(#lease_token) OR "
-                    "attribute_not_exists(#lease_expires_at) OR "
-                    "#lease_expires_at <= :now)"
+                    "attribute_not_exists(#lease_token)"
                 ),
                 ExpressionAttributeNames={
                     "#response": "pending_chat_response",
                     "#processing_started_at": "processing_started_at",
                     "#lease_token": "lease_token",
-                    "#lease_expires_at": "lease_expires_at",
                 },
-                ExpressionAttributeValues={
-                    ":string_type": "S",
-                    ":now": self._epoch_seconds(now),
-                },
+                ExpressionAttributeValues={":string_type": "S"},
                 ReturnValues="ALL_OLD",
             )
         except ClientError as exc:

--- a/backend/app/dynamodb_state_repository.py
+++ b/backend/app/dynamodb_state_repository.py
@@ -302,22 +302,43 @@ class DynamoDBStateRepository:
             additional_remove="processing_started_at",
         )
 
-    def pop_pending_chat_response_if_unowned(self, session_id: str) -> Optional[str]:
+    def pop_pending_chat_response_if_unowned(
+        self, session_id: str, *, now: Optional[datetime] = None
+    ) -> Optional[str]:
         """Atomically consume a response only outside active ownership."""
+        current_time = self._to_utc(now or datetime.now(timezone.utc))
         try:
             response = self._table.update_item(
                 Key={"PK": self._session_pk(session_id), "SK": "BUFFER"},
-                UpdateExpression=("REMOVE #response, #processing_started_at"),
+                UpdateExpression=(
+                    "REMOVE #response, #processing_started_at, #lease_token, "
+                    "#lease_expires_at"
+                ),
                 ConditionExpression=(
                     "attribute_type(#response, :string_type) AND "
-                    "attribute_not_exists(#lease_token)"
+                    "(attribute_not_exists(#lease_token) OR "
+                    "(#lease_expires_at <= :now AND "
+                    "(attribute_not_exists(#payload) OR "
+                    "(attribute_type(#payload, :list_type) AND "
+                    "size(#payload) = :zero)) AND "
+                    "(attribute_not_exists(#messages) OR "
+                    "(attribute_type(#messages, :list_type) AND "
+                    "size(#messages) = :zero))))"
                 ),
                 ExpressionAttributeNames={
                     "#response": "pending_chat_response",
                     "#processing_started_at": "processing_started_at",
                     "#lease_token": "lease_token",
+                    "#lease_expires_at": "lease_expires_at",
+                    "#payload": "processing_payload",
+                    "#messages": "messages",
                 },
-                ExpressionAttributeValues={":string_type": "S"},
+                ExpressionAttributeValues={
+                    ":string_type": "S",
+                    ":list_type": "L",
+                    ":zero": 0,
+                    ":now": self._epoch_seconds(current_time),
+                },
                 ReturnValues="ALL_OLD",
             )
         except ClientError as exc:

--- a/backend/app/dynamodb_state_repository.py
+++ b/backend/app/dynamodb_state_repository.py
@@ -302,6 +302,38 @@ class DynamoDBStateRepository:
             additional_remove="processing_started_at",
         )
 
+    def pop_pending_chat_response_if_unowned(
+        self, session_id: str, now: datetime
+    ) -> Optional[str]:
+        """Atomically consume a response only outside active ownership."""
+        try:
+            response = self._table.update_item(
+                Key={"PK": self._session_pk(session_id), "SK": "BUFFER"},
+                UpdateExpression=("REMOVE #response, #processing_started_at"),
+                ConditionExpression=(
+                    "attribute_type(#response, :string_type) AND "
+                    "(attribute_not_exists(#lease_token) OR "
+                    "attribute_not_exists(#lease_expires_at) OR "
+                    "#lease_expires_at <= :now)"
+                ),
+                ExpressionAttributeNames={
+                    "#response": "pending_chat_response",
+                    "#processing_started_at": "processing_started_at",
+                    "#lease_token": "lease_token",
+                    "#lease_expires_at": "lease_expires_at",
+                },
+                ExpressionAttributeValues={
+                    ":string_type": "S",
+                    ":now": self._epoch_seconds(now),
+                },
+                ReturnValues="ALL_OLD",
+            )
+        except ClientError as exc:
+            if self._is_conditional_failure(exc):
+                return None
+            raise
+        return str(response["Attributes"]["pending_chat_response"])
+
     def set_processing(self, session_id: str) -> None:
         """Mark a session as being processed."""
         self._table.update_item(

--- a/backend/app/message_buffer.py
+++ b/backend/app/message_buffer.py
@@ -330,16 +330,27 @@ def pop_pending_chat_response(session_id: str) -> Optional[str]:
         return result[0]
 
 
-def pop_pending_chat_response_if_unowned(session_id: str) -> Optional[str]:
+def pop_pending_chat_response_if_unowned(
+    session_id: str, *, now: Optional[datetime] = None
+) -> Optional[str]:
     """Consume a response only when processing ownership is not active."""
     if _state_repository is not None:
-        return _state_repository.pop_pending_chat_response_if_unowned(session_id)
+        return _state_repository.pop_pending_chat_response_if_unowned(
+            session_id, now=now
+        )
+    current_time = _to_utc(now or datetime.now(timezone.utc))
     with _state_lock, _pending_state_lock:
-        if session_id in _processing_leases:
+        lease = _processing_leases.get(session_id)
+        if lease is not None and current_time < _to_utc(lease.expires_at):
+            return None
+        if lease is not None and (
+            _processing_payloads.get(session_id) or _buffer.get(session_id)
+        ):
             return None
         result = _pending_chat_responses.pop(session_id, None)
         if result is None:
             return None
+        _processing_leases.pop(session_id, None)
         _processing_sessions.pop(session_id, None)
         return result[0]
 

--- a/backend/app/message_buffer.py
+++ b/backend/app/message_buffer.py
@@ -10,6 +10,7 @@ flush due buffers instead of relying on ``asyncio.create_task`` after response.
 """
 
 import asyncio
+from hashlib import sha256
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -52,6 +53,7 @@ _pending_state_lock = RLock()
 # Tokenized leases coordinate every local destructive buffer-processing path.
 _processing_leases: dict[str, ProcessingLease] = {}
 _processing_payloads: dict[str, str] = {}
+_processing_generations: dict[str, str] = {}
 _state_lock = RLock()
 
 
@@ -61,6 +63,7 @@ class OwnedBufferedMessage:
 
     message: str
     lease: ProcessingLease
+    generation_id: str
 
 
 def set_state_repository(
@@ -144,16 +147,19 @@ async def acquire_and_flush_buffer(
     lease = acquired.lease
     try:
         joined = await _flush_owned_buffer(session_id, lease.token, resume)
+        generation_id = get_processing_generation(session_id)
     except BaseException:
         release_processing_lease(session_id, lease.token)
         raise
-    if joined is None:
+    if joined is None or generation_id is None:
         if resume:
             release_processing_lease(session_id, lease.token)
         else:
             complete_processing(session_id, lease.token, None)
         return None
-    return OwnedBufferedMessage(message=joined, lease=lease)
+    return OwnedBufferedMessage(
+        message=joined, lease=lease, generation_id=generation_id
+    )
 
 
 async def _flush_owned_buffer(
@@ -190,6 +196,10 @@ async def _flush_owned_buffer(
         joined = existing_payload or "\n".join(msg for msg, _ in buffered_entries)
         if joined:
             _processing_payloads[session_id] = joined
+            if existing_payload is None:
+                _processing_generations[session_id] = _generation_id(
+                    session_id, buffered_entries
+                )
         _pending_results.pop(session_id, None)
         _pending_chat_responses.pop(session_id, None)
         _processing_sessions.pop(session_id, None)
@@ -236,6 +246,16 @@ def has_processing_payload(session_id: str) -> bool:
         return bool(_state_repository.get_buffer_state(session_id).processing_payload)
     with _state_lock:
         return session_id in _processing_payloads
+
+
+def get_processing_generation(session_id: str) -> Optional[str]:
+    """Return the stable identity of the currently claimed payload."""
+    if _state_repository is not None:
+        payload = _state_repository.get_buffer_state(session_id).processing_payload
+        entries = [(message.message, message.timestamp) for message in payload]
+        return _generation_id(session_id, entries) if entries else None
+    with _state_lock:
+        return _processing_generations.get(session_id)
 
 
 def clear_buffer(session_id: str) -> None:
@@ -351,6 +371,7 @@ def pop_pending_chat_response_if_unowned(
         if result is None:
             return None
         _processing_leases.pop(session_id, None)
+        _processing_generations.pop(session_id, None)
         _processing_sessions.pop(session_id, None)
         return result[0]
 
@@ -470,6 +491,7 @@ def complete_processing(
             _pending_chat_responses.pop(session_id, None)
         _processing_leases.pop(session_id, None)
         _processing_payloads.pop(session_id, None)
+        _processing_generations.pop(session_id, None)
         _processing_sessions.pop(session_id, None)
         _pending_results.pop(session_id, None)
         return ProcessingCompletionResult(completed=True)
@@ -536,6 +558,14 @@ def _to_utc(value: datetime) -> datetime:
     if value.tzinfo is None:
         return value.replace(tzinfo=timezone.utc)
     return value.astimezone(timezone.utc)
+
+
+def _generation_id(session_id: str, entries: list[tuple[str, datetime]]) -> str:
+    material = "\n".join(
+        f"{_to_utc(timestamp).isoformat()}\0{message}" for message, timestamp in entries
+    )
+    digest = sha256(f"{session_id}\0{material}".encode()).hexdigest()
+    return f"{_to_utc(entries[0][1]).isoformat()}#{digest}"
 
 
 FlushCallback = Callable[[str, str, ProcessingLease], Awaitable[None]]

--- a/backend/app/message_buffer.py
+++ b/backend/app/message_buffer.py
@@ -330,18 +330,12 @@ def pop_pending_chat_response(session_id: str) -> Optional[str]:
         return result[0]
 
 
-def pop_pending_chat_response_if_unowned(
-    session_id: str, *, now: Optional[datetime] = None
-) -> Optional[str]:
+def pop_pending_chat_response_if_unowned(session_id: str) -> Optional[str]:
     """Consume a response only when processing ownership is not active."""
-    current_time = _to_utc(now or datetime.now(timezone.utc))
     if _state_repository is not None:
-        return _state_repository.pop_pending_chat_response_if_unowned(
-            session_id, current_time
-        )
+        return _state_repository.pop_pending_chat_response_if_unowned(session_id)
     with _state_lock, _pending_state_lock:
-        lease = _processing_leases.get(session_id)
-        if lease is not None and current_time < _to_utc(lease.expires_at):
+        if session_id in _processing_leases:
             return None
         result = _pending_chat_responses.pop(session_id, None)
         if result is None:

--- a/backend/app/message_buffer.py
+++ b/backend/app/message_buffer.py
@@ -330,6 +330,26 @@ def pop_pending_chat_response(session_id: str) -> Optional[str]:
         return result[0]
 
 
+def pop_pending_chat_response_if_unowned(
+    session_id: str, *, now: Optional[datetime] = None
+) -> Optional[str]:
+    """Consume a response only when processing ownership is not active."""
+    current_time = _to_utc(now or datetime.now(timezone.utc))
+    if _state_repository is not None:
+        return _state_repository.pop_pending_chat_response_if_unowned(
+            session_id, current_time
+        )
+    with _state_lock, _pending_state_lock:
+        lease = _processing_leases.get(session_id)
+        if lease is not None and current_time < _to_utc(lease.expires_at):
+            return None
+        result = _pending_chat_responses.pop(session_id, None)
+        if result is None:
+            return None
+        _processing_sessions.pop(session_id, None)
+        return result[0]
+
+
 def clear_pending_chat_response(session_id: str) -> None:
     """Clear any pending chat response for a session.
 

--- a/backend/app/state_repository.py
+++ b/backend/app/state_repository.py
@@ -187,9 +187,7 @@ class ChatbotStateRepository(Protocol):
         response leaves the marker unchanged.
         """
 
-    def pop_pending_chat_response_if_unowned(
-        self, session_id: str, now: datetime
-    ) -> Optional[str]:
+    def pop_pending_chat_response_if_unowned(self, session_id: str) -> Optional[str]:
         """Consume a response only when no processing lease is active."""
 
     def set_processing(self, session_id: str) -> None:

--- a/backend/app/state_repository.py
+++ b/backend/app/state_repository.py
@@ -187,6 +187,11 @@ class ChatbotStateRepository(Protocol):
         response leaves the marker unchanged.
         """
 
+    def pop_pending_chat_response_if_unowned(
+        self, session_id: str, now: datetime
+    ) -> Optional[str]:
+        """Consume a response only when no processing lease is active."""
+
     def set_processing(self, session_id: str) -> None:
         """Mark a flushed session as being processed."""
 

--- a/backend/app/state_repository.py
+++ b/backend/app/state_repository.py
@@ -187,7 +187,9 @@ class ChatbotStateRepository(Protocol):
         response leaves the marker unchanged.
         """
 
-    def pop_pending_chat_response_if_unowned(self, session_id: str) -> Optional[str]:
+    def pop_pending_chat_response_if_unowned(
+        self, session_id: str, *, now: Optional[datetime] = None
+    ) -> Optional[str]:
         """Consume a response only when no processing lease is active."""
 
     def set_processing(self, session_id: str) -> None:

--- a/backend/app/tests/test_message_buffer.py
+++ b/backend/app/tests/test_message_buffer.py
@@ -717,6 +717,25 @@ class TestLocalPendingState:
         assert message_buffer.pop_pending_chat_response("s1") is None
         assert message_buffer.is_processing("s1") is True
 
+    def test_active_local_owner_fences_pending_response_consumption(self) -> None:
+        from backend.app import message_buffer
+
+        now = datetime(2026, 8, 17, tzinfo=timezone.utc)
+        acquired = message_buffer.acquire_processing_lease("s1", now=now, token="owner")
+        message_buffer.set_pending_chat_response("s1", '"early"')
+
+        assert (
+            message_buffer.pop_pending_chat_response_if_unowned("s1", now=now) is None
+        )
+        assert acquired.lease is not None
+        assert message_buffer.complete_processing(
+            "s1", acquired.lease.token, '"ready"'
+        ).completed
+        assert (
+            message_buffer.pop_pending_chat_response_if_unowned("s1", now=now)
+            == '"ready"'
+        )
+
     @pytest.mark.parametrize(
         ("setter_name", "popper_name"),
         [

--- a/backend/app/tests/test_message_buffer.py
+++ b/backend/app/tests/test_message_buffer.py
@@ -757,16 +757,50 @@ class TestLocalPendingState:
         message_buffer.set_pending_chat_response("s1", '"early"')
 
         assert acquired.lease is not None
-        assert message_buffer.pop_pending_chat_response_if_unowned("s1") is None
+        assert (
+            message_buffer.pop_pending_chat_response_if_unowned("s1", now=now) is None
+        )
         successor = message_buffer.acquire_processing_lease(
             "s1", now=acquired.lease.expires_at, token="next"
         )
         assert successor.lease is not None
-        assert message_buffer.pop_pending_chat_response_if_unowned("s1") is None
+        assert (
+            message_buffer.pop_pending_chat_response_if_unowned(
+                "s1", now=acquired.lease.expires_at
+            )
+            is None
+        )
         assert message_buffer.complete_processing(
             "s1", successor.lease.token, '"ready"'
         ).completed
         assert message_buffer.pop_pending_chat_response_if_unowned("s1") == '"ready"'
+
+    def test_expired_local_orphan_response_fences_stale_owner(self) -> None:
+        from backend.app import message_buffer
+
+        now = datetime(2026, 8, 18, tzinfo=timezone.utc)
+        acquired = message_buffer.acquire_processing_lease(
+            "orphan", now=now, token="owner"
+        )
+        assert acquired.lease is not None
+        message_buffer.set_pending_chat_response("orphan", '"ready"')
+
+        assert (
+            message_buffer.pop_pending_chat_response_if_unowned(
+                "orphan", now=acquired.lease.expires_at - timedelta(microseconds=1)
+            )
+            is None
+        )
+        assert (
+            message_buffer.pop_pending_chat_response_if_unowned(
+                "orphan", now=acquired.lease.expires_at
+            )
+            == '"ready"'
+        )
+        assert message_buffer.pop_pending_chat_response_if_unowned("orphan") is None
+        assert not message_buffer.complete_processing(
+            "orphan", acquired.lease.token, '"stale"'
+        ).completed
 
     @pytest.mark.parametrize(
         ("setter_name", "popper_name"),
@@ -892,11 +926,13 @@ class TestEndpointBufferIntegration:
         message_buffer._buffer.clear()
         message_buffer._buffer_tasks.clear()
 
+    @pytest.mark.parametrize("durable", [False, True])
     @patch("backend.main.llm_client.get_llm_response_with_tools")
     def test_is_final_bypasses_buffer(
         self,
         mock_llm: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
+        durable: bool,
     ) -> None:
         """When is_final=True, message is processed immediately, not buffered."""
         mock_llm.return_value = make_llm_response(
@@ -906,6 +942,12 @@ class TestEndpointBufferIntegration:
         client, app = self._make_client(monkeypatch, enabled=True)
 
         from backend.app import message_buffer
+        from backend.app.dynamodb_state_repository import DynamoDBStateRepository
+        from backend.tests.test_state_repository import FakeDynamoDBTable
+
+        if durable:
+            repository = DynamoDBStateRepository(table=FakeDynamoDBTable())
+            message_buffer.set_state_repository(repository)
 
         message_buffer._buffer.clear()
         message_buffer._buffer_tasks.clear()
@@ -917,6 +959,7 @@ class TestEndpointBufferIntegration:
         )
         assert r1.status_code == 202
         session_id = r1.json()["session_id"]
+        message_buffer.set_pending_chat_response(session_id, '"stale"')
 
         # Second message with is_final — should process
         r2 = client.post(
@@ -932,10 +975,12 @@ class TestEndpointBufferIntegration:
         # Should contain joined message (original + is_final)
         assert "response" in data
         assert data["session_id"] == session_id
+        assert message_buffer.pop_pending_chat_response(session_id) is None
 
         # Cleanup
         message_buffer._buffer.clear()
         message_buffer._buffer_tasks.clear()
+        message_buffer.set_state_repository(None)
         app.dependency_overrides.clear()
 
     @patch("backend.main.llm_client.get_llm_response_with_tools")

--- a/backend/app/tests/test_message_buffer.py
+++ b/backend/app/tests/test_message_buffer.py
@@ -530,6 +530,38 @@ class TestLocalProcessingLease:
         assert not acquire_processing_lease("legacy", now=now, token="blocked").acquired
         assert release_processing_lease("legacy", "owner").released
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("durable", [False, True])
+    async def test_recovery_race(
+        self, durable: bool, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from backend.app import message_buffer
+        from backend.app.auth import api_key_principal
+        from backend.app.dynamodb_state_repository import DynamoDBStateRepository
+        from backend.app.session import session_manager
+        from backend.main import get_buffer_result
+        from backend.tests.test_state_repository import FakeDynamoDBTable
+
+        if durable:
+            repository = DynamoDBStateRepository(table=FakeDynamoDBTable())
+            message_buffer.set_state_repository(repository)
+        session_manager.bind_session("r", api_key_principal("k"))
+        now = datetime.now(timezone.utc) - timedelta(seconds=61)
+        await add_to_buffer("r", "durable payload")
+        message_buffer.acquire_processing_lease("r", now=now, token="first")
+        await message_buffer._flush_owned_buffer("r", "first")
+        acquire = message_buffer.acquire_and_flush_buffer
+
+        async def finish(*args: object, **kwargs: object) -> object:
+            assert message_buffer.complete_processing("r", "first", '"ready"').completed
+            return await acquire(*args, **kwargs)
+
+        monkeypatch.setattr("backend.main.acquire_and_flush_buffer", finish)
+        assert (await get_buffer_result("r", "k")).status == "ready"
+        assert message_buffer.pop_pending_chat_response("r") is None
+        assert not message_buffer.has_active_processing_lease("r")
+        message_buffer.set_state_repository(None)
+
 
 # ===========================================================================
 # Task 5.5 — Overflow: max_messages triggers immediate flush

--- a/backend/app/tests/test_message_buffer.py
+++ b/backend/app/tests/test_message_buffer.py
@@ -724,17 +724,17 @@ class TestLocalPendingState:
         acquired = message_buffer.acquire_processing_lease("s1", now=now, token="owner")
         message_buffer.set_pending_chat_response("s1", '"early"')
 
-        assert (
-            message_buffer.pop_pending_chat_response_if_unowned("s1", now=now) is None
-        )
         assert acquired.lease is not None
-        assert message_buffer.complete_processing(
-            "s1", acquired.lease.token, '"ready"'
-        ).completed
-        assert (
-            message_buffer.pop_pending_chat_response_if_unowned("s1", now=now)
-            == '"ready"'
+        assert message_buffer.pop_pending_chat_response_if_unowned("s1") is None
+        successor = message_buffer.acquire_processing_lease(
+            "s1", now=acquired.lease.expires_at, token="next"
         )
+        assert successor.lease is not None
+        assert message_buffer.pop_pending_chat_response_if_unowned("s1") is None
+        assert message_buffer.complete_processing(
+            "s1", successor.lease.token, '"ready"'
+        ).completed
+        assert message_buffer.pop_pending_chat_response_if_unowned("s1") == '"ready"'
 
     @pytest.mark.parametrize(
         ("setter_name", "popper_name"),

--- a/backend/main.py
+++ b/backend/main.py
@@ -1970,6 +1970,14 @@ async def get_buffer_result(
             session_id=session_id,
         )
 
+    chat_response_json = pop_pending_chat_response_if_unowned(session_id)
+    if chat_response_json is not None:
+        return BufferResultResponse(
+            status="ready",
+            session_id=session_id,
+            result=chat_response_json,
+        )
+
     return BufferResultResponse(
         status="not_found",
         session_id=session_id,

--- a/backend/main.py
+++ b/backend/main.py
@@ -73,7 +73,7 @@ from backend.app.message_buffer import (
     has_processing_payload,
     is_buffer_ready_to_flush,
     is_buffering,
-    pop_pending_chat_response,
+    pop_pending_chat_response_if_unowned,
     schedule_flush,
     set_state_repository as set_buffer_state_repository,
 )
@@ -1922,7 +1922,7 @@ async def get_buffer_result(
     check_rate_limit(principal)
     bind_or_validate_session(session_id, principal, is_new=False)
 
-    chat_response_json = pop_pending_chat_response(session_id)
+    chat_response_json = pop_pending_chat_response_if_unowned(session_id)
     if chat_response_json is not None:
         return BufferResultResponse(
             status="ready",
@@ -1952,7 +1952,7 @@ async def get_buffer_result(
                 await _on_buffer_window_expired(
                     session_id, owned_message.message, owned_message.lease
                 )
-                chat_response_json = pop_pending_chat_response(session_id)
+                chat_response_json = pop_pending_chat_response_if_unowned(session_id)
                 if chat_response_json is not None:
                     return BufferResultResponse(
                         status="ready",

--- a/backend/main.py
+++ b/backend/main.py
@@ -1936,7 +1936,7 @@ async def get_buffer_result(
             await _on_buffer_window_expired(
                 session_id, owned_message.message, owned_message.lease
             )
-        chat_response_json = pop_pending_chat_response(session_id)
+        chat_response_json = pop_pending_chat_response_if_unowned(session_id)
         status = "ready" if chat_response_json is not None else "pending"
         return BufferResultResponse(
             status=status, session_id=session_id, result=chat_response_json

--- a/backend/tests/test_lambda_runtime.py
+++ b/backend/tests/test_lambda_runtime.py
@@ -207,7 +207,9 @@ def test_chat_processes_owned_batch_from_stale_precount(
         token="concurrent-overflow",
         expires_at=datetime.now(timezone.utc) + timedelta(seconds=60),
     )
-    owned = OwnedBufferedMessage(message="first\nsecond", lease=lease)
+    owned = OwnedBufferedMessage(
+        message="first\nsecond", lease=lease, generation_id="generation"
+    )
     processed: list[str] = []
     released: list[str] = []
     completion = type("Completion", (), {"completed": True})()

--- a/backend/tests/test_lambda_runtime.py
+++ b/backend/tests/test_lambda_runtime.py
@@ -391,6 +391,51 @@ async def test_two_due_buffer_pollers_run_one_processor(
 
 
 @pytest.mark.asyncio
+async def test_competing_pollers_cannot_consume_response_before_owner_release() -> None:
+    """Owner completion exposes one response without an intermediate not-found."""
+    from backend.app import message_buffer
+    from backend.app.auth import api_key_principal
+    from backend.app.dynamodb_state_repository import DynamoDBStateRepository
+    from backend.app.session import session_manager
+    from backend.main import get_buffer_result
+    from backend.tests.test_state_repository import FakeDynamoDBTable
+
+    repository = DynamoDBStateRepository(table=FakeDynamoDBTable())
+    session_id = "owned-poll-response"
+    principal = api_key_principal("lambda-test-key")
+    now = datetime.now(timezone.utc)
+    session_manager.set_state_repository(repository)
+    message_buffer.set_state_repository(repository)
+    repository.bind_owner(session_id, principal)
+    lease = message_buffer.acquire_processing_lease(session_id, now=now, token="owner")
+    assert lease.lease is not None
+    repository.set_pending_chat_response(session_id, '"early"')
+
+    try:
+        competing = await asyncio.gather(
+            get_buffer_result(session_id, "lambda-test-key"),
+            get_buffer_result(session_id, "lambda-test-key"),
+        )
+        assert [result.status for result in competing] == ["pending", "pending"]
+        assert (
+            repository.get_buffer_state(session_id).pending_chat_response == '"early"'
+        )
+
+        completed = message_buffer.complete_processing(
+            session_id, lease.lease.token, '"ready"'
+        )
+        owner_result = await get_buffer_result(session_id, "lambda-test-key")
+        consumed = await get_buffer_result(session_id, "lambda-test-key")
+    finally:
+        session_manager.set_state_repository(None)
+        message_buffer.set_state_repository(None)
+
+    assert completed.completed
+    assert owner_result.status == "ready" and owner_result.result == '"ready"'
+    assert consumed.status == "not_found"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("error_type", [RuntimeError, asyncio.CancelledError])
 async def test_buffer_callback_commits_errors_but_preserves_cancelled_work(
     monkeypatch: pytest.MonkeyPatch,

--- a/backend/tests/test_lambda_runtime.py
+++ b/backend/tests/test_lambda_runtime.py
@@ -436,6 +436,37 @@ async def test_competing_pollers_cannot_consume_response_before_owner_release() 
 
 
 @pytest.mark.asyncio
+async def test_final_poll_recheck_consumes_response_published_between_checks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A completion after the first consume cannot create a not-found window."""
+    from backend.app import message_buffer
+    from backend.app.auth import api_key_principal
+    from backend.app.session import session_manager
+    from backend.main import get_buffer_result
+
+    session_id = "late-poll-response"
+    session_manager.bind_session(session_id, api_key_principal("lambda-test-key"))
+    published = False
+
+    def publish_during_state_check(_: str) -> bool:
+        nonlocal published
+        if not published:
+            message_buffer.set_pending_chat_response(session_id, '"late"')
+            published = True
+        return False
+
+    monkeypatch.setattr(
+        "backend.main.has_processing_payload", publish_during_state_check
+    )
+
+    result = await get_buffer_result(session_id, "lambda-test-key")
+
+    assert result.status == "ready" and result.result == '"late"'
+    assert message_buffer.pop_pending_chat_response(session_id) is None
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("error_type", [RuntimeError, asyncio.CancelledError])
 async def test_buffer_callback_commits_errors_but_preserves_cancelled_work(
     monkeypatch: pytest.MonkeyPatch,

--- a/backend/tests/test_lambda_runtime.py
+++ b/backend/tests/test_lambda_runtime.py
@@ -407,8 +407,10 @@ async def test_competing_pollers_cannot_consume_response_before_owner_release() 
     session_manager.set_state_repository(repository)
     message_buffer.set_state_repository(repository)
     repository.bind_owner(session_id, principal)
+    repository.append_buffer_message(session_id, "work")
     lease = message_buffer.acquire_processing_lease(session_id, now=now, token="owner")
     assert lease.lease is not None
+    assert repository.claim_buffer_messages(session_id, lease.lease.token)
     repository.set_pending_chat_response(session_id, '"early"')
 
     try:

--- a/backend/tests/test_state_repository.py
+++ b/backend/tests/test_state_repository.py
@@ -155,11 +155,32 @@ class FakeDynamoDBTable:
             return
         if expression == (
             "attribute_type(#response, :string_type) AND "
-            "attribute_not_exists(#lease_token)"
+            "(attribute_not_exists(#lease_token) OR (#lease_expires_at <= :now AND "
+            "(attribute_not_exists(#payload) OR (attribute_type(#payload, "
+            ":list_type) AND size(#payload) = :zero)) AND "
+            "(attribute_not_exists(#messages) OR (attribute_type(#messages, "
+            ":list_type) AND size(#messages) = :zero))))"
         ):
             response_name = names["#response"]
             lease_token = names["#lease_token"]
-            if not isinstance(item.get(response_name), str) or lease_token in item:
+            work = [item.get(names[field], []) for field in ("#payload", "#messages")]
+            has_no_work = all(isinstance(value, list) and not value for value in work)
+            expiry = item.get(names["#lease_expires_at"])
+            is_orphan = (
+                lease_token in item
+                and isinstance(expiry, Number)
+                and expiry <= values[":now"]
+                and has_no_work
+            )
+            if (values[":string_type"], values[":list_type"], values[":zero"]) != (
+                "S",
+                "L",
+                0,
+            ):
+                raise ValueError("Unsupported orphan response values")
+            if not isinstance(item.get(response_name), str) or (
+                lease_token in item and not is_orphan
+            ):
                 FakeDynamoDBTable._conditional_failure("response is owned")
             return
         if expression == "attribute_not_exists(#owner) OR #owner = :owner":
@@ -282,9 +303,16 @@ class FakeDynamoDBTable:
                 item.pop(names.get(alias, alias), None)
             return
 
-        if expression == "REMOVE #response, #processing_started_at":
-            item.pop(names["#response"], None)
-            item.pop(names["#processing_started_at"], None)
+        if expression == (
+            "REMOVE #response, #processing_started_at, #lease_token, #lease_expires_at"
+        ):
+            for alias in (
+                "#response",
+                "#processing_started_at",
+                "#lease_token",
+                "#lease_expires_at",
+            ):
+                item.pop(names[alias], None)
             return
 
         if expression == (
@@ -1125,6 +1153,32 @@ def test_owned_response_is_hidden_until_fenced_terminal_transition() -> None:
     assert repository.complete_processing("s1", successor.token, '"ready"').completed
     assert repository.pop_pending_chat_response_if_unowned("s1") == '"ready"'
     assert repository.pop_pending_chat_response_if_unowned("s1") is None
+
+
+def test_expired_orphan_response_is_consumed_and_fences_stale_owner() -> None:
+    table = FakeDynamoDBTable()
+    repository = DynamoDBStateRepository(table=table)
+    now = datetime(2026, 8, 18, tzinfo=timezone.utc)
+    lease = ProcessingLease(token="orphan", expires_at=now + timedelta(seconds=30))
+    repository.append_buffer_message("s1", "work")
+    assert repository.try_acquire_processing_lease("s1", now=now, lease=lease).acquired
+    assert repository.claim_buffer_messages("s1", lease.token)
+    table.items[("SESSION#s1", "BUFFER")].pop("processing_payload")
+    repository.set_pending_chat_response("s1", '"ready"')
+
+    assert (
+        repository.pop_pending_chat_response_if_unowned(
+            "s1", now=lease.expires_at - timedelta(microseconds=1)
+        )
+        is None
+    )
+    assert (
+        repository.pop_pending_chat_response_if_unowned("s1", now=lease.expires_at)
+        == '"ready"'
+    )
+    assert repository.pop_pending_chat_response_if_unowned("s1") is None
+    assert not repository.complete_processing("s1", lease.token, '"stale"').completed
+    assert repository.get_buffer_state("s1").processing_lease is None
 
 
 def test_processing_lease_dtos_reject_incoherent_or_mutable_state() -> None:

--- a/backend/tests/test_state_repository.py
+++ b/backend/tests/test_state_repository.py
@@ -153,6 +153,23 @@ class FakeDynamoDBTable:
             ):
                 FakeDynamoDBTable._conditional_failure("pending value is not a string")
             return
+        if expression == (
+            "attribute_type(#response, :string_type) AND "
+            "(attribute_not_exists(#lease_token) OR "
+            "attribute_not_exists(#lease_expires_at) OR "
+            "#lease_expires_at <= :now)"
+        ):
+            response_name = names["#response"]
+            lease_token = names["#lease_token"]
+            lease_expiry = names["#lease_expires_at"]
+            has_active_lease = (
+                lease_token in item
+                and lease_expiry in item
+                and item[lease_expiry] > values[":now"]
+            )
+            if not isinstance(item.get(response_name), str) or has_active_lease:
+                FakeDynamoDBTable._conditional_failure("response is owned")
+            return
         if expression == "attribute_not_exists(#owner) OR #owner = :owner":
             owner_name = names.get("#owner")
             if owner_name != "owner":
@@ -271,6 +288,11 @@ class FakeDynamoDBTable:
         if expression in ("REMOVE #pending", "REMOVE #pending, #additional"):
             for alias in expression.removeprefix("REMOVE ").split(", "):
                 item.pop(names.get(alias, alias), None)
+            return
+
+        if expression == "REMOVE #response, #processing_started_at":
+            item.pop(names["#response"], None)
+            item.pop(names["#processing_started_at"], None)
             return
 
         if expression == (
@@ -1089,6 +1111,21 @@ def test_processing_lease_requires_recoverable_work() -> None:
     assert repository.get_buffer_state("s1").messages[0].message == "later"
 
 
+def test_owned_response_is_hidden_until_fenced_terminal_transition() -> None:
+    """Polling cannot consume response state while a worker still owns it."""
+    repository = DynamoDBStateRepository(table=FakeDynamoDBTable())
+    now = datetime(2026, 8, 17, tzinfo=timezone.utc)
+    lease = ProcessingLease(token="owner", expires_at=now + timedelta(seconds=30))
+    assert repository.try_acquire_processing_lease("s1", now=now, lease=lease).acquired
+    repository.set_pending_chat_response("s1", '"early"')
+
+    assert repository.pop_pending_chat_response_if_unowned("s1", now) is None
+    assert repository.get_buffer_state("s1").pending_chat_response == '"early"'
+    assert repository.complete_processing("s1", lease.token, '"ready"').completed
+    assert repository.pop_pending_chat_response_if_unowned("s1", now) == '"ready"'
+    assert repository.pop_pending_chat_response_if_unowned("s1", now) is None
+
+
 def test_processing_lease_dtos_reject_incoherent_or_mutable_state() -> None:
     now = datetime.now(timezone.utc)
     lease = ProcessingLease(token="owner", expires_at=now)
@@ -1147,12 +1184,17 @@ def test_processing_lease_translates_only_conditional_errors() -> None:
     ).acquired
     assert not repository.release_processing_lease("s1", "token").released
     assert not repository.complete_processing("s1", "token", '"ready"').completed
+    assert repository.pop_pending_chat_response_if_unowned("s1", now) is None
 
     table.code = "ProvisionedThroughputExceededException"
     with pytest.raises(ClientError):
         repository.try_acquire_processing_lease("s1", now=now, lease=lease)
     with pytest.raises(ClientError):
         repository.release_processing_lease("s1", "token")
+    with pytest.raises(ClientError):
+        repository.complete_processing("s1", "token", '"ready"')
+    with pytest.raises(ClientError):
+        repository.pop_pending_chat_response_if_unowned("s1", now)
 
 
 def test_rate_limit_uses_shared_counter(repository: DynamoDBStateRepository) -> None:

--- a/backend/tests/test_state_repository.py
+++ b/backend/tests/test_state_repository.py
@@ -155,19 +155,11 @@ class FakeDynamoDBTable:
             return
         if expression == (
             "attribute_type(#response, :string_type) AND "
-            "(attribute_not_exists(#lease_token) OR "
-            "attribute_not_exists(#lease_expires_at) OR "
-            "#lease_expires_at <= :now)"
+            "attribute_not_exists(#lease_token)"
         ):
             response_name = names["#response"]
             lease_token = names["#lease_token"]
-            lease_expiry = names["#lease_expires_at"]
-            has_active_lease = (
-                lease_token in item
-                and lease_expiry in item
-                and item[lease_expiry] > values[":now"]
-            )
-            if not isinstance(item.get(response_name), str) or has_active_lease:
+            if not isinstance(item.get(response_name), str) or lease_token in item:
                 FakeDynamoDBTable._conditional_failure("response is owned")
             return
         if expression == "attribute_not_exists(#owner) OR #owner = :owner":
@@ -1119,11 +1111,18 @@ def test_owned_response_is_hidden_until_fenced_terminal_transition() -> None:
     assert repository.try_acquire_processing_lease("s1", now=now, lease=lease).acquired
     repository.set_pending_chat_response("s1", '"early"')
 
-    assert repository.pop_pending_chat_response_if_unowned("s1", now) is None
+    assert repository.pop_pending_chat_response_if_unowned("s1") is None
     assert repository.get_buffer_state("s1").pending_chat_response == '"early"'
-    assert repository.complete_processing("s1", lease.token, '"ready"').completed
-    assert repository.pop_pending_chat_response_if_unowned("s1", now) == '"ready"'
-    assert repository.pop_pending_chat_response_if_unowned("s1", now) is None
+    successor = ProcessingLease(
+        token="next", expires_at=lease.expires_at + timedelta(seconds=30)
+    )
+    assert repository.try_acquire_processing_lease(
+        "s1", now=lease.expires_at, lease=successor
+    ).acquired
+    assert repository.pop_pending_chat_response_if_unowned("s1") is None
+    assert repository.complete_processing("s1", successor.token, '"ready"').completed
+    assert repository.pop_pending_chat_response_if_unowned("s1") == '"ready"'
+    assert repository.pop_pending_chat_response_if_unowned("s1") is None
 
 
 def test_processing_lease_dtos_reject_incoherent_or_mutable_state() -> None:
@@ -1184,7 +1183,7 @@ def test_processing_lease_translates_only_conditional_errors() -> None:
     ).acquired
     assert not repository.release_processing_lease("s1", "token").released
     assert not repository.complete_processing("s1", "token", '"ready"').completed
-    assert repository.pop_pending_chat_response_if_unowned("s1", now) is None
+    assert repository.pop_pending_chat_response_if_unowned("s1") is None
 
     table.code = "ProvisionedThroughputExceededException"
     with pytest.raises(ClientError):
@@ -1194,7 +1193,7 @@ def test_processing_lease_translates_only_conditional_errors() -> None:
     with pytest.raises(ClientError):
         repository.complete_processing("s1", "token", '"ready"')
     with pytest.raises(ClientError):
-        repository.pop_pending_chat_response_if_unowned("s1", now)
+        repository.pop_pending_chat_response_if_unowned("s1")
 
 
 def test_rate_limit_uses_shared_counter(repository: DynamoDBStateRepository) -> None:

--- a/backend/tests/test_state_repository.py
+++ b/backend/tests/test_state_repository.py
@@ -1108,7 +1108,9 @@ def test_owned_response_is_hidden_until_fenced_terminal_transition() -> None:
     repository = DynamoDBStateRepository(table=FakeDynamoDBTable())
     now = datetime(2026, 8, 17, tzinfo=timezone.utc)
     lease = ProcessingLease(token="owner", expires_at=now + timedelta(seconds=30))
+    repository.append_buffer_message("s1", "work")
     assert repository.try_acquire_processing_lease("s1", now=now, lease=lease).acquired
+    assert repository.claim_buffer_messages("s1", lease.token)
     repository.set_pending_chat_response("s1", '"early"')
 
     assert repository.pop_pending_chat_response_if_unowned("s1") is None


### PR DESCRIPTION
## ¿Qué hace este PR?

Evita consumir respuestas mientras existe ownership activo, recupera respuestas terminales huérfanas de leases expirados y cierra la ventana `not_found` mediante un recheck acotado. Los pollers competidores permanecen en `pending` sin consumir ni disparar side effects.

## Issues relacionados

Closes #313
Part of #232

## Tipo de cambio

- [ ] 🆕 Nueva funcionalidad (feature)
- [x] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [ ] 🧪 Tests
- [ ] 📄 Documentación / configuración
- [ ] 🔧 Infra / CI

## Checklist antes de pedir review

- [x] El código corre localmente sin errores (`uvicorn` levanta, tests pasan)
- [x] Los criterios de aceptación del issue relacionado están cumplidos
- [x] No hay credenciales, API keys ni rutas absolutas hardcodeadas
- [x] Si agregué dependencias nuevas, actualicé `requirements.txt` / `pyproject.toml`
- [x] Si modifiqué el schema del endpoint, verifiqué que `/docs` refleja los cambios
- [x] Si modifiqué el harness o el dataset, corrí `python evaluation/harness.py` y el output es el esperado

## Cómo probar este PR

1. Ejecutar `uv run pytest -p no:cacheprovider backend/tests/test_lambda_runtime.py backend/app/tests/test_message_buffer.py backend/tests/test_state_repository.py`.
2. Verificar consumo concurrente, expiración exacta y publicación entre checks.
3. Ejecutar `uv run pytest -p no:cacheprovider backend`.

## Notas para el reviewer

### Cadena de entrega

```text
main → #317/#311 → #318/#312 → 📍 #313 polling ownership → #315 side-effect idempotency
```

Depende de PR #318. Presupuesto de revisión: 400 líneas cambiadas contra `fix/lease-recovery-fencing`. Rollback: revertir este work unit restaura únicamente el orden anterior del polling.