### PR TITLE
fix(ci): gate Lambda rollback after production promotion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -728,8 +728,19 @@ jobs:
     needs: [promote-lambda-production, verify-lambda-production]
     if: |
       always() && (
-        (failure() && github.ref == 'refs/heads/main' && vars.LAMBDA_CUTOVER_ENABLED == 'true') ||
-        (github.event_name == 'workflow_dispatch' && inputs.action == 'rollback-lambda')
+        (
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/main' &&
+          vars.LAMBDA_CUTOVER_ENABLED == 'true' &&
+          needs.promote-lambda-production.result == 'success' &&
+          needs.verify-lambda-production.result == 'failure' &&
+          needs.promote-lambda-production.outputs.previous-version != ''
+        ) ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          inputs.action == 'rollback-lambda' &&
+          inputs.rollback_target_version != ''
+        )
       )
     permissions:
       id-token: write
@@ -762,8 +773,8 @@ jobs:
       - name: Restore previous Lambda alias target
         run: |
           if [[ -z "${LAMBDA_ROLLBACK_TARGET_VERSION}" ]]; then
-            echo "No rollback target version was discovered. Provide workflow_dispatch rollback_target_version."
-            exit 1
+            echo "No rollback target version was discovered. Skipping rollback."
+            exit 0
           fi
           uv run python scripts/lambda_rollback.py rollback-alias \
             --aws-region "${AWS_REGION}" \

--- a/scripts/tests/test_workflow_deploy_checks.py
+++ b/scripts/tests/test_workflow_deploy_checks.py
@@ -14,6 +14,13 @@ from workflow_deploy_checks import check_workflow_deploy
 ROOT = Path(__file__).resolve().parents[2]
 DETERMINISTIC_GATE_FINDING = "deterministic test job must run all Python test roots offline with fake credentials"
 LAMBDA_GATE_FINDING = "lambda package job must depend on the deterministic test gate"
+ROLLBACK_GUARD_FINDING = (
+    "lambda rollback must require successful promotion, failed verification, and a "
+    "non-empty target"
+)
+ROLLBACK_TARGET_FINDING = (
+    "lambda rollback must skip safely when no target version exists"
+)
 
 
 def _findings() -> list[str]:
@@ -297,3 +304,56 @@ def test_lambda_production_cutover_is_lambda_only_and_promotes_same_package() ->
         "lambda rollback job must restore a discovered previous alias version"
         not in findings
     )
+
+
+def test_lambda_rollback_requires_completed_production_promotion_and_failed_smoke(
+) -> None:
+    """Pre-production failures must not trigger a production alias rollback."""
+    findings = _findings()
+
+    assert ROLLBACK_GUARD_FINDING not in findings
+
+
+@pytest.mark.parametrize(
+    ("old", "new"),
+    [
+        (
+            "needs.promote-lambda-production.result == 'success'",
+            "failure()",
+        ),
+        (
+            "needs.verify-lambda-production.result == 'failure'",
+            "needs.verify-lambda-production.result == 'skipped'",
+        ),
+        (
+            "needs.promote-lambda-production.outputs.previous-version != ''",
+            "needs.promote-lambda-production.outputs.previous-version == ''",
+        ),
+        (
+            "inputs.rollback_target_version != ''",
+            "inputs.rollback_target_version == ''",
+        ),
+    ],
+)
+def test_lambda_rollback_rejects_broader_activation_conditions(
+    tmp_path: Path, old: str, new: str
+) -> None:
+    """Rollback activation must remain bound to promotion, smoke, and target state."""
+    project_root = _mutated_project(tmp_path, old, new)
+
+    assert ROLLBACK_GUARD_FINDING in check_workflow_deploy(project_root)
+
+
+def test_lambda_rollback_without_target_does_not_fail_the_workflow(
+    tmp_path: Path,
+) -> None:
+    """A missing manual or unexpected rollback target must be a safe no-op."""
+    project_root = _mutated_project(
+        tmp_path,
+        'echo "No rollback target version was discovered. Skipping rollback."\n'
+        "            exit 0",
+        'echo "No rollback target version was discovered. Skipping rollback."\n'
+        "            exit 1",
+    )
+
+    assert ROLLBACK_TARGET_FINDING in check_workflow_deploy(project_root)

--- a/scripts/workflow_deploy_checks.py
+++ b/scripts/workflow_deploy_checks.py
@@ -467,6 +467,36 @@ def _check_lambda_delivery(
             "lambda rollback job must restore a discovered previous alias version"
         )
 
+    if (
+        not rollback_job
+        or not _contains_all(
+            rollback_job,
+            [
+                "always()",
+                "needs.promote-lambda-production.result == 'success'",
+                "needs.verify-lambda-production.result == 'failure'",
+                "needs.promote-lambda-production.outputs.previous-version != ''",
+                "github.event_name == 'push'",
+                "inputs.rollback_target_version != ''",
+            ],
+        )
+        or "failure()" in rollback_job
+    ):
+        findings.append(
+            "lambda rollback must require successful promotion, failed verification, and a non-empty target"
+        )
+
+    if not rollback_job or not _contains_all(
+        rollback_job,
+        [
+            "No rollback target version was discovered. Skipping rollback.",
+            "exit 0",
+        ],
+    ):
+        findings.append(
+            "lambda rollback must skip safely when no target version exists"
+        )
+
     return findings
 
 


### PR DESCRIPTION
## ¿Qué hace este PR?

- Restringe el rollback automático de Lambda a promociones exitosas cuya verificación de producción haya fallado y tenga una versión anterior disponible.
- Evita fallos secundarios cuando un rollback manual o inesperado no tiene una versión objetivo.
- Añade guardas estáticas y pruebas de mutación para impedir que reaparezca una condición global basada en `failure()`.

## Issues relacionados

Closes #221

## Tipo de cambio

- [ ] 🆕 Nueva funcionalidad (feature)
- [x] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [ ] 🧪 Tests
- [ ] 📄 Documentación / configuración
- [ ] 🔧 Infra / CI

## Cambios

| Archivo | Cambio |
|---|---|
| `.github/workflows/ci.yml` | Vincula el rollback automático a los resultados de promoción/verificación y trata un target vacío como no-op. |
| `scripts/workflow_deploy_checks.py` | Rechaza condiciones de rollback amplias o sin target. |
| `scripts/tests/test_workflow_deploy_checks.py` | Añade regresiones y mutaciones para los caminos automático, manual y sin target. |

## Checklist antes de pedir review

- [x] El código corre localmente sin errores (tests pasan)
- [x] Los criterios de aceptación del issue relacionado están cumplidos
- [x] No hay credenciales, API keys ni rutas absolutas hardcodeadas
- [x] No se agregaron dependencias
- [x] No se modificó el schema del endpoint
- [x] No se modificó el harness ni el dataset
- [x] El issue relacionado tiene `status:approved`
- [x] El commit usa formato convencional y no contiene atribución de IA

## Cómo probar este PR

1. Ejecutar `UV_CACHE_DIR=/tmp/uv-cache uv run pytest scripts/tests/test_workflow_deploy_checks.py -q`.
2. Confirmar que los 35 tests pasan.
3. Ejecutar `git diff --check origin/main...HEAD` y verificar que no reporte errores.

## Notas para el reviewer

El job conserva `always()` para poder evaluar resultados de dependencias fallidas, pero ya no usa `failure()`: exige explícitamente promoción exitosa, verificación fallida y target no vacío. El rollback manual exige un target explícito y el paso mantiene un no-op defensivo si el valor llegara vacío.