### PR TITLE
feat(ci): [#240] fail closed preview deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -802,7 +802,7 @@ jobs:
       state-key-prefix: ${{ steps.preview.outputs.state-key-prefix }}
       expiration-at: ${{ steps.preview.outputs.expiration-at }}
     env:
-      AWS_PREVIEW_DEPLOY_ROLE_ARN: ${{ secrets.AWS_PREVIEW_DEPLOY_ROLE_ARN || secrets.AWS_DEPLOY_ROLE_ARN }}
+      AWS_PREVIEW_DEPLOY_ROLE_ARN: ${{ secrets.AWS_PREVIEW_DEPLOY_ROLE_ARN }}
       TF_PREVIEW_STATE_BUCKET: ${{ vars.TF_PREVIEW_STATE_BUCKET || 'arte-chatbot-terraform-state' }}
       TF_PREVIEW_STATE_PREFIX: ${{ vars.TF_PREVIEW_STATE_PREFIX || 'lambda-previews' }}
       TF_VAR_pr_number: ${{ github.event.pull_request.number }}
@@ -814,6 +814,8 @@ jobs:
       TF_VAR_backend_runtime_secret_arns: ${{ secrets.LAMBDA_PREVIEW_RUNTIME_SECRET_ARNS_JSON || '{}' }}
       TF_VAR_backend_runtime_environment_variables: ${{ vars.LAMBDA_PREVIEW_RUNTIME_ENV_JSON || '{}' }}
       TF_VAR_kms_key_arns: ${{ secrets.LAMBDA_PREVIEW_KMS_KEY_ARNS_JSON || '[]' }}
+      TF_VAR_lambda_permissions_boundary_arn: ${{ vars.LAMBDA_PREVIEW_PERMISSIONS_BOUNDARY_ARN }}
+      TF_VAR_lambda_execution_role_arn: ${{ vars.LAMBDA_PREVIEW_EXECUTION_ROLE_ARN }}
       TF_VAR_allowed_cors_origins: ${{ vars.LAMBDA_PREVIEW_ALLOWED_CORS_ORIGINS || '*' }}
     steps:
       - name: Checkout code
@@ -836,6 +838,8 @@ jobs:
               "AWS_PREVIEW_DEPLOY_ROLE_ARN",
               "TF_PREVIEW_STATE_BUCKET",
               "TF_VAR_aws_bucket_name",
+              "TF_VAR_lambda_permissions_boundary_arn",
+              "TF_VAR_lambda_execution_role_arn",
           ]
           missing = [name for name in required if not os.environ.get(name)]
           if missing:
@@ -923,6 +927,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    env:
+      AWS_PREVIEW_DEPLOY_ROLE_ARN: ${{ secrets.AWS_PREVIEW_DEPLOY_ROLE_ARN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -938,10 +944,17 @@ jobs:
       - name: Install smoke dependencies
         run: uv sync --frozen --group dev
 
+      - name: Verify preview smoke configuration
+        run: |
+          if [[ -z "${AWS_PREVIEW_DEPLOY_ROLE_ARN:-}" ]]; then
+            echo "Missing required Lambda preview smoke configuration: AWS_PREVIEW_DEPLOY_ROLE_ARN"
+            exit 1
+          fi
+
       - name: Configure AWS credentials through OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_PREVIEW_DEPLOY_ROLE_ARN || secrets.AWS_DEPLOY_ROLE_ARN }}
+          role-to-assume: ${{ env.AWS_PREVIEW_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Resolve preview chat API key from runtime secret ARN

--- a/.github/workflows/lambda-preview-cleanup.yml
+++ b/.github/workflows/lambda-preview-cleanup.yml
@@ -24,7 +24,7 @@ jobs:
       contents: read
       pull-requests: write
     env:
-      AWS_PREVIEW_DEPLOY_ROLE_ARN: ${{ secrets.AWS_PREVIEW_DEPLOY_ROLE_ARN || secrets.AWS_DEPLOY_ROLE_ARN }}
+      AWS_PREVIEW_DEPLOY_ROLE_ARN: ${{ secrets.AWS_PREVIEW_DEPLOY_ROLE_ARN }}
       TF_VAR_pr_number: ${{ github.event.pull_request.number }}
       TF_VAR_pr_sha: ${{ github.event.pull_request.head.sha }}
       TF_VAR_pr_head_ref: ${{ github.event.pull_request.head.ref }}
@@ -34,6 +34,8 @@ jobs:
       TF_VAR_backend_runtime_secret_arns: ${{ secrets.LAMBDA_PREVIEW_RUNTIME_SECRET_ARNS_JSON || '{}' }}
       TF_VAR_backend_runtime_environment_variables: ${{ vars.LAMBDA_PREVIEW_RUNTIME_ENV_JSON || '{}' }}
       TF_VAR_kms_key_arns: ${{ secrets.LAMBDA_PREVIEW_KMS_KEY_ARNS_JSON || '[]' }}
+      TF_VAR_lambda_permissions_boundary_arn: ${{ vars.LAMBDA_PREVIEW_PERMISSIONS_BOUNDARY_ARN }}
+      TF_VAR_lambda_execution_role_arn: ${{ vars.LAMBDA_PREVIEW_EXECUTION_ROLE_ARN }}
       TF_VAR_allowed_cors_origins: ${{ vars.LAMBDA_PREVIEW_ALLOWED_CORS_ORIGINS || '*' }}
       TF_VAR_expiration_at: "1970-01-01T00:00:00Z"
     steps:
@@ -43,7 +45,7 @@ jobs:
       - name: Verify cleanup configuration
         run: |
           missing=()
-          for name in AWS_PREVIEW_DEPLOY_ROLE_ARN TF_PREVIEW_STATE_BUCKET TF_VAR_aws_bucket_name; do
+          for name in AWS_PREVIEW_DEPLOY_ROLE_ARN TF_PREVIEW_STATE_BUCKET TF_VAR_aws_bucket_name TF_VAR_lambda_permissions_boundary_arn TF_VAR_lambda_execution_role_arn; do
             if [[ -z "${!name:-}" ]]; then
               missing+=("${name}")
             fi

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -56,6 +56,8 @@ GitHub Variables are non-sensitive values used by `.github/workflows/ci.yml`.
 | `LAMBDA_STAGING_IAM_DENIED_DYNAMODB_TABLE_NAME` | GitHub Variable | `<denied-table-name>` | Resource expected to fail the IAM-denied staging probe. |
 | `LAMBDA_STAGING_SMOKE_CHAT_MESSAGE` | GitHub Variable | `Validación staging: ...` | Optional staging smoke prompt. |
 | `LAMBDA_PREVIEW_ENABLED` | GitHub Variable | `true` | Enables per-PR Lambda previews for same-repository PRs. |
+| `LAMBDA_PREVIEW_PERMISSIONS_BOUNDARY_ARN` | GitHub Variable | `arn:aws:iam::521170872319:policy/arte-chatbot-preview-lambda-boundary` | Foundation-managed permissions boundary that caps the shared preview Lambda runtime role. Preview deploy and cleanup fail closed when it is missing. |
+| `LAMBDA_PREVIEW_EXECUTION_ROLE_ARN` | GitHub Variable | `arn:aws:iam::521170872319:role/arte-chatbot-preview-lambda-runtime` | Foundation-managed Lambda execution role. The preview deploy role may pass only this role to Lambda. |
 | `TF_PREVIEW_STATE_BUCKET` | GitHub Variable | `arte-chatbot-terraform-state` | S3 bucket used by the preview Terraform backend. Defaults to this value in workflows. |
 | `TF_PREVIEW_STATE_PREFIX` | GitHub Variable | `lambda-previews` | S3 key prefix for per-PR Terraform state, producing keys like `lambda-previews/pr-220/terraform.tfstate`. |
 | `LAMBDA_PREVIEW_RUNTIME_ENV_JSON` | GitHub Variable | `{"LOG_LEVEL":"INFO"}` | Optional non-sensitive preview runtime environment variables. |
@@ -73,8 +75,8 @@ GitHub Secrets are sensitive values used by workflow jobs. They are not read by 
 |---|---|---|---|
 | `AWS_CI_ROLE_ARN` | GitHub Secret | `arn:aws:iam::521170872319:role/<ci-role>` | OIDC role used by CI jobs that need AWS access. |
 | `AWS_DEPLOY_ROLE_ARN` | GitHub Secret | `arn:aws:iam::521170872319:role/<deploy-role>` | OIDC role used by staging/prod Lambda deploy jobs. |
-| `AWS_PREVIEW_DEPLOY_ROLE_ARN` | GitHub Secret | `arn:aws:iam::521170872319:role/<preview-deploy-role>` | OIDC role used to apply/destroy per-PR preview Terraform. Falls back to `AWS_DEPLOY_ROLE_ARN` if omitted. |
-| `LAMBDA_PREVIEW_RUNTIME_SECRET_ARNS_JSON` | GitHub Secret | `{"OPENAI_API_KEY":"arn:...","CHAT_API_KEY":"arn:..."}` | SSM/Secrets Manager ARNs injected into preview Lambda as secret refs. The preview smoke job resolves the same `CHAT_API_KEY` ARN through AWS CLI, masks the value, and uses it for `/chat` and evaluation. Preview-scoped ARNs are preferred, but shared runtime ARNs are allowed while bootstrapping previews. |
+| `AWS_PREVIEW_DEPLOY_ROLE_ARN` | GitHub Secret | `arn:aws:iam::521170872319:role/arte-chatbot-preview-github-deploy` | Dedicated OIDC role used to apply/destroy per-PR preview Terraform and run preview smoke checks. It is required; preview workflows never fall back to `AWS_DEPLOY_ROLE_ARN`. |
+| `LAMBDA_PREVIEW_RUNTIME_SECRET_ARNS_JSON` | GitHub Secret | `{"OPENAI_API_KEY":"arn:...:parameter/arte-chatbot/pr-preview/OPENAI_API_KEY","CHAT_API_KEY":"arn:...:secret:/arte-chatbot/pr-preview/CHAT_API_KEY-..."}` | Preview-only SSM/Secrets Manager ARNs injected as secret refs. Both Terraform validation and the foundation-managed AWS boundary restrict access to `/arte-chatbot/pr-preview/`; production runtime secret ARNs are rejected and cannot be read by the preview Lambda role. |
 | `LAMBDA_PREVIEW_KMS_KEY_ARNS_JSON` | GitHub Secret | `["arn:aws:kms:..."]` | Optional KMS keys needed to decrypt preview runtime secret refs. Use `[]` or omit it when no custom KMS key is needed. |
 | `OPENAI_API_KEY` | GitHub Secret | `<openai-api-key>` | CI/evaluation plaintext credential. Lambda production runtime should use AWS SSM/Secrets Manager instead. |
 | `CHAT_API_KEY` | GitHub Secret | `<chat-api-key>` | Plaintext API key used by production smoke checks. Do not put the Secrets Manager ARN here. |

--- a/infra/terraform/envs/pr-preview/main.tf
+++ b/infra/terraform/envs/pr-preview/main.tf
@@ -16,6 +16,10 @@ locals {
   }
 }
 
+data "aws_iam_role" "preview_lambda_execution" {
+  name = element(reverse(split("/", var.lambda_execution_role_arn)), 0)
+}
+
 resource "terraform_data" "preview_guard" {
   input = local.preview_id
 
@@ -28,6 +32,16 @@ resource "terraform_data" "preview_guard" {
     precondition {
       condition     = local.preview_id == "pr-${var.pr_number}"
       error_message = "PR preview ids must be derived from the pull request number."
+    }
+
+    precondition {
+      condition     = data.aws_iam_role.preview_lambda_execution.arn == var.lambda_execution_role_arn
+      error_message = "The configured preview Lambda execution role ARN does not resolve to the expected role."
+    }
+
+    precondition {
+      condition     = data.aws_iam_role.preview_lambda_execution.permissions_boundary == var.lambda_permissions_boundary_arn
+      error_message = "The preview Lambda execution role must retain the foundation-managed permissions boundary."
     }
   }
 }
@@ -67,8 +81,10 @@ module "lambda_backend" {
       GIT_SHA             = var.pr_sha
     },
   )
-  runtime_secret_arns = var.backend_runtime_secret_arns
-  kms_key_arns        = var.kms_key_arns
+  runtime_secret_arns      = var.backend_runtime_secret_arns
+  kms_key_arns             = var.kms_key_arns
+  permissions_boundary_arn = var.lambda_permissions_boundary_arn
+  execution_role_arn       = var.lambda_execution_role_arn
 
   tags = merge(local.common_tags, { Service = "lambda-backend" })
 

--- a/infra/terraform/envs/pr-preview/variables.tf
+++ b/infra/terraform/envs/pr-preview/variables.tf
@@ -61,15 +61,38 @@ variable "aws_bucket_name" {
 }
 
 variable "backend_runtime_secret_arns" {
-  description = "Preview app secret ARNs, such as OPENAI_API_KEY and CHAT_API_KEY. Prefer preview-scoped secrets; shared ARNs are allowed for temporary smoke validation."
+  description = "Preview app secret ARNs, such as OPENAI_API_KEY and CHAT_API_KEY. Every ARN must use the /arte-chatbot/pr-preview/ namespace enforced by the execution-role boundary."
   type        = map(string)
   default     = {}
 
   validation {
     condition = alltrue([
-      for arn in values(var.backend_runtime_secret_arns) : startswith(arn, "arn:")
+      for arn in values(var.backend_runtime_secret_arns) : (
+        startswith(arn, "arn:") &&
+        strcontains(lower(arn), "/arte-chatbot/pr-preview/")
+      )
     ])
-    error_message = "Preview secret refs must be AWS ARNs, not plaintext secret values."
+    error_message = "Preview secret refs must be AWS ARNs in the /arte-chatbot/pr-preview/ namespace."
+  }
+}
+
+variable "lambda_permissions_boundary_arn" {
+  description = "Foundation-managed permissions boundary ARN required on every preview Lambda execution role."
+  type        = string
+
+  validation {
+    condition     = startswith(var.lambda_permissions_boundary_arn, "arn:aws:iam::")
+    error_message = "lambda_permissions_boundary_arn must be an IAM policy ARN."
+  }
+}
+
+variable "lambda_execution_role_arn" {
+  description = "Foundation-managed execution role ARN shared by PR preview Lambdas."
+  type        = string
+
+  validation {
+    condition     = startswith(var.lambda_execution_role_arn, "arn:aws:iam::")
+    error_message = "lambda_execution_role_arn must be an IAM role ARN."
   }
 }
 

--- a/infra/terraform/modules/lambda_backend/main.tf
+++ b/infra/terraform/modules/lambda_backend/main.tf
@@ -46,6 +46,8 @@ locals {
     local.secret_reference_environment_variables,
     local.sanitized_runtime_environment_variables,
   )
+
+  execution_role_arn = var.execution_role_arn != null ? var.execution_role_arn : aws_iam_role.lambda[0].arn
 }
 
 data "aws_partition" "current" {}
@@ -105,9 +107,12 @@ data "aws_iam_policy_document" "assume_lambda" {
 }
 
 resource "aws_iam_role" "lambda" {
-  name               = var.name
-  assume_role_policy = data.aws_iam_policy_document.assume_lambda.json
-  tags               = merge(var.tags, { Service = "lambda-backend" })
+  count = var.execution_role_arn == null ? 1 : 0
+
+  name                 = var.name
+  assume_role_policy   = data.aws_iam_policy_document.assume_lambda.json
+  permissions_boundary = var.permissions_boundary_arn
+  tags                 = merge(var.tags, { Service = "lambda-backend" })
 }
 
 data "aws_iam_policy_document" "lambda_runtime" {
@@ -179,14 +184,16 @@ data "aws_iam_policy_document" "lambda_runtime" {
 }
 
 resource "aws_iam_role_policy" "lambda_runtime" {
+  count = var.execution_role_arn == null ? 1 : 0
+
   name   = "${var.name}-runtime"
-  role   = aws_iam_role.lambda.id
+  role   = aws_iam_role.lambda[0].id
   policy = data.aws_iam_policy_document.lambda_runtime.json
 }
 
 resource "aws_lambda_function" "this" {
   function_name = var.name
-  role          = aws_iam_role.lambda.arn
+  role          = local.execution_role_arn
   handler       = var.handler
   runtime       = var.runtime
   filename      = var.lambda_package_path

--- a/infra/terraform/modules/lambda_backend/outputs.tf
+++ b/infra/terraform/modules/lambda_backend/outputs.tf
@@ -25,7 +25,7 @@ output "published_version" {
 
 output "role_arn" {
   description = "Lambda execution role ARN."
-  value       = aws_iam_role.lambda.arn
+  value       = local.execution_role_arn
 }
 
 output "state_table_name" {

--- a/infra/terraform/modules/lambda_backend/variables.tf
+++ b/infra/terraform/modules/lambda_backend/variables.tf
@@ -136,6 +136,28 @@ variable "kms_key_arns" {
   default     = []
 }
 
+variable "permissions_boundary_arn" {
+  description = "Optional IAM permissions boundary attached to the Lambda execution role. Preview environments must supply the foundation-managed preview boundary."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.permissions_boundary_arn == null || startswith(var.permissions_boundary_arn, "arn:")
+    error_message = "permissions_boundary_arn must be an AWS ARN when provided."
+  }
+}
+
+variable "execution_role_arn" {
+  description = "Optional pre-existing Lambda execution role ARN. When set, this module does not create or manage an IAM role or runtime policy."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.execution_role_arn == null || startswith(var.execution_role_arn, "arn:aws:iam::")
+    error_message = "execution_role_arn must be an IAM role ARN when provided."
+  }
+}
+
 variable "access_log_retention_days" {
   description = "CloudWatch log retention days for Lambda and API Gateway access logs."
   type        = number

--- a/scripts/terraform_foundation_checks.py
+++ b/scripts/terraform_foundation_checks.py
@@ -157,6 +157,8 @@ def _check_pr_preview_lambda(
             'SECRET_NAMESPACE    = "/arte-chatbot/pr-preview/${local.preview_id}/"',
             "CLEANUP_AFTER",
             "PULL_REQUEST_NUMBER",
+            "permissions_boundary_arn = var.lambda_permissions_boundary_arn",
+            "execution_role_arn       = var.lambda_execution_role_arn",
         ],
     ):
         findings.append(
@@ -176,7 +178,7 @@ def _check_pr_preview_lambda(
             'variable "pr_sha"',
             'variable "expiration_at"',
             'default     = "arte-chatbot-preview"',
-            "Preview secret refs must be AWS ARNs, not plaintext secret values.",
+            "Preview secret refs must be AWS ARNs in the /arte-chatbot/pr-preview/ namespace.",
             "default     = 259200",
         ],
     ):
@@ -359,6 +361,19 @@ def _check_lambda_backend_module(
     ):
         findings.append(
             "lambda_backend runtime_secret_arns must reject plaintext secret values"
+        )
+
+    if not _contains_all(
+        lambda_main + lambda_variables,
+        [
+            'variable "execution_role_arn"',
+            "var.execution_role_arn == null ? 1 : 0",
+            "var.execution_role_arn != null ? var.execution_role_arn",
+            "permissions_boundary = var.permissions_boundary_arn",
+        ],
+    ):
+        findings.append(
+            "lambda_backend must support a foundation-managed bounded execution role"
         )
 
     if 'default     = "python3.12"' not in _variable_block(lambda_variables, "runtime"):

--- a/scripts/tests/test_terraform_foundation.py
+++ b/scripts/tests/test_terraform_foundation.py
@@ -107,6 +107,10 @@ def test_lambda_backend_uses_role_credentials_without_vpc_or_static_keys() -> No
         not in findings
     )
     assert (
+        "lambda_backend must support a foundation-managed bounded execution role"
+        not in findings
+    )
+    assert (
         "lambda_backend runtime must be python3.12 for package compatibility"
         not in findings
     )

--- a/scripts/tests/test_workflow_deploy_checks.py
+++ b/scripts/tests/test_workflow_deploy_checks.py
@@ -47,6 +47,18 @@ def _mutated_project(tmp_path: Path, old: str, new: str) -> Path:
     return tmp_path
 
 
+def _mutated_checked_file(
+    tmp_path: Path, relative_path: Path, old: str, new: str
+) -> Path:
+    """Copy checked inputs and mutate one workflow file."""
+    project_root = _mutated_project(tmp_path, "name: CI", "name: CI")
+    path = project_root / relative_path
+    content = path.read_text(encoding="utf-8")
+    assert old in content, f"mutation target is missing: {old}"
+    path.write_text(content.replace(old, new, 1), encoding="utf-8")
+    return project_root
+
+
 def test_workflow_keeps_production_lambda_deploys_on_main_after_gates() -> None:
     """PRs must not deploy; production Lambda waits for package and cutover gates."""
     findings = _findings()
@@ -286,6 +298,41 @@ def test_lambda_pr_preview_deploys_smokes_comments_and_cleans_up() -> None:
     assert (
         "lambda PR preview cleanup must destroy Terraform state on PR close"
         not in findings
+    )
+    assert (
+        "lambda PR preview workflows must fail closed without the dedicated preview deploy role"
+        not in findings
+    )
+
+
+def test_lambda_preview_rejects_production_role_fallback(tmp_path: Path) -> None:
+    """Preview jobs must never fall back to the production deployment role."""
+    project_root = _mutated_project(
+        tmp_path,
+        "AWS_PREVIEW_DEPLOY_ROLE_ARN: ${{ secrets.AWS_PREVIEW_DEPLOY_ROLE_ARN }}",
+        "AWS_PREVIEW_DEPLOY_ROLE_ARN: ${{ secrets.AWS_PREVIEW_DEPLOY_ROLE_ARN || secrets.AWS_DEPLOY_ROLE_ARN }}",
+    )
+
+    assert (
+        "lambda PR preview workflows must fail closed without the dedicated preview deploy role"
+        in check_workflow_deploy(project_root)
+    )
+
+
+def test_lambda_preview_cleanup_rejects_production_role_fallback(
+    tmp_path: Path,
+) -> None:
+    """Cleanup must fail closed rather than assume the production role."""
+    project_root = _mutated_checked_file(
+        tmp_path,
+        Path(".github/workflows/lambda-preview-cleanup.yml"),
+        "AWS_PREVIEW_DEPLOY_ROLE_ARN: ${{ secrets.AWS_PREVIEW_DEPLOY_ROLE_ARN }}",
+        "AWS_PREVIEW_DEPLOY_ROLE_ARN: ${{ secrets.AWS_PREVIEW_DEPLOY_ROLE_ARN || secrets.AWS_DEPLOY_ROLE_ARN }}",
+    )
+
+    assert (
+        "lambda PR preview workflows must fail closed without the dedicated preview deploy role"
+        in check_workflow_deploy(project_root)
     )
 
 

--- a/scripts/workflow_deploy_checks.py
+++ b/scripts/workflow_deploy_checks.py
@@ -176,6 +176,28 @@ def _check_lambda_preview_delivery(
 ) -> list[str]:
     findings: list[str] = []
 
+    preview_workflows = "\n".join(
+        [preview_deploy_job, preview_smoke_job, preview_cleanup_workflow]
+    )
+    if (
+        "secrets.AWS_PREVIEW_DEPLOY_ROLE_ARN ||" in preview_workflows
+        or "AWS_PREVIEW_DEPLOY_ROLE_ARN: ${{ secrets.AWS_PREVIEW_DEPLOY_ROLE_ARN }}"
+        not in preview_deploy_job
+        or "AWS_PREVIEW_DEPLOY_ROLE_ARN: ${{ secrets.AWS_PREVIEW_DEPLOY_ROLE_ARN }}"
+        not in preview_smoke_job
+        or "AWS_PREVIEW_DEPLOY_ROLE_ARN: ${{ secrets.AWS_PREVIEW_DEPLOY_ROLE_ARN }}"
+        not in preview_cleanup_workflow
+        or "Missing required Lambda preview deploy configuration"
+        not in preview_deploy_job
+        or "Missing required Lambda preview smoke configuration"
+        not in preview_smoke_job
+        or "Missing required Lambda preview cleanup configuration"
+        not in preview_cleanup_workflow
+    ):
+        findings.append(
+            "lambda PR preview workflows must fail closed without the dedicated preview deploy role"
+        )
+
     if not preview_deploy_job or not _contains_all(
         preview_deploy_job,
         [
@@ -195,6 +217,8 @@ def _check_lambda_preview_delivery(
             "TF_VAR_pr_number",
             "TF_VAR_backend_runtime_secret_arns: ${{ secrets.LAMBDA_PREVIEW_RUNTIME_SECRET_ARNS_JSON || '{}' }}",
             "TF_VAR_kms_key_arns: ${{ secrets.LAMBDA_PREVIEW_KMS_KEY_ARNS_JSON || '[]' }}",
+            "TF_VAR_lambda_permissions_boundary_arn: ${{ vars.LAMBDA_PREVIEW_PERMISSIONS_BOUNDARY_ARN }}",
+            "TF_VAR_lambda_execution_role_arn: ${{ vars.LAMBDA_PREVIEW_EXECUTION_ROLE_ARN }}",
         ],
     ):
         findings.append(


### PR DESCRIPTION
## ¿Qué hace este PR?

- Elimina los fallbacks desde los workflows preview hacia el rol de despliegue productivo.
- Hace que deploy, smoke y cleanup fallen de forma cerrada cuando falta la configuración preview.
- Conecta el entorno Terraform preview con el rol de ejecución y la permissions boundary administrados por la foundation.

## Issues relacionados

Closes #240

## Tipo de cambio

- [x] 🆕 Nueva funcionalidad (feature)
- [ ] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [ ] 🧪 Tests
- [ ] 📄 Documentación / configuración
- [ ] 🔧 Infra / CI

## Checklist antes de pedir review

- [x] El código corre localmente sin errores y los tests focales pasan
- [x] Los criterios de aceptación están cubiertos por la cadena completa
- [x] No hay credenciales, API keys ni rutas absolutas hardcodeadas
- [x] No se agregaron dependencias
- [x] No se modificó el schema del endpoint
- [x] No se modificó el harness ni el dataset
- [x] No hay scripts `.sh` modificados; ShellCheck no aplica
- [x] El commit usa Conventional Commits y no contiene `Co-Authored-By`

## Cómo probar este PR

1. `UV_CACHE_DIR=/tmp/uv-cache uv run --group lint ruff format --check scripts/terraform_foundation_checks.py scripts/workflow_deploy_checks.py scripts/tests/test_terraform_foundation.py scripts/tests/test_workflow_deploy_checks.py`
2. `UV_CACHE_DIR=/tmp/uv-cache uv run pytest scripts/tests/test_terraform_foundation.py scripts/tests/test_workflow_deploy_checks.py`
3. `terraform fmt -check -recursive infra/terraform && terraform -chdir=infra/terraform/envs/prod validate && terraform -chdir=infra/terraform/envs/pr-preview validate`

## Prerrequisito de entrega

Después de integrar #324 y #325, aplicar o importar la foundation desde un contexto confiable y configurar estas variables de repositorio con sus outputs:

- `LAMBDA_PREVIEW_PERMISSIONS_BOUNDARY_ARN`
- `LAMBDA_PREVIEW_EXECUTION_ROLE_ARN`

El workflow falla cerrado de forma intencional mientras falte cualquiera de ellas.

## Notas para el reviewer

La validación de ARNs dentro del Terraform del PR es defensa adicional, no la frontera principal. La protección efectiva vive en la permissions boundary administrada por la foundation.

## Chain Context

| Field | Value |
|-------|-------|
| Chain | Issue #240 — AWS preview authority isolation |
| Tracker PR | Not needed |
| Position | 3 of 3 |
| Base | `feat/preview-deploy-policy` |
| Depends on | #327 |
| Follow-up | None |
| Review budget | 211 / 400 changed lines |
| Starts at | PR #325 least-privilege preview deploy authority |
| Ends with | Preview consumers fail closed and no longer reference production deploy authority |

### Chain Overview

```text
main
 └── #326 PR 1 — runtime boundary
      └── #327 PR 2 — deploy policy
           └── 📍 #323 PR 3 — fail-closed consumers
```

### Scope

- Includes: workflows fail-closed, preview runtime wiring, static checks, tests and consumer documentation.
- Excludes: API key rotation, GitHub organization redesign, unrelated AWS resources and Lambda ownership changes.

### Autonomy

- [x] CI is expected to pass after the documented foundation outputs are configured
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests and documentation cover this unit
