### PR TITLE
fix(state): [#315] fence recovered processing side effects

### DIFF
--- a/backend/app/dynamodb_state_repository.py
+++ b/backend/app/dynamodb_state_repository.py
@@ -110,12 +110,8 @@ class DynamoDBStateRepository:
                 ]
             )
         except ClientError as exc:
-            existing = self._get_item(item["PK"], item["SK"], consistent=True) or {}
-            if not self._is_transaction_canceled(exc):
-                raise
-            if existing.get("processing_generation") == generation_id:
+            if self._is_duplicate_side_effect(exc):
                 return
-            raise StaleProcessingOwnershipError from exc
 
     def bind_owner(self, session_id: str, owner: str) -> None:
         """Conditionally bind a session owner."""
@@ -201,12 +197,8 @@ class DynamoDBStateRepository:
                     ]
                 )
             except ClientError as exc:
-                item = self._get_item(pk, "TOKENS", consistent=True) or {}
-                if not self._is_transaction_canceled(exc):
-                    raise
-                if generation_id in item.get("processing_generations", set()):
+                if self._is_duplicate_side_effect(exc):
                     return
-                raise StaleProcessingOwnershipError from exc
             return
         self._table.update_item(
             Key={"PK": self._session_pk(session_id), "SK": "TOKENS"},
@@ -640,8 +632,23 @@ class DynamoDBStateRepository:
             raise ValueError("generation_id and lease_token must be provided together")
 
     @staticmethod
-    def _is_transaction_canceled(exc: ClientError) -> bool:
-        return exc.response["Error"]["Code"] == "TransactionCanceledException"
+    def _is_duplicate_side_effect(exc: ClientError) -> bool:
+        if exc.response.get("Error", {}).get("Code") != "TransactionCanceledException":
+            raise exc
+        try:
+            lease_reason, marker_reason = (
+                reason["Code"] for reason in exc.response["CancellationReasons"]
+            )
+        except (KeyError, TypeError, ValueError):
+            raise exc
+        if lease_reason == "ConditionalCheckFailed" and marker_reason in (
+            "None",
+            "ConditionalCheckFailed",
+        ):
+            raise StaleProcessingOwnershipError from exc
+        if (lease_reason, marker_reason) == ("None", "ConditionalCheckFailed"):
+            return True
+        raise exc
 
     def _get_turns(self, session_id: str, max_turns: int) -> list[ChatTurn]:
         items: list[dict[str, Any]] = []
@@ -668,13 +675,8 @@ class DynamoDBStateRepository:
 
         return [self._turn_from_item(item) for item in reversed(items)]
 
-    def _get_item(
-        self, pk: str, sk: str, *, consistent: bool = False
-    ) -> dict[str, Any]:
-        response = self._table.get_item(
-            Key={"PK": pk, "SK": sk},
-            **({"ConsistentRead": True} if consistent else {}),
-        )
+    def _get_item(self, pk: str, sk: str) -> dict[str, Any]:
+        response = self._table.get_item(Key={"PK": pk, "SK": sk})
         return response.get("Item", {})
 
     def _session_pk(self, session_id: str) -> str:

--- a/backend/app/dynamodb_state_repository.py
+++ b/backend/app/dynamodb_state_repository.py
@@ -6,6 +6,7 @@ import time
 from typing import Any, Optional
 
 import boto3
+from boto3.dynamodb.types import TypeSerializer
 from botocore.exceptions import ClientError
 
 from backend.app.state_repository import (
@@ -48,6 +49,7 @@ class DynamoDBStateRepository:
         self._table = table or boto3.resource(
             "dynamodb", region_name=region_name
         ).Table(table_name)
+        self._table_name = getattr(self._table, "name", table_name)
         self._key_prefix = key_prefix.strip("#")
         self._session_ttl_seconds = session_ttl_seconds
         self._buffer_ttl_seconds = buffer_ttl_seconds
@@ -69,20 +71,51 @@ class DynamoDBStateRepository:
             token_totals=tokens,
         )
 
-    def append_turn(self, session_id: str, turn: ChatTurn) -> None:
+    def append_turn(
+        self,
+        session_id: str,
+        turn: ChatTurn,
+        *,
+        generation_id: Optional[str] = None,
+        lease_token: Optional[str] = None,
+    ) -> None:
         """Append a conversation turn as an immutable item."""
         timestamp = self._to_utc(turn.timestamp).isoformat()
-        self._table.put_item(
-            Item={
-                "PK": self._session_pk(session_id),
-                "SK": f"TURN#{timestamp}",
-                "question": turn.question,
-                "answer": turn.answer,
-                "timestamp": timestamp,
-                "source_documents": turn.source_documents,
-                "expires_at": self._ttl(self._session_ttl_seconds),
-            }
-        )
+        item = {
+            "PK": self._session_pk(session_id),
+            "SK": f"TURN#{generation_id or timestamp}",
+            "question": turn.question,
+            "answer": turn.answer,
+            "timestamp": timestamp,
+            "source_documents": turn.source_documents,
+            "expires_at": self._ttl(self._session_ttl_seconds),
+        }
+        if generation_id is None:
+            self._table.put_item(Item=item)
+            return
+        self._require_fence(generation_id, lease_token)
+        item["processing_generation"] = generation_id
+        try:
+            self._transact_write(
+                [
+                    self._lease_condition(session_id, lease_token),
+                    {
+                        "Put": {
+                            "TableName": self._table_name,
+                            "Item": item,
+                            "ConditionExpression": "attribute_not_exists(PK)",
+                        }
+                    },
+                ]
+            )
+        except ClientError as exc:
+            existing = self._get_item(item["PK"], item["SK"], consistent=True) or {}
+            if (
+                self._is_transaction_canceled(exc)
+                and existing.get("processing_generation") == generation_id
+            ):
+                return
+            raise
 
     def bind_owner(self, session_id: str, owner: str) -> None:
         """Conditionally bind a session owner."""
@@ -123,8 +156,58 @@ class DynamoDBStateRepository:
             },
         )
 
-    def add_token_usage(self, session_id: str, totals: TokenTotals) -> None:
+    def add_token_usage(
+        self,
+        session_id: str,
+        totals: TokenTotals,
+        *,
+        generation_id: Optional[str] = None,
+        lease_token: Optional[str] = None,
+    ) -> None:
         """Accumulate token counters atomically."""
+        if generation_id is not None:
+            self._require_fence(generation_id, lease_token)
+            pk = self._session_pk(session_id)
+            try:
+                self._transact_write(
+                    [
+                        self._lease_condition(session_id, lease_token),
+                        {
+                            "Update": {
+                                "TableName": self._table_name,
+                                "Key": {"PK": pk, "SK": "TOKENS"},
+                                "UpdateExpression": (
+                                    "SET expires_at = :ttl ADD input_tokens :input, "
+                                    "output_tokens :output, total_tokens :total, "
+                                    "#generations :generation_set"
+                                ),
+                                "ConditionExpression": (
+                                    "attribute_not_exists(#generations) OR "
+                                    "NOT contains(#generations, :generation)"
+                                ),
+                                "ExpressionAttributeNames": {
+                                    "#generations": "processing_generations"
+                                },
+                                "ExpressionAttributeValues": {
+                                    ":input": totals.input_tokens,
+                                    ":output": totals.output_tokens,
+                                    ":total": totals.total_tokens,
+                                    ":ttl": self._ttl(self._session_ttl_seconds),
+                                    ":generation": generation_id,
+                                    ":generation_set": {generation_id},
+                                },
+                            }
+                        },
+                    ]
+                )
+            except ClientError as exc:
+                item = self._get_item(pk, "TOKENS", consistent=True) or {}
+                if self._is_transaction_canceled(exc) and generation_id in item.get(
+                    "processing_generations", set()
+                ):
+                    return
+                raise
+            return
         self._table.update_item(
             Key={"PK": self._session_pk(session_id), "SK": "TOKENS"},
             UpdateExpression=(
@@ -523,6 +606,49 @@ class DynamoDBStateRepository:
             raise
         return ProcessingCompletionResult(completed=True)
 
+    def _lease_condition(
+        self, session_id: str, lease_token: Optional[str]
+    ) -> dict[str, Any]:
+        return {
+            "ConditionCheck": {
+                "TableName": self._table_name,
+                "Key": {"PK": self._session_pk(session_id), "SK": "BUFFER"},
+                "ConditionExpression": "#lease_token = :token",
+                "ExpressionAttributeNames": {"#lease_token": "lease_token"},
+                "ExpressionAttributeValues": {":token": lease_token},
+            }
+        }
+
+    def _transact_write(self, items: list[dict[str, Any]]) -> None:
+        transaction_client = getattr(self._table, "transaction_client", None)
+        if transaction_client is not None:
+            transaction_client.transact_write_items(TransactItems=items)
+            return
+        serializer = TypeSerializer()
+        serialized = []
+        for action in items:
+            operation, parameters = next(iter(action.items()))
+            request = dict(parameters)
+            for field in ("Key", "Item", "ExpressionAttributeValues"):
+                if field in request:
+                    request[field] = {
+                        key: serializer.serialize(value)
+                        for key, value in request[field].items()
+                    }
+            serialized.append({operation: request})
+        self._table.meta.client.transact_write_items(TransactItems=serialized)
+
+    @staticmethod
+    def _require_fence(generation_id: str, lease_token: Optional[str]) -> None:
+        if not generation_id or not lease_token:
+            raise ValueError("generation_id and lease_token must be provided together")
+
+    @staticmethod
+    def _is_transaction_canceled(exc: ClientError) -> bool:
+        return (
+            exc.response.get("Error", {}).get("Code") == "TransactionCanceledException"
+        )
+
     def _get_turns(self, session_id: str, max_turns: int) -> list[ChatTurn]:
         items: list[dict[str, Any]] = []
         exclusive_start_key: Optional[dict[str, Any]] = None
@@ -548,8 +674,13 @@ class DynamoDBStateRepository:
 
         return [self._turn_from_item(item) for item in reversed(items)]
 
-    def _get_item(self, pk: str, sk: str) -> dict[str, Any]:
-        response = self._table.get_item(Key={"PK": pk, "SK": sk})
+    def _get_item(
+        self, pk: str, sk: str, *, consistent: bool = False
+    ) -> dict[str, Any]:
+        response = self._table.get_item(
+            Key={"PK": pk, "SK": sk},
+            **({"ConsistentRead": True} if consistent else {}),
+        )
         return response.get("Item", {})
 
     def _session_pk(self, session_id: str) -> str:

--- a/backend/app/dynamodb_state_repository.py
+++ b/backend/app/dynamodb_state_repository.py
@@ -20,6 +20,7 @@ from backend.app.state_repository import (
     ProcessingLeaseResult,
     RateLimitDecision,
     SessionState,
+    StaleProcessingOwnershipError,
     TokenTotals,
 )
 
@@ -110,12 +111,11 @@ class DynamoDBStateRepository:
             )
         except ClientError as exc:
             existing = self._get_item(item["PK"], item["SK"], consistent=True) or {}
-            if (
-                self._is_transaction_canceled(exc)
-                and existing.get("processing_generation") == generation_id
-            ):
+            if not self._is_transaction_canceled(exc):
+                raise
+            if existing.get("processing_generation") == generation_id:
                 return
-            raise
+            raise StaleProcessingOwnershipError from exc
 
     def bind_owner(self, session_id: str, owner: str) -> None:
         """Conditionally bind a session owner."""
@@ -202,11 +202,11 @@ class DynamoDBStateRepository:
                 )
             except ClientError as exc:
                 item = self._get_item(pk, "TOKENS", consistent=True) or {}
-                if self._is_transaction_canceled(exc) and generation_id in item.get(
-                    "processing_generations", set()
-                ):
+                if not self._is_transaction_canceled(exc):
+                    raise
+                if generation_id in item.get("processing_generations", set()):
                     return
-                raise
+                raise StaleProcessingOwnershipError from exc
             return
         self._table.update_item(
             Key={"PK": self._session_pk(session_id), "SK": "TOKENS"},
@@ -641,9 +641,7 @@ class DynamoDBStateRepository:
 
     @staticmethod
     def _is_transaction_canceled(exc: ClientError) -> bool:
-        return (
-            exc.response.get("Error", {}).get("Code") == "TransactionCanceledException"
-        )
+        return exc.response["Error"]["Code"] == "TransactionCanceledException"
 
     def _get_turns(self, session_id: str, max_turns: int) -> list[ChatTurn]:
         items: list[dict[str, Any]] = []

--- a/backend/app/dynamodb_state_repository.py
+++ b/backend/app/dynamodb_state_repository.py
@@ -620,10 +620,6 @@ class DynamoDBStateRepository:
         }
 
     def _transact_write(self, items: list[dict[str, Any]]) -> None:
-        transaction_client = getattr(self._table, "transaction_client", None)
-        if transaction_client is not None:
-            transaction_client.transact_write_items(TransactItems=items)
-            return
         serializer = TypeSerializer()
         serialized = []
         for action in items:

--- a/backend/app/message_buffer.py
+++ b/backend/app/message_buffer.py
@@ -54,6 +54,7 @@ _pending_state_lock = RLock()
 _processing_leases: dict[str, ProcessingLease] = {}
 _processing_payloads: dict[str, str] = {}
 _processing_generations: dict[str, str] = {}
+_processing_side_effects: dict[str, set[str]] = {}
 _state_lock = RLock()
 
 
@@ -258,6 +259,29 @@ def get_processing_generation(session_id: str) -> Optional[str]:
         return _processing_generations.get(session_id)
 
 
+def commit_local_processing_side_effect(
+    session_id: str,
+    generation_id: str,
+    token: str,
+    effect: str,
+    commit: Callable[[], None],
+) -> None:
+    """Fence and deduplicate one in-memory processing side effect."""
+    with _state_lock:
+        if _state_repository is not None:
+            commit()
+            return
+        lease = _processing_leases.get(session_id)
+        owner = lease.token if lease is not None else None
+        if (owner, _processing_generations.get(session_id)) != (token, generation_id):
+            raise RuntimeError("stale buffer processing owner")
+        applied = _processing_side_effects.setdefault(session_id, set())
+        marker = f"{generation_id}:{effect}"
+        if marker not in applied:
+            commit()
+            applied.add(marker)
+
+
 def clear_buffer(session_id: str) -> None:
     """Clear buffer state for a session.
 
@@ -372,6 +396,7 @@ def pop_pending_chat_response_if_unowned(
             return None
         _processing_leases.pop(session_id, None)
         _processing_generations.pop(session_id, None)
+        _processing_side_effects.pop(session_id, None)
         _processing_sessions.pop(session_id, None)
         return result[0]
 
@@ -492,6 +517,7 @@ def complete_processing(
         _processing_leases.pop(session_id, None)
         _processing_payloads.pop(session_id, None)
         _processing_generations.pop(session_id, None)
+        _processing_side_effects.pop(session_id, None)
         _processing_sessions.pop(session_id, None)
         _pending_results.pop(session_id, None)
         return ProcessingCompletionResult(completed=True)

--- a/backend/app/message_buffer.py
+++ b/backend/app/message_buffer.py
@@ -25,6 +25,7 @@ from backend.app.state_repository import (
     ProcessingCompletionResult,
     ProcessingLeaseReleaseResult,
     ProcessingLeaseResult,
+    StaleProcessingOwnershipError,
 )
 
 logger = logging.getLogger(__name__)
@@ -274,7 +275,7 @@ def commit_local_processing_side_effect(
         lease = _processing_leases.get(session_id)
         owner = lease.token if lease is not None else None
         if (owner, _processing_generations.get(session_id)) != (token, generation_id):
-            raise RuntimeError("stale buffer processing owner")
+            raise StaleProcessingOwnershipError("stale buffer processing owner")
         applied = _processing_side_effects.setdefault(session_id, set())
         marker = f"{generation_id}:{effect}"
         if marker not in applied:

--- a/backend/app/session.py
+++ b/backend/app/session.py
@@ -97,6 +97,9 @@ class SessionManager:
         question: str,
         answer: str,
         source_documents: Optional[List[str]] = None,
+        *,
+        generation_id: Optional[str] = None,
+        lease_token: Optional[str] = None,
     ) -> None:
         """
         Añade un turno a la sesión.
@@ -122,6 +125,8 @@ class SessionManager:
                     timestamp=turn.timestamp,
                     source_documents=turn.source_documents,
                 ),
+                generation_id=generation_id,
+                lease_token=lease_token,
             )
             return
 
@@ -266,6 +271,9 @@ class SessionManager:
         input_tokens: int,
         output_tokens: int,
         total_tokens: int,
+        *,
+        generation_id: Optional[str] = None,
+        lease_token: Optional[str] = None,
     ) -> None:
         """Acumula el uso de tokens para una sesión.
 
@@ -285,6 +293,8 @@ class SessionManager:
                     output_tokens=output_tokens,
                     total_tokens=total_tokens,
                 ),
+                generation_id=generation_id,
+                lease_token=lease_token,
             )
             return
         with self._lock:

--- a/backend/app/session.py
+++ b/backend/app/session.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 from backend.app.config import settings
 from backend.app.context_budget import SelectedContext, select_history
 from backend.app.context_budget_config import ContextBudgetConfig
+from backend.app.message_buffer import commit_local_processing_side_effect
 from backend.app.state_repository import (
     ChatbotStateRepository,
     ChatTurn as RepositoryChatTurn,
@@ -110,6 +111,15 @@ class SessionManager:
             answer: Respuesta del asistente
             source_documents: Lista de documentos fuente utilizados (opcional)
         """
+        if generation_id is not None and self.state_repository is None:
+            commit_local_processing_side_effect(
+                session_id,
+                generation_id,
+                lease_token or "",
+                "turn",
+                lambda: self.add_turn(session_id, question, answer, source_documents),
+            )
+            return
         turn = ChatTurn(
             question=question,
             answer=answer,
@@ -285,6 +295,17 @@ class SessionManager:
             output_tokens: Tokens de salida a acumular.
             total_tokens: Total de tokens a acumular.
         """
+        if generation_id is not None and self.state_repository is None:
+            commit_local_processing_side_effect(
+                session_id,
+                generation_id,
+                lease_token or "",
+                "tokens",
+                lambda: self.add_token_usage(
+                    session_id, input_tokens, output_tokens, total_tokens
+                ),
+            )
+            return
         if self.state_repository is not None:
             self.state_repository.add_token_usage(
                 session_id,

--- a/backend/app/state_repository.py
+++ b/backend/app/state_repository.py
@@ -128,7 +128,14 @@ class ChatbotStateRepository(Protocol):
     def get_session(self, session_id: str, max_turns: int = 20) -> SessionState:
         """Return persisted session state with at most the latest turns."""
 
-    def append_turn(self, session_id: str, turn: ChatTurn) -> None:
+    def append_turn(
+        self,
+        session_id: str,
+        turn: ChatTurn,
+        *,
+        generation_id: Optional[str] = None,
+        lease_token: Optional[str] = None,
+    ) -> None:
         """Append one conversation turn."""
 
     def bind_owner(self, session_id: str, owner: str) -> None:
@@ -140,7 +147,14 @@ class ChatbotStateRepository(Protocol):
     def set_user_profile(self, session_id: str, profile: str) -> None:
         """Persist the user profile for a session."""
 
-    def add_token_usage(self, session_id: str, totals: TokenTotals) -> None:
+    def add_token_usage(
+        self,
+        session_id: str,
+        totals: TokenTotals,
+        *,
+        generation_id: Optional[str] = None,
+        lease_token: Optional[str] = None,
+    ) -> None:
         """Accumulate token usage for a session."""
 
     def get_token_totals(self, session_id: str) -> TokenTotals:

--- a/backend/app/state_repository.py
+++ b/backend/app/state_repository.py
@@ -15,6 +15,10 @@ class OwnershipConflictError(StateRepositoryError):
     """Raised when a session is already owned by another principal."""
 
 
+class StaleProcessingOwnershipError(StateRepositoryError):
+    """Raised when processing side effects have lost lease ownership."""
+
+
 class ChatTurn(BaseModel):
     """A single persisted conversation turn."""
 

--- a/backend/app/state_repository.py
+++ b/backend/app/state_repository.py
@@ -128,14 +128,7 @@ class ChatbotStateRepository(Protocol):
     def get_session(self, session_id: str, max_turns: int = 20) -> SessionState:
         """Return persisted session state with at most the latest turns."""
 
-    def append_turn(
-        self,
-        session_id: str,
-        turn: ChatTurn,
-        *,
-        generation_id: Optional[str] = None,
-        lease_token: Optional[str] = None,
-    ) -> None:
+    def append_turn(self, session_id: str, turn: ChatTurn, **_: Optional[str]) -> None:
         """Append one conversation turn."""
 
     def bind_owner(self, session_id: str, owner: str) -> None:
@@ -147,14 +140,7 @@ class ChatbotStateRepository(Protocol):
     def set_user_profile(self, session_id: str, profile: str) -> None:
         """Persist the user profile for a session."""
 
-    def add_token_usage(
-        self,
-        session_id: str,
-        totals: TokenTotals,
-        *,
-        generation_id: Optional[str] = None,
-        lease_token: Optional[str] = None,
-    ) -> None:
+    def add_token_usage(self, sid: str, t: TokenTotals, **_: Optional[str]) -> None:
         """Accumulate token usage for a session."""
 
     def get_token_totals(self, session_id: str) -> TokenTotals:

--- a/backend/main.py
+++ b/backend/main.py
@@ -966,10 +966,7 @@ async def _process_chat_message(
     request_id = request_id or str(uuid.uuid4())
     deadline = deadline or _request_deadline()
     request_start = time.time()
-    side_effect_fence = {
-        "generation_id": processing_generation,
-        "lease_token": processing_token,
-    }
+    fence = {"generation_id": processing_generation, "lease_token": processing_token}
 
     logger.debug(
         "Incoming request: request_id=%s, session_id=%s, message_preview=%s",
@@ -1036,7 +1033,7 @@ async def _process_chat_message(
             question=message,
             answer=response_text,
             source_documents=[],
-            **side_effect_fence,
+            **fence,
         )
         response_time_ms = (time.time() - request_start) * 1000
         _fire_conversation_log(
@@ -1172,14 +1169,14 @@ async def _process_chat_message(
                         question=message,
                         answer=response_text,
                         source_documents=[],
-                        **side_effect_fence,
+                        **fence,
                     )
                     session_manager.add_token_usage(
                         session_id,
                         acc_input_tokens,
                         acc_output_tokens,
                         acc_total_tokens,
-                        **side_effect_fence,
+                        **fence,
                     )
                     response_time_ms = (time.time() - request_start) * 1000
                     _fire_conversation_log(
@@ -1215,14 +1212,14 @@ async def _process_chat_message(
                         question=message,
                         answer=OUT_OF_DOMAIN_MESSAGE,
                         source_documents=[],
-                        **side_effect_fence,
+                        **fence,
                     )
                     session_manager.add_token_usage(
                         session_id,
                         acc_input_tokens,
                         acc_output_tokens,
                         acc_total_tokens,
-                        **side_effect_fence,
+                        **fence,
                     )
                     response_time_ms = (time.time() - request_start) * 1000
                     _fire_conversation_log(
@@ -1284,14 +1281,14 @@ async def _process_chat_message(
                     question=message,
                     answer=response_text,
                     source_documents=[],
-                    **side_effect_fence,
+                    **fence,
                 )
                 session_manager.add_token_usage(
                     session_id,
                     acc_input_tokens,
                     acc_output_tokens,
                     acc_total_tokens,
-                    **side_effect_fence,
+                    **fence,
                 )
                 response_time_ms = (time.time() - request_start) * 1000
                 _fire_conversation_log(
@@ -1535,14 +1532,14 @@ async def _process_chat_message(
                     question=message,
                     answer=response_text,
                     source_documents=[s.ruta for s in source_docs],
-                    **side_effect_fence,
+                    **fence,
                 )
                 session_manager.add_token_usage(
                     session_id,
                     acc_input_tokens,
                     acc_output_tokens,
                     acc_total_tokens,
-                    **side_effect_fence,
+                    **fence,
                 )
                 response_time_ms = (time.time() - request_start) * 1000
                 _fire_conversation_log(
@@ -1583,14 +1580,14 @@ async def _process_chat_message(
                     question=message,
                     answer=error_content,
                     source_documents=[],
-                    **side_effect_fence,
+                    **fence,
                 )
                 session_manager.add_token_usage(
                     session_id,
                     acc_input_tokens,
                     acc_output_tokens,
                     acc_total_tokens,
-                    **side_effect_fence,
+                    **fence,
                 )
                 response_time_ms = (time.time() - request_start) * 1000
                 _fire_conversation_log(
@@ -1650,14 +1647,14 @@ async def _process_chat_message(
                 question=message,
                 answer=response_text,
                 source_documents=[],
-                **side_effect_fence,
+                **fence,
             )
             session_manager.add_token_usage(
                 session_id,
                 acc_input_tokens,
                 acc_output_tokens,
                 acc_total_tokens,
-                **side_effect_fence,
+                **fence,
             )
             response_time_ms = (time.time() - request_start) * 1000
             _fire_conversation_log(
@@ -1692,7 +1689,7 @@ async def _process_chat_message(
             acc_input_tokens,
             acc_output_tokens,
             acc_total_tokens,
-            **side_effect_fence,
+            **fence,
         )
         response_time_ms = (time.time() - request_start) * 1000
         _fire_conversation_log(
@@ -1742,15 +1739,13 @@ async def _process_chat_message(
             error.iteration,
             int(deadline.elapsed_seconds() * 1000),
         )
-        session_manager.add_turn(
-            session_id, message, response_text, [], **side_effect_fence
-        )
+        session_manager.add_turn(session_id, message, response_text, [], **fence)
         session_manager.add_token_usage(
             session_id,
             acc_input_tokens,
             acc_output_tokens,
             acc_total_tokens,
-            **side_effect_fence,
+            **fence,
         )
         return ChatResponse(
             response=response_text,

--- a/backend/main.py
+++ b/backend/main.py
@@ -68,6 +68,7 @@ from backend.app.message_buffer import (
     add_to_buffer,
     clear_pending_chat_response,
     complete_processing,
+    get_processing_generation,
     get_buffer_count,
     has_active_processing_lease,
     has_processing_payload,
@@ -958,11 +959,17 @@ async def _process_chat_message(
     file_inputs_client: FileInputsClient,
     request_id: Optional[str] = None,
     deadline: Optional[RequestDeadline] = None,
+    processing_generation: Optional[str] = None,
+    processing_token: Optional[str] = None,
 ) -> ChatResponse:
     """Core chat processing logic shared between endpoint and buffer callback."""
     request_id = request_id or str(uuid.uuid4())
     deadline = deadline or _request_deadline()
     request_start = time.time()
+    side_effect_fence = {
+        "generation_id": processing_generation,
+        "lease_token": processing_token,
+    }
 
     logger.debug(
         "Incoming request: request_id=%s, session_id=%s, message_preview=%s",
@@ -1029,6 +1036,7 @@ async def _process_chat_message(
             question=message,
             answer=response_text,
             source_documents=[],
+            **side_effect_fence,
         )
         response_time_ms = (time.time() - request_start) * 1000
         _fire_conversation_log(
@@ -1164,12 +1172,14 @@ async def _process_chat_message(
                         question=message,
                         answer=response_text,
                         source_documents=[],
+                        **side_effect_fence,
                     )
                     session_manager.add_token_usage(
                         session_id,
                         acc_input_tokens,
                         acc_output_tokens,
                         acc_total_tokens,
+                        **side_effect_fence,
                     )
                     response_time_ms = (time.time() - request_start) * 1000
                     _fire_conversation_log(
@@ -1205,12 +1215,14 @@ async def _process_chat_message(
                         question=message,
                         answer=OUT_OF_DOMAIN_MESSAGE,
                         source_documents=[],
+                        **side_effect_fence,
                     )
                     session_manager.add_token_usage(
                         session_id,
                         acc_input_tokens,
                         acc_output_tokens,
                         acc_total_tokens,
+                        **side_effect_fence,
                     )
                     response_time_ms = (time.time() - request_start) * 1000
                     _fire_conversation_log(
@@ -1272,9 +1284,14 @@ async def _process_chat_message(
                     question=message,
                     answer=response_text,
                     source_documents=[],
+                    **side_effect_fence,
                 )
                 session_manager.add_token_usage(
-                    session_id, acc_input_tokens, acc_output_tokens, acc_total_tokens
+                    session_id,
+                    acc_input_tokens,
+                    acc_output_tokens,
+                    acc_total_tokens,
+                    **side_effect_fence,
                 )
                 response_time_ms = (time.time() - request_start) * 1000
                 _fire_conversation_log(
@@ -1518,9 +1535,14 @@ async def _process_chat_message(
                     question=message,
                     answer=response_text,
                     source_documents=[s.ruta for s in source_docs],
+                    **side_effect_fence,
                 )
                 session_manager.add_token_usage(
-                    session_id, acc_input_tokens, acc_output_tokens, acc_total_tokens
+                    session_id,
+                    acc_input_tokens,
+                    acc_output_tokens,
+                    acc_total_tokens,
+                    **side_effect_fence,
                 )
                 response_time_ms = (time.time() - request_start) * 1000
                 _fire_conversation_log(
@@ -1561,9 +1583,14 @@ async def _process_chat_message(
                     question=message,
                     answer=error_content,
                     source_documents=[],
+                    **side_effect_fence,
                 )
                 session_manager.add_token_usage(
-                    session_id, acc_input_tokens, acc_output_tokens, acc_total_tokens
+                    session_id,
+                    acc_input_tokens,
+                    acc_output_tokens,
+                    acc_total_tokens,
+                    **side_effect_fence,
                 )
                 response_time_ms = (time.time() - request_start) * 1000
                 _fire_conversation_log(
@@ -1623,9 +1650,14 @@ async def _process_chat_message(
                 question=message,
                 answer=response_text,
                 source_documents=[],
+                **side_effect_fence,
             )
             session_manager.add_token_usage(
-                session_id, acc_input_tokens, acc_output_tokens, acc_total_tokens
+                session_id,
+                acc_input_tokens,
+                acc_output_tokens,
+                acc_total_tokens,
+                **side_effect_fence,
             )
             response_time_ms = (time.time() - request_start) * 1000
             _fire_conversation_log(
@@ -1656,7 +1688,11 @@ async def _process_chat_message(
             )
 
         session_manager.add_token_usage(
-            session_id, acc_input_tokens, acc_output_tokens, acc_total_tokens
+            session_id,
+            acc_input_tokens,
+            acc_output_tokens,
+            acc_total_tokens,
+            **side_effect_fence,
         )
         response_time_ms = (time.time() - request_start) * 1000
         _fire_conversation_log(
@@ -1706,9 +1742,15 @@ async def _process_chat_message(
             error.iteration,
             int(deadline.elapsed_seconds() * 1000),
         )
-        session_manager.add_turn(session_id, message, response_text, [])
+        session_manager.add_turn(
+            session_id, message, response_text, [], **side_effect_fence
+        )
         session_manager.add_token_usage(
-            session_id, acc_input_tokens, acc_output_tokens, acc_total_tokens
+            session_id,
+            acc_input_tokens,
+            acc_output_tokens,
+            acc_total_tokens,
+            **side_effect_fence,
         )
         return ChatResponse(
             response=response_text,
@@ -1749,6 +1791,7 @@ async def _on_buffer_window_expired(
     Processes the joined message with the chatbot in the background
     and stores the response for polling by the client.
     """
+    generation_id = get_processing_generation(session_id)
     logger.info(
         "Buffer window expired for session %s: %d chars accumulated, "
         "processing in background",
@@ -1762,6 +1805,8 @@ async def _on_buffer_window_expired(
             llm_client=llm_client,
             s3_client=s3_client,
             file_inputs_client=file_inputs_client,
+            processing_generation=generation_id,
+            processing_token=lease.token if generation_id is not None else None,
         )
         response_json = response.model_dump_json()
         logger.info(
@@ -1823,6 +1868,7 @@ async def chat_endpoint(
     deadline = _request_deadline(http_request.scope)
     request_id = str(uuid.uuid4())
     processing_lease: Optional[ProcessingLease] = None
+    processing_generation: Optional[str] = None
 
     # P4: Multi-message buffer — intercept before normal processing
     if settings.multi_message_buffer_enabled:
@@ -1837,6 +1883,7 @@ async def chat_endpoint(
         )
         if owned_message is not None:
             processing_lease = owned_message.lease
+            processing_generation = owned_message.generation_id
             if len(owned_message.message) > settings.max_chat_message_chars:
                 complete_processing(session_id, processing_lease.token, None)
                 processing_lease = None
@@ -1872,6 +1919,10 @@ async def chat_endpoint(
             file_inputs_client=file_inputs_client,
             request_id=request_id,
             deadline=deadline,
+            processing_generation=processing_generation,
+            processing_token=(
+                processing_lease.token if processing_lease is not None else None
+            ),
         )
         if processing_lease is not None:
             completion = complete_processing(

--- a/backend/tests/test_state_repository.py
+++ b/backend/tests/test_state_repository.py
@@ -27,12 +27,14 @@ class FakeDynamoDBTable:
     """Small in-memory DynamoDB Table fake for repository unit tests."""
 
     def __init__(self, query_page_size: int | None = None) -> None:
+        self.name = "test-table"
+        self.transaction_client = self
         self.items: dict[tuple[str, str], dict[str, Any]] = {}
         self.query_calls: list[dict[str, Any]] = []
         self.query_page_size = query_page_size
         self._lock = RLock()
 
-    def get_item(self, Key: dict[str, str]) -> dict[str, Any]:
+    def get_item(self, Key: dict[str, str], **_: Any) -> dict[str, Any]:
         with self._lock:
             item = self.items.get((Key["PK"], Key["SK"]))
             return {"Item": deepcopy(item)} if item else {}
@@ -40,6 +42,64 @@ class FakeDynamoDBTable:
     def put_item(self, Item: dict[str, Any]) -> None:
         with self._lock:
             self.items[(Item["PK"], Item["SK"])] = deepcopy(Item)
+
+    def transact_write_items(self, TransactItems: list[dict[str, Any]]) -> None:
+        if len(TransactItems) != 2 or "ConditionCheck" not in TransactItems[0]:
+            raise ValueError("Unsupported processing transaction")
+        condition = TransactItems[0]["ConditionCheck"]
+        if condition != {
+            "TableName": self.name,
+            "Key": {"PK": condition["Key"]["PK"], "SK": "BUFFER"},
+            "ConditionExpression": "#lease_token = :token",
+            "ExpressionAttributeNames": {"#lease_token": "lease_token"},
+            "ExpressionAttributeValues": {
+                ":token": condition["ExpressionAttributeValues"][":token"]
+            },
+        }:
+            raise ValueError("Unsupported lease transaction condition")
+        with self._lock:
+            buffer_key = condition["Key"]["PK"], "BUFFER"
+            token = condition["ExpressionAttributeValues"][":token"]
+            if self.items.get(buffer_key, {}).get("lease_token") != token:
+                self._transaction_failure()
+            operation, request = next(iter(TransactItems[1].items()))
+            if request["TableName"] != self.name:
+                raise ValueError("Unsupported transaction table")
+            key = request.get("Key") or {
+                field: request["Item"][field] for field in ("PK", "SK")
+            }
+            item_key = key["PK"], key["SK"]
+            if operation == "Put":
+                if request.get("ConditionExpression") != "attribute_not_exists(PK)":
+                    raise ValueError("Unsupported transactional put")
+                if item_key in self.items:
+                    self._transaction_failure()
+                self.items[item_key] = deepcopy(request["Item"])
+                return
+            if operation != "Update":
+                raise ValueError("Unsupported processing transaction operation")
+            values = request["ExpressionAttributeValues"]
+            generation = values[":generation"]
+            item = deepcopy(
+                self.items.get(item_key, {"PK": key["PK"], "SK": key["SK"]})
+            )
+            generations = set(item.get("processing_generations", set()))
+            if generation in generations:
+                self._transaction_failure()
+            for field in ("input_tokens", "output_tokens", "total_tokens"):
+                item[field] = int(item.get(field, 0)) + int(
+                    values[f":{field.removesuffix('_tokens')}"]
+                )
+            item["expires_at"] = values[":ttl"]
+            item["processing_generations"] = generations | values[":generation_set"]
+            self.items[item_key] = item
+
+    @staticmethod
+    def _transaction_failure() -> None:
+        raise ClientError(
+            {"Error": {"Code": "TransactionCanceledException"}},
+            "TransactWriteItems",
+        )
 
     def query(
         self,
@@ -1179,6 +1239,50 @@ def test_expired_orphan_response_is_consumed_and_fences_stale_owner() -> None:
     assert repository.pop_pending_chat_response_if_unowned("s1") is None
     assert not repository.complete_processing("s1", lease.token, '"stale"').completed
     assert repository.get_buffer_state("s1").processing_lease is None
+
+
+@pytest.mark.asyncio
+async def test_recovered_processing_side_effects_are_idempotent() -> None:
+    from backend.app import message_buffer
+
+    table = FakeDynamoDBTable()
+    repository = DynamoDBStateRepository(table=table)
+    message_buffer.set_state_repository(repository)
+    try:
+        await message_buffer.add_to_buffer("s1", "work")
+        owned = await message_buffer.acquire_and_flush_buffer("s1")
+        assert owned is not None
+        generation_id = owned.generation_id
+        turn = ChatTurn(
+            question="work",
+            answer="ready",
+            timestamp=datetime.now(timezone.utc),
+            source_documents=[],
+        )
+        owner_fence = {"generation_id": generation_id, "lease_token": owned.lease.token}
+        repository.append_turn("s1", turn, **owner_fence)
+
+        successor = ProcessingLease(
+            token="successor",
+            expires_at=owned.lease.expires_at + timedelta(minutes=1),
+        )
+        assert repository.try_acquire_processing_lease(
+            "s1", now=owned.lease.expires_at, lease=successor
+        ).acquired
+        assert message_buffer.get_processing_generation("s1") == generation_id
+        totals = TokenTotals(input_tokens=2, output_tokens=3, total_tokens=5)
+        with pytest.raises(ClientError, match="TransactionCanceledException"):
+            repository.add_token_usage("s1", totals, **owner_fence)
+
+        successor_fence = owner_fence | {"lease_token": successor.token}
+        repository.append_turn("s1", turn, **successor_fence)
+        for _ in range(2):
+            repository.add_token_usage("s1", totals, **successor_fence)
+        state = repository.get_session("s1")
+        assert len(state.turns) == 1
+        assert state.token_totals == totals
+    finally:
+        message_buffer.set_state_repository(None)
 
 
 def test_processing_lease_dtos_reject_incoherent_or_mutable_state() -> None:

--- a/backend/tests/test_state_repository.py
+++ b/backend/tests/test_state_repository.py
@@ -6,9 +6,11 @@ from datetime import datetime, timedelta, timezone
 from numbers import Number
 import re
 from threading import Barrier, Event, RLock, Thread, current_thread
+from types import SimpleNamespace
 from typing import Any, Callable
 
 import pytest
+from boto3.dynamodb.types import TypeDeserializer
 from botocore.exceptions import ClientError
 from pydantic import ValidationError
 
@@ -28,7 +30,8 @@ class FakeDynamoDBTable:
 
     def __init__(self, query_page_size: int | None = None) -> None:
         self.name = "test-table"
-        self.transaction_client = self
+        self.meta = SimpleNamespace(client=self)
+        self.transaction_calls: list[list[dict[str, Any]]] = []
         self.items: dict[tuple[str, str], dict[str, Any]] = {}
         self.query_calls: list[dict[str, Any]] = []
         self.query_page_size = query_page_size
@@ -44,41 +47,40 @@ class FakeDynamoDBTable:
             self.items[(Item["PK"], Item["SK"])] = deepcopy(Item)
 
     def transact_write_items(self, TransactItems: list[dict[str, Any]]) -> None:
-        if len(TransactItems) != 2 or "ConditionCheck" not in TransactItems[0]:
-            raise ValueError("Unsupported processing transaction")
+        self.transaction_calls.append(deepcopy(TransactItems))
+        decoder = TypeDeserializer()
+
+        def decode(values: dict[str, Any]) -> dict[str, Any]:
+            return {key: decoder.deserialize(value) for key, value in values.items()}
+
         condition = TransactItems[0]["ConditionCheck"]
-        if condition != {
-            "TableName": self.name,
-            "Key": {"PK": condition["Key"]["PK"], "SK": "BUFFER"},
-            "ConditionExpression": "#lease_token = :token",
-            "ExpressionAttributeNames": {"#lease_token": "lease_token"},
-            "ExpressionAttributeValues": {
-                ":token": condition["ExpressionAttributeValues"][":token"]
-            },
-        }:
-            raise ValueError("Unsupported lease transaction condition")
+        assert condition["ConditionExpression"] == "#lease_token = :token"
         with self._lock:
-            buffer_key = condition["Key"]["PK"], "BUFFER"
-            token = condition["ExpressionAttributeValues"][":token"]
+            buffer_key = decode(condition["Key"])["PK"], "BUFFER"
+            token = decode(condition["ExpressionAttributeValues"])[":token"]
             if self.items.get(buffer_key, {}).get("lease_token") != token:
                 self._transaction_failure()
             operation, request = next(iter(TransactItems[1].items()))
-            if request["TableName"] != self.name:
-                raise ValueError("Unsupported transaction table")
-            key = request.get("Key") or {
-                field: request["Item"][field] for field in ("PK", "SK")
-            }
-            item_key = key["PK"], key["SK"]
+            assert condition["TableName"] == request["TableName"] == self.name
             if operation == "Put":
+                item = decode(request["Item"])
+                item_key = item["PK"], item["SK"]
                 if request.get("ConditionExpression") != "attribute_not_exists(PK)":
                     raise ValueError("Unsupported transactional put")
                 if item_key in self.items:
                     self._transaction_failure()
-                self.items[item_key] = deepcopy(request["Item"])
+                self.items[item_key] = item
                 return
             if operation != "Update":
                 raise ValueError("Unsupported processing transaction operation")
-            values = request["ExpressionAttributeValues"]
+            assert request["Key"]["SK"] == {"S": "TOKENS"}
+            assert "NOT contains" in request["ConditionExpression"]
+            names = request["ExpressionAttributeNames"]
+            assert names["#generations"] == "processing_generations"
+            assert request["ExpressionAttributeValues"][":generation_set"]["SS"]
+            key = decode(request["Key"])
+            item_key = key["PK"], key["SK"]
+            values = decode(request["ExpressionAttributeValues"])
             generation = values[":generation"]
             item = deepcopy(
                 self.items.get(item_key, {"PK": key["PK"], "SK": key["SK"]})
@@ -1242,46 +1244,55 @@ def test_expired_orphan_response_is_consumed_and_fences_stale_owner() -> None:
 
 
 @pytest.mark.asyncio
-async def test_recovered_processing_side_effects_are_idempotent() -> None:
+@pytest.mark.parametrize("durable", [False, True])
+async def test_recovered_processing_side_effects_are_idempotent(
+    durable: bool,
+) -> None:
     from backend.app import message_buffer
+    from backend.app.session import SessionManager
 
     table = FakeDynamoDBTable()
-    repository = DynamoDBStateRepository(table=table)
+    repository = DynamoDBStateRepository(table=table) if durable else None
+    manager = SessionManager(state_repository=repository)
     message_buffer.set_state_repository(repository)
     try:
         await message_buffer.add_to_buffer("s1", "work")
         owned = await message_buffer.acquire_and_flush_buffer("s1")
-        assert owned is not None
-        generation_id = owned.generation_id
-        turn = ChatTurn(
-            question="work",
-            answer="ready",
-            timestamp=datetime.now(timezone.utc),
-            source_documents=[],
-        )
-        owner_fence = {"generation_id": generation_id, "lease_token": owned.lease.token}
-        repository.append_turn("s1", turn, **owner_fence)
+
+        def persist(*, turn: bool, tokens: bool, **fence: str | None) -> None:
+            if turn:
+                manager.add_turn("s1", "work", "ready", **fence)
+            if tokens:
+                manager.add_token_usage("s1", 2, 3, 5, **fence)
+
+        owner_fence = {
+            "generation_id": owned.generation_id,
+            "lease_token": owned.lease.token,
+        }
+        persist(turn=True, tokens=False, **owner_fence)
 
         successor = ProcessingLease(
             token="successor",
             expires_at=owned.lease.expires_at + timedelta(minutes=1),
         )
-        assert repository.try_acquire_processing_lease(
-            "s1", now=owned.lease.expires_at, lease=successor
-        ).acquired
-        assert message_buffer.get_processing_generation("s1") == generation_id
-        totals = TokenTotals(input_tokens=2, output_tokens=3, total_tokens=5)
-        with pytest.raises(ClientError, match="TransactionCanceledException"):
-            repository.add_token_usage("s1", totals, **owner_fence)
+        if repository:
+            repository.try_acquire_processing_lease(
+                "s1", now=owned.lease.expires_at, lease=successor
+            )
+        else:
+            message_buffer.try_acquire_local_processing_lease(
+                "s1", now=owned.lease.expires_at, lease=successor
+            )
+        with pytest.raises(ClientError if durable else RuntimeError):
+            persist(turn=False, tokens=True, **owner_fence)
 
         successor_fence = owner_fence | {"lease_token": successor.token}
-        repository.append_turn("s1", turn, **successor_fence)
         for _ in range(2):
-            repository.add_token_usage("s1", totals, **successor_fence)
-        state = repository.get_session("s1")
-        assert len(state.turns) == 1
-        assert state.token_totals == totals
+            persist(turn=True, tokens=True, **successor_fence)
+        assert len(manager.get_history("s1")) == 1
+        assert manager.get_token_totals("s1").total_tokens == 5
     finally:
+        message_buffer.complete_processing("s1", "successor", None)
         message_buffer.set_state_repository(None)
 
 

--- a/backend/tests/test_state_repository.py
+++ b/backend/tests/test_state_repository.py
@@ -21,6 +21,7 @@ from backend.app.state_repository import (
     OwnershipConflictError,
     ProcessingLease,
     ProcessingLeaseResult,
+    StaleProcessingOwnershipError,
     TokenTotals,
 )
 
@@ -32,6 +33,7 @@ class FakeDynamoDBTable:
         self.name = "test-table"
         self.meta = SimpleNamespace(client=self)
         self.transaction_calls: list[list[dict[str, Any]]] = []
+        self.transaction_error_code: str | None = None
         self.items: dict[tuple[str, str], dict[str, Any]] = {}
         self.query_calls: list[dict[str, Any]] = []
         self.query_page_size = query_page_size
@@ -71,8 +73,6 @@ class FakeDynamoDBTable:
                     self._transaction_failure()
                 self.items[item_key] = item
                 return
-            if operation != "Update":
-                raise ValueError("Unsupported processing transaction operation")
             assert request["Key"]["SK"] == {"S": "TOKENS"}
             assert "NOT contains" in request["ConditionExpression"]
             names = request["ExpressionAttributeNames"]
@@ -96,12 +96,9 @@ class FakeDynamoDBTable:
             item["processing_generations"] = generations | values[":generation_set"]
             self.items[item_key] = item
 
-    @staticmethod
-    def _transaction_failure() -> None:
-        raise ClientError(
-            {"Error": {"Code": "TransactionCanceledException"}},
-            "TransactWriteItems",
-        )
+    def _transaction_failure(self) -> None:
+        code = self.transaction_error_code or "TransactionCanceledException"
+        raise ClientError({"Error": {"Code": code}}, "TransactWriteItems")
 
     def query(
         self,
@@ -1283,7 +1280,7 @@ async def test_recovered_processing_side_effects_are_idempotent(
             message_buffer.try_acquire_local_processing_lease(
                 "s1", now=owned.lease.expires_at, lease=successor
             )
-        with pytest.raises(ClientError if durable else RuntimeError):
+        with pytest.raises(StaleProcessingOwnershipError):
             persist(turn=False, tokens=True, **owner_fence)
 
         successor_fence = owner_fence | {"lease_token": successor.token}
@@ -1291,6 +1288,10 @@ async def test_recovered_processing_side_effects_are_idempotent(
             persist(turn=True, tokens=True, **successor_fence)
         assert len(manager.get_history("s1")) == 1
         assert manager.get_token_totals("s1").total_tokens == 5
+        if durable:
+            table.transaction_error_code = "ProvisionedThroughputExceededException"
+            with pytest.raises(ClientError):
+                persist(turn=False, tokens=True, **successor_fence)
     finally:
         message_buffer.complete_processing("s1", "successor", None)
         message_buffer.set_state_repository(None)

--- a/backend/tests/test_state_repository.py
+++ b/backend/tests/test_state_repository.py
@@ -32,14 +32,13 @@ class FakeDynamoDBTable:
     def __init__(self, query_page_size: int | None = None) -> None:
         self.name = "test-table"
         self.meta = SimpleNamespace(client=self)
-        self.transaction_calls: list[list[dict[str, Any]]] = []
-        self.transaction_error_code: str | None = None
+        self.transaction_failure: dict[str, Any] | None = None
         self.items: dict[tuple[str, str], dict[str, Any]] = {}
         self.query_calls: list[dict[str, Any]] = []
         self.query_page_size = query_page_size
         self._lock = RLock()
 
-    def get_item(self, Key: dict[str, str], **_: Any) -> dict[str, Any]:
+    def get_item(self, Key: dict[str, str]) -> dict[str, Any]:
         with self._lock:
             item = self.items.get((Key["PK"], Key["SK"]))
             return {"Item": deepcopy(item)} if item else {}
@@ -49,28 +48,28 @@ class FakeDynamoDBTable:
             self.items[(Item["PK"], Item["SK"])] = deepcopy(Item)
 
     def transact_write_items(self, TransactItems: list[dict[str, Any]]) -> None:
-        self.transaction_calls.append(deepcopy(TransactItems))
-        decoder = TypeDeserializer()
+        if self.transaction_failure:
+            raise ClientError(self.transaction_failure, "TransactWriteItems")
 
         def decode(values: dict[str, Any]) -> dict[str, Any]:
-            return {key: decoder.deserialize(value) for key, value in values.items()}
+            return {
+                key: TypeDeserializer().deserialize(value)
+                for key, value in values.items()
+            }
 
         condition = TransactItems[0]["ConditionCheck"]
         assert condition["ConditionExpression"] == "#lease_token = :token"
         with self._lock:
             buffer_key = decode(condition["Key"])["PK"], "BUFFER"
             token = decode(condition["ExpressionAttributeValues"])[":token"]
-            if self.items.get(buffer_key, {}).get("lease_token") != token:
-                self._transaction_failure()
+            lease_failed = self.items.get(buffer_key, {}).get("lease_token") != token
             operation, request = next(iter(TransactItems[1].items()))
             assert condition["TableName"] == request["TableName"] == self.name
             if operation == "Put":
                 item = decode(request["Item"])
                 item_key = item["PK"], item["SK"]
-                if request.get("ConditionExpression") != "attribute_not_exists(PK)":
-                    raise ValueError("Unsupported transactional put")
-                if item_key in self.items:
-                    self._transaction_failure()
+                assert request.get("ConditionExpression") == "attribute_not_exists(PK)"
+                self._transaction_failure(lease_failed, item_key in self.items)
                 self.items[item_key] = item
                 return
             assert request["Key"]["SK"] == {"S": "TOKENS"}
@@ -81,24 +80,33 @@ class FakeDynamoDBTable:
             key = decode(request["Key"])
             item_key = key["PK"], key["SK"]
             values = decode(request["ExpressionAttributeValues"])
-            generation = values[":generation"]
             item = deepcopy(
                 self.items.get(item_key, {"PK": key["PK"], "SK": key["SK"]})
             )
             generations = set(item.get("processing_generations", set()))
-            if generation in generations:
-                self._transaction_failure()
+            marker_failed = values[":generation"] in generations
+            self._transaction_failure(lease_failed, marker_failed)
             for field in ("input_tokens", "output_tokens", "total_tokens"):
-                item[field] = int(item.get(field, 0)) + int(
-                    values[f":{field.removesuffix('_tokens')}"]
-                )
+                source = f":{field.removesuffix('_tokens')}"
+                item[field] = int(item.get(field, 0)) + int(values[source])
             item["expires_at"] = values[":ttl"]
             item["processing_generations"] = generations | values[":generation_set"]
             self.items[item_key] = item
 
-    def _transaction_failure(self) -> None:
-        code = self.transaction_error_code or "TransactionCanceledException"
-        raise ClientError({"Error": {"Code": code}}, "TransactWriteItems")
+    def _transaction_failure(self, lease_failed: bool, marker_failed: bool) -> None:
+        if not lease_failed and not marker_failed:
+            return
+        reasons = [
+            {"Code": "ConditionalCheckFailed" if failed else "None"}
+            for failed in (lease_failed, marker_failed)
+        ]
+        raise ClientError(
+            {
+                "Error": {"Code": "TransactionCanceledException"},
+                "CancellationReasons": reasons,
+            },
+            "TransactWriteItems",
+        )
 
     def query(
         self,
@@ -1242,9 +1250,7 @@ def test_expired_orphan_response_is_consumed_and_fences_stale_owner() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("durable", [False, True])
-async def test_recovered_processing_side_effects_are_idempotent(
-    durable: bool,
-) -> None:
+async def test_processing_side_effect_cancellation_parity(durable: bool) -> None:
     from backend.app import message_buffer
     from backend.app.session import SessionManager
 
@@ -1256,42 +1262,41 @@ async def test_recovered_processing_side_effects_are_idempotent(
         await message_buffer.add_to_buffer("s1", "work")
         owned = await message_buffer.acquire_and_flush_buffer("s1")
 
-        def persist(*, turn: bool, tokens: bool, **fence: str | None) -> None:
-            if turn:
+        def persist(effect: str, **fence: str | None) -> None:
+            if effect != "tokens":
                 manager.add_turn("s1", "work", "ready", **fence)
-            if tokens:
+            if effect != "turn":
                 manager.add_token_usage("s1", 2, 3, 5, **fence)
 
         owner_fence = {
             "generation_id": owned.generation_id,
             "lease_token": owned.lease.token,
         }
-        persist(turn=True, tokens=False, **owner_fence)
-
-        successor = ProcessingLease(
-            token="successor",
-            expires_at=owned.lease.expires_at + timedelta(minutes=1),
-        )
-        if repository:
-            repository.try_acquire_processing_lease(
-                "s1", now=owned.lease.expires_at, lease=successor
-            )
-        else:
-            message_buffer.try_acquire_local_processing_lease(
-                "s1", now=owned.lease.expires_at, lease=successor
-            )
-        with pytest.raises(StaleProcessingOwnershipError):
-            persist(turn=False, tokens=True, **owner_fence)
+        persist("turn", **owner_fence)
+        successor = message_buffer.acquire_processing_lease(
+            "s1", now=owned.lease.expires_at, token="successor"
+        ).lease
+        for effect in ("turn", "tokens"):
+            with pytest.raises(StaleProcessingOwnershipError):
+                persist(effect, **owner_fence)
 
         successor_fence = owner_fence | {"lease_token": successor.token}
         for _ in range(2):
-            persist(turn=True, tokens=True, **successor_fence)
+            persist("both", **successor_fence)
         assert len(manager.get_history("s1")) == 1
         assert manager.get_token_totals("s1").total_tokens == 5
         if durable:
-            table.transaction_error_code = "ProvisionedThroughputExceededException"
+            failures = ("TransactionConflict", "ThrottlingError", "Unknown", 42, None)
+            for code in failures:
+                response = {"Error": {"Code": "TransactionCanceledException"}}
+                if code is not None:
+                    response["CancellationReasons"] = [{"Code": "None"}, {"Code": code}]
+                table.transaction_failure = response
+                with pytest.raises(ClientError):
+                    persist("tokens", **successor_fence)
+            table.transaction_failure = {"Error": {"Code": "InternalServerError"}}
             with pytest.raises(ClientError):
-                persist(turn=False, tokens=True, **successor_fence)
+                persist("tokens", **successor_fence)
     finally:
         message_buffer.complete_processing("s1", "successor", None)
         message_buffer.set_state_repository(None)


### PR DESCRIPTION
## ¿Qué hace este PR?

Introduce una generación estable por payload y hace idempotentes los turnos y el uso de tokens durante recuperación. Las transacciones DynamoDB y la implementación local rechazan dueños obsoletos con el mismo resultado de dominio y clasifican cancelaciones por razón ordenada.

## Issues relacionados

Closes #315
Part of #232

## Tipo de cambio

- [ ] 🆕 Nueva funcionalidad (feature)
- [x] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [ ] 🧪 Tests
- [ ] 📄 Documentación / configuración
- [ ] 🔧 Infra / CI

## Checklist antes de pedir review

- [x] El código corre localmente sin errores (`uvicorn` levanta, tests pasan)
- [x] Los criterios de aceptación del issue relacionado están cumplidos
- [x] No hay credenciales, API keys ni rutas absolutas hardcodeadas
- [x] Si agregué dependencias nuevas, actualicé `requirements.txt` / `pyproject.toml`
- [x] Si modifiqué el schema del endpoint, verifiqué que `/docs` refleja los cambios
- [x] Si modifiqué el harness o el dataset, corrí `python evaluation/harness.py` y el output es el esperado

## Cómo probar este PR

1. Ejecutar `uv run pytest -p no:cacheprovider backend/tests/test_state_repository.py backend/app/tests/test_message_buffer.py`.
2. Verificar retry parcial tras takeover, stale-owner rejection y clasificación de `CancellationReasons`.
3. Ejecutar `uv run pytest -p no:cacheprovider backend`.

## Notas para el reviewer

### Cadena de entrega

```text
main → #317/#311 → #318/#312 → #319/#313 → 📍 #315 side-effect idempotency
```

Depende de PR #319. Presupuesto de revisión: 400 líneas cambiadas contra `fix/buffer-result-ownership`. El guarantee cubre turnos y token usage locales/durables; llamadas externas a LLM/tools siguen siendo at-least-once. Rollback: revertir este work unit elimina generaciones e idempotencia sin alterar recovery/polling.