### PR TITLE
feat(iam): [#240] restrict preview deployment authority

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -170,6 +170,31 @@ The PR preview path creates one isolated Lambda/API Gateway/DynamoDB stack per s
 
 Preview resources are tagged with `Environment=pr-preview`, `PreviewId=pr-<number>`, `PullRequest=<number>`, `ExpiresAt`, and `CleanupAfter`. These tags are the orphan-resource guardrail if a workflow is cancelled before cleanup.
 
+### Provision preview AWS authority
+
+The production Terraform root owns one GitHub OIDC provider and creates two roles with non-overlapping trust subjects:
+
+| Role | GitHub `sub` | Authority |
+|---|---|---|
+| Production deploy | `repo:<owner>/arte-chatbot:ref:refs/heads/main` | Existing production promotion permissions only; it cannot create preview Lambda, DynamoDB, API Gateway, or IAM resources. |
+| Preview deploy | `repo:<owner>/arte-chatbot:pull_request` | Preview-prefixed infrastructure, isolated Terraform state, preview-scoped runtime secrets, and `iam:PassRole` for the single foundation-managed preview execution role. |
+
+Set `create_github_oidc_role=true` and apply `infra/terraform/envs/prod` from a trusted operator context. Then copy these outputs into GitHub configuration:
+
+1. `github_preview_deploy_role_arn` → secret `AWS_PREVIEW_DEPLOY_ROLE_ARN`.
+2. `preview_lambda_permissions_boundary_arn` → variable `LAMBDA_PREVIEW_PERMISSIONS_BOUNDARY_ARN`.
+3. `preview_lambda_execution_role_arn` → variable `LAMBDA_PREVIEW_EXECUTION_ROLE_ARN`.
+
+If `arte-chatbot-preview-github-deploy` already exists, import it before planning so Terraform adopts rather than recreates it:
+
+```bash
+terraform -chdir=infra/terraform/envs/prod import \
+  'module.github_oidc[0].aws_iam_role.preview' \
+  arte-chatbot-preview-github-deploy
+```
+
+The preview Lambda execution role and its boundary live in the trusted production foundation. Pull-request Terraform only receives their ARNs: it cannot modify either resource. The boundary permits preview-prefixed DynamoDB/log resources, catalog reads, and only SSM/Secrets Manager paths under `/arte-chatbot/pr-preview/`. This remains effective even if a pull request attempts to broaden its generated inline policy.
+
 Previews intentionally use direct API Gateway URLs first. DNS per PR is a later enhancement and is not required for this scope.
 
 ## Multi-message buffering on Lambda

--- a/infra/terraform/envs/prod/main.tf
+++ b/infra/terraform/envs/prod/main.tf
@@ -155,6 +155,8 @@ module "github_oidc" {
   preview_role_name = var.github_preview_role_name
 
   preview_resource_prefix      = "arte-chatbot-preview"
+  preview_state_bucket_name    = var.preview_state_bucket_name
+  preview_state_key_prefix     = var.preview_state_key_prefix
   preview_catalog_bucket_names = [var.aws_bucket_name]
   preview_kms_key_arns         = var.preview_kms_key_arns
 

--- a/infra/terraform/envs/prod/variables.tf
+++ b/infra/terraform/envs/prod/variables.tf
@@ -145,7 +145,17 @@ variable "github_preview_role_name" {
   default     = "arte-chatbot-preview-github-deploy"
 }
 
+variable "preview_state_bucket_name" {
+  description = "S3 bucket containing isolated pull-request preview Terraform state."
+  type        = string
+  default     = "arte-chatbot-terraform-state"
+}
 
+variable "preview_state_key_prefix" {
+  description = "S3 key prefix containing isolated pull-request preview Terraform states."
+  type        = string
+  default     = "lambda-previews"
+}
 
 variable "preview_kms_key_arns" {
   description = "Optional KMS keys used only for preview-scoped runtime secrets."

--- a/infra/terraform/modules/github_oidc/main.tf
+++ b/infra/terraform/modules/github_oidc/main.tf
@@ -108,89 +108,59 @@ data "aws_iam_policy_document" "deploy" {
     actions   = ["ecr:GetAuthorizationToken"]
     resources = ["*"]
   }
-
   statement {
     sid = "EcrPromotion"
     actions = [
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:BatchGetImage",
-      "ecr:CompleteLayerUpload",
-      "ecr:DescribeImages",
-      "ecr:DescribeRepositories",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:InitiateLayerUpload",
-      "ecr:PutImage",
-      "ecr:UploadLayerPart",
+      "ecr:BatchCheckLayerAvailability", "ecr:BatchGetImage",
+      "ecr:CompleteLayerUpload", "ecr:DescribeImages",
+      "ecr:DescribeRepositories", "ecr:GetDownloadUrlForLayer",
+      "ecr:InitiateLayerUpload", "ecr:PutImage", "ecr:UploadLayerPart",
     ]
     resources = var.ecr_repository_arns
   }
-
   dynamic "statement" {
     for_each = length(local.ssm_deploy_resources) > 0 ? [1] : []
-
     content {
-      sid = "SsmDeployCommand"
-      actions = [
-        "ssm:SendCommand",
-      ]
+      sid       = "SsmDeployCommand"
+      actions   = ["ssm:SendCommand"]
       resources = local.ssm_deploy_resources
     }
   }
-
   dynamic "statement" {
     for_each = length(local.ssm_deploy_resources) > 0 ? [1] : []
-
     content {
       sid = "SsmDeployStatusReads"
       actions = [
-        "ssm:GetCommandInvocation",
-        "ssm:DescribeInstanceInformation",
-        "ssm:ListCommandInvocations",
-        "ssm:ListCommands",
+        "ssm:GetCommandInvocation", "ssm:DescribeInstanceInformation",
+        "ssm:ListCommandInvocations", "ssm:ListCommands",
       ]
       resources = ["*"]
     }
   }
-
   dynamic "statement" {
     for_each = length(local.lambda_deploy_arns) > 0 ? [1] : []
-
     content {
       sid = "LambdaPackagePromotion"
       actions = [
-        "lambda:GetAlias",
-        "lambda:GetFunction",
-        "lambda:PublishVersion",
-        "lambda:UpdateAlias",
-        "lambda:UpdateFunctionCode",
+        "lambda:GetAlias", "lambda:GetFunction", "lambda:PublishVersion",
+        "lambda:UpdateAlias", "lambda:UpdateFunctionCode",
       ]
       resources = local.lambda_deploy_arns
     }
   }
-
   dynamic "statement" {
     for_each = length(var.state_table_arns) > 0 ? [1] : []
-
     content {
-      sid = "ReadSmokeStateTable"
-      actions = [
-        "dynamodb:DescribeTable",
-        "dynamodb:GetItem",
-        "dynamodb:Query",
-      ]
+      sid       = "ReadSmokeStateTable"
+      actions   = ["dynamodb:DescribeTable", "dynamodb:GetItem", "dynamodb:Query"]
       resources = var.state_table_arns
     }
   }
-
   dynamic "statement" {
     for_each = length(var.secret_arns) > 0 ? [1] : []
-
     content {
-      sid = "ReadDeploymentSecretMetadata"
-      actions = [
-        "secretsmanager:DescribeSecret",
-        "ssm:GetParameters",
-      ]
+      sid       = "ReadDeploymentSecretMetadata"
+      actions   = ["secretsmanager:DescribeSecret", "ssm:GetParameters"]
       resources = var.secret_arns
     }
   }
@@ -267,4 +237,119 @@ resource "aws_iam_role" "preview_lambda" {
 resource "aws_iam_role_policy_attachment" "preview_lambda_runtime" {
   role       = aws_iam_role.preview_lambda.name
   policy_arn = aws_iam_policy.preview_lambda_boundary.arn
+}
+
+data "aws_iam_policy_document" "preview_deploy" {
+  statement {
+    sid       = "ReadCallerIdentity"
+    actions   = ["sts:GetCallerIdentity"]
+    resources = ["*"]
+  }
+  statement {
+    sid       = "UsePreviewTerraformState"
+    actions   = ["s3:DeleteObject", "s3:GetObject", "s3:PutObject"]
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${var.preview_state_bucket_name}/${var.preview_state_key_prefix}/*"]
+  }
+  statement {
+    sid       = "ListPreviewTerraformState"
+    actions   = ["s3:GetBucketLocation", "s3:ListBucket"]
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${var.preview_state_bucket_name}"]
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values   = ["${var.preview_state_key_prefix}/*"]
+    }
+  }
+  statement {
+    sid       = "ReadFoundationPreviewRole"
+    actions   = ["iam:GetRole"]
+    resources = [aws_iam_role.preview_lambda.arn]
+  }
+  statement {
+    sid       = "PassFoundationPreviewRoleToLambda"
+    actions   = ["iam:PassRole"]
+    resources = [aws_iam_role.preview_lambda.arn]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["lambda.amazonaws.com"]
+    }
+  }
+  statement {
+    sid = "ManagePreviewLambdaFunctions"
+    actions = [
+      "lambda:AddPermission", "lambda:CreateAlias", "lambda:CreateFunction",
+      "lambda:DeleteAlias", "lambda:DeleteFunction", "lambda:GetAlias",
+      "lambda:GetFunction", "lambda:GetFunctionCodeSigningConfig",
+      "lambda:GetPolicy", "lambda:ListAliases", "lambda:ListVersionsByFunction",
+      "lambda:PublishVersion", "lambda:RemovePermission", "lambda:TagResource",
+      "lambda:UntagResource", "lambda:UpdateAlias", "lambda:UpdateFunctionCode",
+      "lambda:UpdateFunctionConfiguration",
+    ]
+    resources = local.preview_lambda_arns
+  }
+  statement {
+    sid = "ManagePreviewDynamoDbTables"
+    actions = [
+      "dynamodb:CreateTable", "dynamodb:DeleteTable",
+      "dynamodb:DescribeContinuousBackups", "dynamodb:DescribeTable",
+      "dynamodb:DescribeTimeToLive", "dynamodb:GetItem",
+      "dynamodb:ListTagsOfResource", "dynamodb:Query",
+      "dynamodb:TagResource", "dynamodb:UntagResource",
+      "dynamodb:UpdateContinuousBackups", "dynamodb:UpdateTimeToLive",
+    ]
+    resources = local.preview_table_arns
+  }
+  statement {
+    sid       = "ReadPreviewLogGroups"
+    actions   = ["logs:DescribeLogGroups"]
+    resources = ["*"]
+  }
+  statement {
+    sid = "ManagePreviewLogGroups"
+    actions = [
+      "logs:CreateLogGroup", "logs:DeleteLogGroup", "logs:ListTagsForResource",
+      "logs:PutRetentionPolicy", "logs:TagResource", "logs:UntagResource",
+    ]
+    resources = local.preview_log_arns
+  }
+  statement {
+    sid       = "CreateTaggedPreviewApis"
+    actions   = ["apigateway:POST"]
+    resources = ["arn:${data.aws_partition.current.partition}:apigateway:${data.aws_region.current.name}::/apis"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/Environment"
+      values   = ["pr-preview"]
+    }
+  }
+  statement {
+    sid       = "ManageTaggedPreviewApis"
+    actions   = ["apigateway:DELETE", "apigateway:GET", "apigateway:PATCH", "apigateway:POST", "apigateway:PUT"]
+    resources = ["arn:${data.aws_partition.current.partition}:apigateway:${data.aws_region.current.name}::/apis/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/Environment"
+      values   = ["pr-preview"]
+    }
+  }
+  statement {
+    sid       = "ReadPreviewRuntimeSecrets"
+    actions   = ["secretsmanager:GetSecretValue", "ssm:GetParameter", "ssm:GetParameters"]
+    resources = concat(local.preview_ssm_secret_arns, local.preview_secrets_manager_arns)
+  }
+  dynamic "statement" {
+    for_each = length(var.preview_kms_key_arns) > 0 ? [1] : []
+    content {
+      sid       = "DecryptPreviewRuntimeSecrets"
+      actions   = ["kms:Decrypt"]
+      resources = var.preview_kms_key_arns
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "preview_deploy" {
+  name   = "${var.preview_role_name}-deploy"
+  role   = aws_iam_role.preview.id
+  policy = data.aws_iam_policy_document.preview_deploy.json
 }

--- a/infra/terraform/modules/github_oidc/variables.tf
+++ b/infra/terraform/modules/github_oidc/variables.tf
@@ -30,7 +30,16 @@ variable "preview_resource_prefix" {
   default     = "arte-chatbot-preview"
 }
 
+variable "preview_state_bucket_name" {
+  description = "S3 bucket containing isolated preview Terraform state."
+  type        = string
+}
 
+variable "preview_state_key_prefix" {
+  description = "S3 key prefix containing isolated preview Terraform states."
+  type        = string
+  default     = "lambda-previews"
+}
 
 variable "preview_catalog_bucket_names" {
   description = "S3 catalog buckets that preview Lambda runtimes may read."

--- a/scripts/terraform_foundation_checks.py
+++ b/scripts/terraform_foundation_checks.py
@@ -216,6 +216,7 @@ def _check_github_oidc_role_separation(
     """Require separate OIDC identities and an immutable preview runtime boundary."""
     findings: list[str] = []
     production_policy = _data_block(oidc_main, "aws_iam_policy_document", "deploy")
+    preview_policy = _data_block(oidc_main, "aws_iam_policy_document", "preview_deploy")
 
     if (
         oidc_main.count('resource "aws_iam_openid_connect_provider" "github"') != 1
@@ -260,6 +261,27 @@ def _check_github_oidc_role_separation(
     ):
         findings.append(
             "preview Lambda role must have a foundation-managed boundary limited to preview secrets"
+        )
+
+    if not _contains_all(
+        preview_policy,
+        [
+            "aws_iam_role.preview_lambda.arn",
+            'values   = ["lambda.amazonaws.com"]',
+            "${var.preview_state_key_prefix}/*",
+            "local.preview_lambda_arns",
+            "local.preview_table_arns",
+        ],
+    ) or any(
+        action in preview_policy
+        for action in [
+            "iam:CreateRole",
+            "iam:DeleteRolePermissionsBoundary",
+            "iam:PutRolePermissionsBoundary",
+        ]
+    ):
+        findings.append(
+            "preview deploy role must pass only the foundation runtime role and manage prefixed resources"
         )
 
     preview_role_variable = _variable_block(prod_variables, "github_preview_role_name")

--- a/scripts/tests/test_terraform_foundation.py
+++ b/scripts/tests/test_terraform_foundation.py
@@ -1,6 +1,7 @@
 """Validation tests for the PR2 Terraform foundation work unit."""
 
 from pathlib import Path
+import shutil
 import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -13,6 +14,19 @@ ROOT = Path(__file__).resolve().parents[2]
 
 def _findings() -> list[str]:
     return check_foundation(ROOT)
+
+
+def _mutated_terraform_project(
+    tmp_path: Path, relative_path: Path, old: str, new: str
+) -> Path:
+    """Copy static-check inputs and mutate one Terraform contract."""
+    shutil.copytree(ROOT / "infra", tmp_path / "infra")
+    shutil.copytree(ROOT / "admin", tmp_path / "admin")
+    path = tmp_path / relative_path
+    content = path.read_text(encoding="utf-8")
+    assert old in content, f"mutation target is missing: {old}"
+    path.write_text(content.replace(old, new, 1), encoding="utf-8")
+    return tmp_path
 
 
 def test_prod_is_lambda_only_without_ec2_or_cloudflare_tunnel_wiring() -> None:
@@ -155,6 +169,10 @@ def test_github_oidc_separates_production_and_preview_authority() -> None:
         not in findings
     )
     assert (
+        "preview deploy role must pass only the foundation runtime role and manage prefixed resources"
+        not in findings
+    )
+    assert (
         "production foundation must expose reproducible preview role and boundary outputs"
         not in findings
     )
@@ -167,4 +185,36 @@ def test_preview_boundary_excludes_production_secret_namespaces() -> None:
     assert (
         "preview Lambda role must have a foundation-managed boundary limited to preview secrets"
         not in findings
+    )
+
+
+def test_oidc_check_rejects_preview_subject_widening(tmp_path: Path) -> None:
+    """A broad repository subject must fail the OIDC trust contract."""
+    project_root = _mutated_terraform_project(
+        tmp_path,
+        Path("infra/terraform/modules/github_oidc/main.tf"),
+        "repo:${var.github_owner}/${var.github_repository}:pull_request",
+        "repo:${var.github_owner}/${var.github_repository}:*",
+    )
+
+    assert (
+        "GitHub OIDC must use one provider with separate main and pull_request role subjects"
+        in check_foundation(project_root)
+    )
+
+
+def test_boundary_check_rejects_production_secret_namespace(
+    tmp_path: Path,
+) -> None:
+    """A production namespace accidentally admitted by the boundary must fail."""
+    project_root = _mutated_terraform_project(
+        tmp_path,
+        Path("infra/terraform/modules/github_oidc/main.tf"),
+        "parameter/arte-chatbot/pr-preview/*",
+        "parameter/arte-chatbot/prod/*",
+    )
+
+    assert (
+        "preview Lambda role must have a foundation-managed boundary limited to preview secrets"
+        in check_foundation(project_root)
     )


### PR DESCRIPTION
## ¿Qué hace este PR?

- Concede al rol preview únicamente la autoridad necesaria para recursos con prefijos preview.
- Restringe `iam:PassRole` al rol de ejecución foundation y al servicio Lambda.
- Limita el acceso a state y secretos preview, añade pruebas negativas y documenta bootstrap/import.

## Issues relacionados

Closes #240

## Tipo de cambio

- [x] 🆕 Nueva funcionalidad (feature)
- [ ] 🐛 Corrección de bug
- [ ] ♻️ Refactor (sin cambio funcional)
- [ ] 🧪 Tests
- [ ] 📄 Documentación / configuración
- [ ] 🔧 Infra / CI

## Checklist antes de pedir review

- [x] El código corre localmente sin errores y los tests focales pasan
- [x] Los criterios de aceptación del issue relacionado están cumplidos por la cadena completa
- [x] No hay credenciales, API keys ni rutas absolutas hardcodeadas
- [x] No se agregaron dependencias
- [x] No se modificó el schema del endpoint
- [x] No se modificó el harness ni el dataset
- [x] No hay scripts `.sh` modificados; ShellCheck no aplica
- [x] El commit usa Conventional Commits y no contiene `Co-Authored-By`

## Cómo probar este PR

1. `UV_CACHE_DIR=/tmp/uv-cache uv run --group lint ruff format --check scripts/terraform_foundation_checks.py scripts/workflow_deploy_checks.py scripts/tests/test_terraform_foundation.py scripts/tests/test_workflow_deploy_checks.py`
2. `UV_CACHE_DIR=/tmp/uv-cache uv run pytest scripts/tests/test_terraform_foundation.py scripts/tests/test_workflow_deploy_checks.py`
3. `terraform fmt -check -recursive infra/terraform && terraform -chdir=infra/terraform/envs/prod validate && terraform -chdir=infra/terraform/envs/pr-preview validate`

## Notas para el reviewer

La validación de ARNs dentro del Terraform del PR es defensa adicional, no la frontera principal. La protección efectiva vive en la permissions boundary administrada por la foundation.

## Chain Context

| Field | Value |
|-------|-------|
| Chain | Issue #240 — AWS preview authority isolation |
| Tracker PR | Not needed |
| Position | 3 of 3 |
| Base | `feat/preview-runtime-boundary` |
| Depends on | #324 |
| Follow-up | None |
| Review budget | 293 / 400 changed lines |
| Starts at | PR #324 preview identity and runtime boundary |
| Ends with | Complete least-privilege preview deployment authority and documented bootstrap |

### Chain Overview

```text
main
 └── #323 PR 1 — fail-closed consumers
      └── #324 PR 2 — runtime boundary
           └── 📍 PR 3 — deploy policy
```

### Scope

- Includes: least-privilege deploy policy, exact PassRole, preview state scoping, negative tests and operational documentation.
- Excludes: API key rotation, GitHub organization redesign, unrelated AWS resources and Lambda ownership changes.

### Autonomy

- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests and documentation cover this unit
